### PR TITLE
deps(spaceui): TypeScript 5.4 → 6.0.2 across workspace

### DIFF
--- a/spaceui/.storybook/package.json
+++ b/spaceui/.storybook/package.json
@@ -21,7 +21,7 @@
     "storybook": "^10.3.5",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.2",
     "vite": "^8.0.8",
     "@tailwindcss/vite": "^4.1.0",
     "tailwindcss": "^4.1.0"

--- a/spaceui/bun.lock
+++ b/spaceui/bun.lock
@@ -12,7 +12,7 @@
         "@storybook/react-vite": "^10.3.5",
         "storybook": "^10.3.5",
         "turbo": "^2.0.0",
-        "typescript": "^5.4.0",
+        "typescript": "^6.0.2",
       },
     },
     ".storybook": {
@@ -35,7 +35,7 @@
         "react-dom": "^19.2.5",
         "storybook": "^10.3.5",
         "tailwindcss": "^4.1.0",
-        "typescript": "^5.4.0",
+        "typescript": "^6.0.2",
         "vite": "^8.0.8",
       },
     },
@@ -60,7 +60,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "tailwindcss": "^4.1.0",
-        "typescript": "^5.4.2",
+        "typescript": "^6.0.2",
         "vite": "^8.0.8",
       },
     },
@@ -81,7 +81,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "tsup": "^8.0.0",
-        "typescript": "^5.4.0",
+        "typescript": "^6.0.2",
       },
       "optionalDependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -110,7 +110,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "tsup": "^8.0.0",
-        "typescript": "^5.4.0",
+        "typescript": "^6.0.2",
       },
       "peerDependencies": {
         "@tanstack/react-virtual": "^3.0.0",
@@ -129,7 +129,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "tsup": "^8.0.0",
-        "typescript": "^5.4.0",
+        "typescript": "^6.0.2",
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
@@ -144,7 +144,7 @@
       "devDependencies": {
         "@types/react": "^19.2.14",
         "react": "^19.2.5",
-        "typescript": "^5.4.0",
+        "typescript": "^6.0.2",
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
@@ -185,7 +185,7 @@
         "@types/react-dom": "^19.2.3",
         "tailwindcss": "^4.2.2",
         "tsup": "^8.0.0",
-        "typescript": "^5.4.0",
+        "typescript": "^6.0.2",
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
@@ -1363,7 +1363,7 @@
 
     "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 

--- a/spaceui/examples/showcase/package.json
+++ b/spaceui/examples/showcase/package.json
@@ -26,7 +26,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@tailwindcss/vite": "^4.1.0",
     "tailwindcss": "^4.1.0",
-    "typescript": "^5.4.2",
+    "typescript": "^6.0.2",
     "vite": "^8.0.8"
   }
 }

--- a/spaceui/examples/showcase/src/vite-env.d.ts
+++ b/spaceui/examples/showcase/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare module "*.css";

--- a/spaceui/package.json
+++ b/spaceui/package.json
@@ -34,7 +34,7 @@
     "@storybook/react-vite": "^10.3.5",
     "storybook": "^10.3.5",
     "turbo": "^2.0.0",
-    "typescript": "^5.4.0"
+    "typescript": "^6.0.2"
   },
   "packageManager": "bun@1.1.0",
   "engines": {

--- a/spaceui/packages/ai/package.json
+++ b/spaceui/packages/ai/package.json
@@ -35,7 +35,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "tsup": "^8.0.0",
-    "typescript": "^5.4.0"
+    "typescript": "^6.0.2"
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",

--- a/spaceui/packages/explorer/package.json
+++ b/spaceui/packages/explorer/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "tsup": "^8.0.0",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3"
   },

--- a/spaceui/packages/forms/package.json
+++ b/spaceui/packages/forms/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "tsup": "^8.0.0",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3"
   },

--- a/spaceui/packages/icons/package.json
+++ b/spaceui/packages/icons/package.json
@@ -22,7 +22,7 @@
   "dependencies": {},
   "devDependencies": {
     "react": "^19.2.5",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.2",
     "@types/react": "^19.2.14"
   },
   "peerDependencies": {

--- a/spaceui/packages/icons/tsconfig.json
+++ b/spaceui/packages/icons/tsconfig.json
@@ -8,7 +8,8 @@
 		"esModuleInterop": true,
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
-		"noEmit": true
+		"noEmit": true,
+		"ignoreDeprecations": "6.0"
 	},
 	"include": ["**/*.ts", "**/*.tsx", "types.d.ts"],
 	"exclude": ["node_modules"]

--- a/spaceui/packages/primitives/package.json
+++ b/spaceui/packages/primitives/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "tsup": "^8.0.0",
-    "typescript": "^5.4.0",
+    "typescript": "^6.0.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "tailwindcss": "^4.2.2"

--- a/spaceui/tsconfig.base.json
+++ b/spaceui/tsconfig.base.json
@@ -18,7 +18,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "ignoreDeprecations": "6.0"
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

Aligns all 8 spaceui manifests with `interface/` and `docs/` which already run `typescript ^6.0.2`. Subsumes Dependabot PR #38 (showcase TS 6 bump) and extends it to every spaceui package.

## Manifest bumps (8 files)

`spaceui/package.json`, `spaceui/.storybook/package.json`, `spaceui/examples/showcase/package.json`, `spaceui/packages/{primitives,forms,ai,explorer,icons}/package.json`: all `typescript: ^5.4.x` → `^6.0.2`.

## TS 6 stricter-behavior fixes

### 1. `ignoreDeprecations: "6.0"` opt-out (2 tsconfigs)

Added to `spaceui/tsconfig.base.json` and `spaceui/packages/icons/tsconfig.json` (icons doesn't extend the base).

**Why:** `tsup`'s DTS step (rolldown-plugin-dts) injects a synthetic `baseUrl` into its virtual rollup config. TS 6 promoted the `baseUrl` deprecation from a warning (TS 5) to a hard error in DTS builds. The opt-out silences it for the 6.x lifecycle — TypeScript team's documented escape hatch until TS 7 actually removes `baseUrl`. **Our own tsconfigs do NOT use `baseUrl`** — this is purely a workaround for the bundler's internals.

### 2. `vite-env.d.ts` for showcase (new file)

```ts
/// <reference types="vite/client" />
declare module "*.css";
```

**Why:** TS 6 requires explicit module declarations for CSS side-effect imports. `main.tsx` uses `import "./index.css"`. Without this declaration, tsc fails with TS2882. Same pattern `interface/` uses.

## Test plan

- [x] `cd spaceui && bun install` clean
- [x] `bun run typecheck`: 8/9 packages pass; only `@spacedrive/storybook` fails on the pre-existing `@types/node` + `./storybook.css` issue (unchanged from main, documented in PR C/F)
- [x] `bun run storybook:build`: clean
- [x] `bun run showcase:build`: **passes** (first time after PR F + this fix — the showcase API drift fixed in PR F + the new vite-env.d.ts together unblock it)
- [x] `bun run storybook`: dev boots; Button stories render; no errors

Dependabot PR #38 will auto-close once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)