### PR TITLE
deps(spaceui): align workspace packages with interface, fix surfaced drift

### DIFF
--- a/spaceui/bun.lock
+++ b/spaceui/bun.lock
@@ -51,7 +51,7 @@
         "@spacedrive/tokens": "workspace:*",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "react-hook-form": "^7.51.0",
+        "react-hook-form": "^7.72.1",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -68,26 +68,26 @@
       "name": "@spacedrive/ai",
       "version": "0.2.3",
       "dependencies": {
-        "@phosphor-icons/react": "^2.1.0",
-        "@spacedrive/primitives": "^0.2.0",
-        "clsx": "^2.1.0",
-        "framer-motion": "^11.0.0",
+        "@phosphor-icons/react": "^2.1.10",
+        "@spacedrive/primitives": "^0.2.3",
+        "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
         "react-loader-spinner": "^8.0.2",
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",
-        "remark-gfm": "^4.0.0",
+        "remark-gfm": "^4.0.1",
       },
       "devDependencies": {
-        "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
       },
       "optionalDependencies": {
-        "@dnd-kit/core": "^6.0.0",
-        "@dnd-kit/sortable": "^8.0.0",
-        "@dnd-kit/utilities": "^3.0.0",
-        "@react-sigma/core": "^4.0.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@react-sigma/core": "^5.0.6",
         "graphology": "^0.26.0",
         "sigma": "^3.0.0",
       },
@@ -102,13 +102,13 @@
       "name": "@spacedrive/explorer",
       "version": "0.2.3",
       "dependencies": {
-        "@phosphor-icons/react": "^2.1.0",
-        "@spacedrive/primitives": "^0.2.0",
-        "clsx": "^2.1.0",
+        "@phosphor-icons/react": "^2.1.10",
+        "@spacedrive/primitives": "^0.2.3",
+        "clsx": "^2.1.1",
       },
       "devDependencies": {
-        "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
       },
@@ -122,12 +122,12 @@
       "name": "@spacedrive/forms",
       "version": "0.2.3",
       "dependencies": {
-        "@spacedrive/primitives": "^0.2.0",
-        "clsx": "^2.1.0",
+        "@spacedrive/primitives": "^0.2.3",
+        "clsx": "^2.1.1",
       },
       "devDependencies": {
-        "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
       },
@@ -135,15 +135,15 @@
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
         "react-hook-form": "^7.0.0",
-        "zod": "^3.0.0",
+        "zod": "^3.0.0 || ^4.0.0",
       },
     },
     "packages/icons": {
       "name": "@spacedrive/icons",
       "version": "0.2.3",
       "devDependencies": {
-        "@types/react": "^19.0.0",
-        "react": "^18.0.0 || ^19.0.0",
+        "@types/react": "^19.2.14",
+        "react": "^19.2.5",
         "typescript": "^5.4.0",
       },
       "peerDependencies": {
@@ -155,7 +155,7 @@
       "version": "0.2.3",
       "dependencies": {
         "@headlessui/react": "^1.7.0",
-        "@phosphor-icons/react": "^2.1.0",
+        "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-checkbox": "^1.1.0",
         "@radix-ui/react-collapsible": "^1.1.0",
         "@radix-ui/react-context-menu": "^2.2.0",
@@ -171,19 +171,19 @@
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.0",
         "@react-spring/web": "^10.0.3",
-        "class-variance-authority": "^0.7.0",
-        "clsx": "^2.1.0",
-        "framer-motion": "^11.0.0",
-        "react-hook-form": "^7.50.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
+        "react-hook-form": "^7.72.1",
         "react-loading-icons": "^1.1.0",
         "react-resizable-layout": "^0.7.0",
-        "sonner": "^1.4.0",
-        "zod": "^3.22.0",
+        "sonner": "^2.0.7",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0",
-        "tailwindcss": "^4.1.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "tailwindcss": "^4.2.2",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
       },
@@ -279,7 +279,7 @@
 
     "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
 
-    "@dnd-kit/sortable": ["@dnd-kit/sortable@8.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.1.0", "react": ">=16.8.0" } }, "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g=="],
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
 
     "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
