### PR TITLE
deps(spaceui-showcase): april 2026 batch + tokens import + react dedupe

### DIFF
--- a/spaceui/.storybook/storybook.css
+++ b/spaceui/.storybook/storybook.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
-@import "@spacedrive/tokens/theme";
-@import "@spacedrive/tokens/css";
+@import "@spacedrive/tokens/src/css/theme.css";
+@import "@spacedrive/tokens/src/css/base.css";
 
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/spaceui/bun.lock
+++ b/spaceui/bun.lock
@@ -55,7 +55,7 @@
       "name": "@spacedrive/showcase",
       "version": "0.0.0",
       "dependencies": {
-        "@hookform/resolvers": "^3.3.0",
+        "@hookform/resolvers": "^5.2.2",
         "@spacedrive/ai": "workspace:*",
         "@spacedrive/explorer": "workspace:*",
         "@spacedrive/forms": "workspace:*",
@@ -64,13 +64,13 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.51.0",
-        "zod": "^3.22.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.0",
         "@types/react": "^18.2.64",
         "@types/react-dom": "^18.2.21",
-        "@vitejs/plugin-react": "^4.2.1",
+        "@vitejs/plugin-react": "^5.2.0",
         "tailwindcss": "^4.1.0",
         "typescript": "^5.4.2",
         "vite": "^6.4.2",
@@ -367,7 +367,7 @@
 
     "@headlessui/react": ["@headlessui/react@1.7.19", "", { "dependencies": { "@tanstack/react-virtual": "^3.0.0-beta.60", "client-only": "^0.0.1" }, "peerDependencies": { "react": "^16 || ^17 || ^18", "react-dom": "^16 || ^17 || ^18" } }, "sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw=="],
 
-    "@hookform/resolvers": ["@hookform/resolvers@3.10.0", "", { "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag=="],
+    "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -503,7 +503,7 @@
 
     "@react-spring/web": ["@react-spring/web@9.7.5", "", { "dependencies": { "@react-spring/animated": "~9.7.5", "@react-spring/core": "~9.7.5", "@react-spring/shared": "~9.7.5", "@react-spring/types": "~9.7.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
@@ -572,6 +572,8 @@
     "@spacedrive/storybook": ["@spacedrive/storybook@workspace:.storybook"],
 
     "@spacedrive/tokens": ["@spacedrive/tokens@workspace:packages/tokens"],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@storybook/addon-actions": ["@storybook/addon-actions@8.6.18", "", { "dependencies": { "@storybook/global": "^5.0.0", "@types/uuid": "^9.0.1", "dequal": "^2.0.2", "polished": "^4.2.2", "uuid": "^9.0.0" }, "peerDependencies": { "storybook": "^8.6.18" } }, "sha512-GcYhtE91GjIQTuZlwpTJ8jfMp6NC79nkpe1DGe0eetTpyQqLq1WUt+ACkk0Z5lqq2u8HBc09zCCGw+D8iCLpYQ=="],
 
@@ -725,7 +727,7 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
     "@vitest/expect": ["@vitest/expect@2.0.5", "", { "dependencies": { "@vitest/spy": "2.0.5", "@vitest/utils": "2.0.5", "chai": "^5.1.1", "tinyrainbow": "^1.2.0" } }, "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA=="],
 
@@ -1323,7 +1325,7 @@
 
     "react-markdown": ["react-markdown@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw=="],
 
-    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+    "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
@@ -1548,6 +1550,8 @@
     "@spacedrive/showcase/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "@spacedrive/showcase/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "@spacedrive/showcase/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@spacedrive/storybook/@chromatic-com/storybook": ["@chromatic-com/storybook@2.0.2", "", { "dependencies": { "chromatic": "^11.4.0", "filesize": "^10.0.12", "jsonfile": "^6.1.0", "react-confetti": "^6.1.0", "strip-ansi": "^7.1.0" } }, "sha512-7bPIliISedeIpnVKbzktysFYW5n56bN91kxuOj1XXKixmjbUHRUMvcXd4K2liN6MiR5ZqJtmtcPsZ6CebbGlEA=="],
 

--- a/spaceui/examples/showcase/package.json
+++ b/spaceui/examples/showcase/package.json
@@ -17,13 +17,13 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.0",
-    "zod": "^3.22.0",
-    "@hookform/resolvers": "^3.3.0"
+    "zod": "^4.3.6",
+    "@hookform/resolvers": "^5.2.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.21",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react": "^5.2.0",
     "@tailwindcss/vite": "^4.1.0",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.4.2",

--- a/spaceui/examples/showcase/src/index.css
+++ b/spaceui/examples/showcase/src/index.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
-@import "@spacedrive/tokens/theme";
-@import "@spacedrive/tokens/css";
+@import "@spacedrive/tokens/css/theme.css";
+@import "@spacedrive/tokens/css/base.css";
 
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/spaceui/examples/showcase/vite.config.ts
+++ b/spaceui/examples/showcase/vite.config.ts
@@ -6,6 +6,11 @@ import path from 'path'
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
+    // Force a single React copy. Bun's hoister keeps two majors (18 + 19) in
+    // node_modules because Storybook 8.6 satisfies its `^19.0.0-beta` peer with
+    // 19.x while showcase pins React 18. Without dedupe, Radix loads its own
+    // React copy and `useRef` returns null. Same fix pattern as interface/.
+    dedupe: ['react', 'react-dom'],
     alias: {
       '@spacedrive/tokens': path.resolve(__dirname, '../../packages/tokens/src'),
       '@spacedrive/primitives': path.resolve(__dirname, '../../packages/primitives/src'),

--- a/spaceui/packages/primitives/src/Input.tsx
+++ b/spaceui/packages/primitives/src/Input.tsx
@@ -72,6 +72,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 			iconPosition = "left",
 			className,
 			error,
+			inputElementClassName,
 			...props
 		},
 		ref,
@@ -117,7 +118,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 						(right || (icon && iconPosition === "right")) && "pr-0",
 						icon && iconPosition === "left" && "pl-0",
 						size === "xs" && "!py-0",
-						props.inputElementClassName,
+						inputElementClassName,
 					)}
 					onKeyDown={(e) => {
 						e.stopPropagation();


### PR DESCRIPTION
## Summary

Workspace-grouped local replacement for Dependabot PRs #21, #22, #25, plus pre-existing bug fixes surfaced by smoke testing.

### Dependency bumps
- `zod` 3.22 → ^4.3.6
- `@hookform/resolvers` 3.3 → ^5.2.2
- `@vitejs/plugin-react` 4.2 → ^5.2.0 *(Dependabot wanted ^6.0.1 but v6 requires Vite 8; full ^6 lands in PR E alongside Vite 8)*

### Bug fixes (surfaced by smoke testing this PR)
- **`spaceui/examples/showcase/src/index.css`** + **`spaceui/.storybook/storybook.css`**: replace `@spacedrive/tokens/theme` and `@spacedrive/tokens/css` imports with literal source paths. The Tailwind v4 Vite plugin doesn't honor the `exports` map in `@spacedrive/tokens/package.json` for CSS `@import`. Showcase uses no `src/` prefix because its `vite.config.ts` aliases `@spacedrive/tokens` to `packages/tokens/src`; storybook uses the full `src/css/` path because it has no such alias.
- **`spaceui/examples/showcase/vite.config.ts`**: add `dedupe: ['react', 'react-dom']`. bun's hoister keeps two React majors in `spaceui/node_modules` (React 18 from showcase + React 19 satisfying Storybook 8.6's `^19.0.0-beta` peer). Without dedupe, Radix loaded its own React copy and `useRef` returned null on the first `<TooltipProvider>` render, producing a blank page. Same fix pattern as `interface/vite.config.ts`.
- **`spaceui/packages/primitives/src/Input.tsx`**: destructure `inputElementClassName` from props before the `{...props}` spread onto `<input>`. Previously the prop leaked to the DOM, producing a React unknown-prop warning on every render of the PrimitivesAIExplorerForms showcase tab.

## Test plan

- [x] \`cd spaceui && bun install\` clean
- [x] \`bun run showcase\` boots; Buttons + Input/Select + Tooltip + TagPill + GridItem/RenameInput render manually verified across both tabs
- [x] No \`useRef\` / TooltipProvider errors in DevTools
- [x] No \`inputElementClassName\` unknown-prop warning
- [x] CSS pipeline returns 8538 bytes of compiled tokens CSS at \`/src/index.css\`

Dependabot PRs #21, #22, #25 will auto-close once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)