@@ -475,7 +475,7 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
-    "@react-sigma/core": ["@react-sigma/core@4.0.3", "", { "peerDependencies": { "graphology": "^0.25.4", "react": "^18.0.0", "sigma": "^3.0.0-beta.24" } }, "sha512-/y/U1GH18xjGYMWNYXXqHGJ+8tHf+e4z1i0gNSm9iuhch8sGFJooO3VfyPJlBox42Wl4/gCapQhOHAfVW0pRtw=="],
+    "@react-sigma/core": ["@react-sigma/core@5.0.6", "", { "peerDependencies": { "graphology": "^0.26.0", "react": "^18.0.0 || ^19.0.0", "sigma": "^3.0.2" } }, "sha512-Xu2qXyvDZIhmvGC1n8d7Kcxm5Ntcz4HbPIM7CPDD2e4h3s/oxVpVPX7wtsNreJRRPj9mK+3oqB6SWXNI4mTqVg=="],
 
     "@react-spring/animated": ["@react-spring/animated@10.0.3", "", { "dependencies": { "@react-spring/shared": "~10.0.3", "@react-spring/types": "~10.0.3" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-7MrxADV3vaUADn2V9iYhaIL6iOWRx9nCJjYrsk2AHD2kwPr6fg7Pt0v+deX5RnCDmCKNnD6W5fasiyM8D+wzJQ=="],
 
@@ -887,7 +887,7 @@
 
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
-    "framer-motion": ["framer-motion@11.18.2", "", { "dependencies": { "motion-dom": "^11.18.1", "motion-utils": "^11.18.1", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w=="],
+    "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
 
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
@@ -1135,9 +1135,9 @@
 
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
 
-    "motion-dom": ["motion-dom@11.18.1", "", { "dependencies": { "motion-utils": "^11.18.1" } }, "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw=="],
+    "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
 
-    "motion-utils": ["motion-utils@11.18.1", "", {}, "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA=="],
+    "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -1150,8 +1150,6 @@
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
-
-    "obliterator": ["obliterator@2.0.5", "", {}, "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw=="],
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
@@ -1221,7 +1219,7 @@
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
-    "react-hook-form": ["react-hook-form@7.72.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw=="],
+    "react-hook-form": ["react-hook-form@7.72.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
@@ -1287,7 +1285,7 @@
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
-    "sonner": ["sonner@1.7.4", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw=="],
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
@@ -1413,7 +1411,7 @@
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -1434,14 +1432,6 @@
     "@radix-ui/react-progress/@radix-ui/react-context": ["@radix-ui/react-context@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw=="],
 
     "@radix-ui/react-progress/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
-
-    "@react-sigma/core/graphology": ["graphology@0.25.4", "", { "dependencies": { "events": "^3.3.0", "obliterator": "^2.0.2" }, "peerDependencies": { "graphology-types": ">=0.24.0" } }, "sha512-33g0Ol9nkWdD6ulw687viS8YJQBxqG5LWII6FI6nul0pq6iM2t5EKquOTFDbyTblRB3O9I+7KX4xI8u5ffekAQ=="],
-
-    "@react-sigma/core/react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
-
-    "@spacedrive/icons/react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
-
-    "@spacedrive/showcase/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 

--- a/spaceui/examples/showcase/package.json
+++ b/spaceui/examples/showcase/package.json
@@ -16,7 +16,7 @@
     "@spacedrive/tokens": "workspace:*",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "react-hook-form": "^7.51.0",
+    "react-hook-form": "^7.72.1",
     "zod": "^4.3.6",
     "@hookform/resolvers": "^5.2.2"
   },

--- a/spaceui/examples/showcase/src/App.tsx
+++ b/spaceui/examples/showcase/src/App.tsx
@@ -14,9 +14,9 @@ import {
 	TabsList,
 	TabsRoot,
 	TabsTrigger,
-	Tooltip,
 	TooltipContent,
 	TooltipProvider,
+	TooltipRoot,
 	TooltipTrigger,
 } from "@spacedrive/primitives";
 import { ChatComposer, Markdown, ModelSelector, ToolCall } from "@spacedrive/ai";
@@ -121,14 +121,14 @@ export default function App() {
 									<SelectOption value="beta">Beta</SelectOption>
 									<SelectOption value="stable">Stable</SelectOption>
 								</Select>
-								<Tooltip>
+								<TooltipRoot>
 									<TooltipTrigger asChild>
 										<Button size="xs" variant="outline">
 											Hover for tooltip
 										</Button>
 									</TooltipTrigger>
 									<TooltipContent>Tooltip is wired</TooltipContent>
-								</Tooltip>
+								</TooltipRoot>
 							</CardContent>
 						</Card>
 					</TabsContent>
@@ -139,7 +139,7 @@ export default function App() {
 								<CardTitle>ToolCall + Markdown</CardTitle>
 							</CardHeader>
 							<CardContent className="space-y-3">
-								<ToolCall toolCall={toolCall} expanded />
+								<ToolCall pair={toolCall} />
 								<Markdown content={"## Markdown\n\n- list item\n- code\n\n`spaceui`"} />
 							</CardContent>
 						</Card>

--- a/spaceui/packages/ai/package.json
+++ b/spaceui/packages/ai/package.json
@@ -22,18 +22,18 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@phosphor-icons/react": "^2.1.0",
-    "@spacedrive/primitives": "^0.2.0",
-    "clsx": "^2.1.0",
-    "framer-motion": "^11.0.0",
+    "@phosphor-icons/react": "^2.1.10",
+    "@spacedrive/primitives": "^0.2.3",
+    "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
     "react-loader-spinner": "^8.0.2",
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
-    "remark-gfm": "^4.0.0"
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "tsup": "^8.0.0",
     "typescript": "^5.4.0"
   },
@@ -44,10 +44,10 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "optionalDependencies": {
-    "@dnd-kit/core": "^6.0.0",
-    "@dnd-kit/sortable": "^8.0.0",
-    "@dnd-kit/utilities": "^3.0.0",
-    "@react-sigma/core": "^4.0.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@react-sigma/core": "^5.0.6",
     "graphology": "^0.26.0",
     "sigma": "^3.0.0"
   }

--- a/spaceui/packages/explorer/package.json
+++ b/spaceui/packages/explorer/package.json
@@ -22,15 +22,15 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@spacedrive/primitives": "^0.2.0",
-    "@phosphor-icons/react": "^2.1.0",
-    "clsx": "^2.1.0"
+    "@spacedrive/primitives": "^0.2.3",
+    "@phosphor-icons/react": "^2.1.10",
+    "clsx": "^2.1.1"
   },
   "devDependencies": {
     "tsup": "^8.0.0",
     "typescript": "^5.4.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/spaceui/packages/forms/package.json
+++ b/spaceui/packages/forms/package.json
@@ -22,19 +22,19 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@spacedrive/primitives": "^0.2.0",
-    "clsx": "^2.1.0"
+    "@spacedrive/primitives": "^0.2.3",
+    "clsx": "^2.1.1"
   },
   "devDependencies": {
     "tsup": "^8.0.0",
     "typescript": "^5.4.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-hook-form": "^7.0.0",
-    "zod": "^3.0.0"
+    "zod": "^3.0.0 || ^4.0.0"
   }
 }

--- a/spaceui/packages/icons/package.json
+++ b/spaceui/packages/icons/package.json
@@ -21,9 +21,9 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
+    "react": "^19.2.5",
     "typescript": "^5.4.0",
-    "@types/react": "^19.0.0"
+    "@types/react": "^19.2.14"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0"

--- a/spaceui/packages/primitives/package.json
+++ b/spaceui/packages/primitives/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.0",
-    "@phosphor-icons/react": "^2.1.0",
+    "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-checkbox": "^1.1.0",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-context-menu": "^2.2.0",
@@ -39,21 +39,21 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.0",
     "@react-spring/web": "^10.0.3",
-    "class-variance-authority": "^0.7.0",
-    "clsx": "^2.1.0",
-    "framer-motion": "^11.0.0",
-    "react-hook-form": "^7.50.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
+    "react-hook-form": "^7.72.1",
     "react-loading-icons": "^1.1.0",
     "react-resizable-layout": "^0.7.0",
-    "sonner": "^1.4.0",
-    "zod": "^3.22.0"
+    "sonner": "^2.0.7",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "tsup": "^8.0.0",
     "typescript": "^5.4.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "tailwindcss": "^4.1.0"
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "tailwindcss": "^4.2.2"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",


### PR DESCRIPTION
## Summary

Aligns the 5 publishable spaceui packages (primitives, forms, ai, explorer, icons) and the showcase example with the dep ranges that `interface/` already uses in production. Eliminates duplicate-version hoisting in `node_modules/.bun/` and removes peer/dep mismatches that the april 2026 dep batch (PRs #34, #35, #36, #41) surfaced.

## What changed

**Real version bumps:** framer-motion 11→12, sonner 1→2, zod 3→4, react-hook-form 7.50→7.72.1, @phosphor-icons/react patches, @types/react patches, tailwindcss patches, @dnd-kit/* alignment, @react-sigma/core 4→5.

**Peer-range widening** (correctness fix, not version bump):
- `forms/peerDependencies.zod`: `"^3.0.0"` → `"^3.0.0 || ^4.0.0"` — primitives now uses zod 4, forms's peer must accept it.

**App.tsx + showcase fixes** (PR B leftovers surfaced by stricter post-alignment types):
- showcase react-hook-form aligned to ^7.72.1 (eliminates type split with @spacedrive/forms)
- `App.tsx:142`: `<ToolCall toolCall={...} />` → `<ToolCall pair={...} />` (prop renamed in ai)
- `App.tsx:124`: `<Tooltip>` (compound with `label`) → `<TooltipRoot>` (bare Radix root for compound usage)

## Intentionally NOT changed

The VS Code dep extension flags some ranges that are **design decisions, not bugs**:

| Flagged | Why we keep it |
|---|---|
| `typescript: ^5.4.0` in all 5 packages | TS 6 migration is Dependabot PR #38 territory; deferred for a coordinated workspace bump |
| `@headlessui/react: ^1.7.0` in primitives | v2 is a major API rewrite (Menu, Transition restructured). v1.7.9 still works for Dropdown.tsx. v2 migration is its own PR |
| `peerDependencies.react: ^18.0.0 \|\| ^19.0.0` | Published packages must support both React majors so downstream consumers can choose |
| `forms/peerDependencies.react-hook-form: ^7.0.0` | Broad peer for downstream flexibility |

## Test plan

- [x] `cd spaceui && bun install` clean
- [x] Duplicate-version checks: framer-motion single (12.38.0), sonner single (2.0.7), react-hook-form effective single (7.72.1)
- [x] `bun run typecheck`: 8/9 packages pass (storybook pre-existing missing `@types/node` failure unchanged from main)
- [x] `bun run storybook:build` + `bun run showcase:build`: both succeed
- [x] `bun run storybook`: dev boots; Button stories render; no useRef errors, no failed resolutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)