### PR TITLE
deps(spaceui): adopt Tailwind v4 canonical class syntax

### DIFF
--- a/spaceui/packages/explorer/src/RenameInput.tsx
+++ b/spaceui/packages/explorer/src/RenameInput.tsx
@@ -97,14 +97,14 @@ export function RenameInput({
 			<Input
 				ref={inputRef}
 				value={value}
-				onChange={(e) => setValue(e.target.value)}
+				onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
 				onKeyDown={handleKeyDown}
 				onBlur={handleBlur}
 				variant="transparent"
 				size="xs"
 				disabled={isSaving}
 				className={clsx(
-					"min-w-[60px] !h-auto !py-0.5 !px-1 text-center",
+					"min-w-[60px] h-auto! py-0.5! px-1! text-center",
 					isSaving && "opacity-50",
 				)}
 				inputElementClassName="text-center"

--- a/spaceui/packages/primitives/src/Button.tsx
+++ b/spaceui/packages/primitives/src/Button.tsx
@@ -37,7 +37,7 @@ export const buttonStyles = cva(
 	{
 		variants: {
 			size: {
-				icon: "!p-1",
+				icon: "p-1!",
 				lg: "text-md px-3 py-1.5 font-medium",
 				md: "px-2.5 py-1.5 text-sm font-medium",
 				sm: "px-2 py-0.5 text-sm font-medium",

--- a/spaceui/packages/primitives/src/CircleButtonGroup.tsx
+++ b/spaceui/packages/primitives/src/CircleButtonGroup.tsx
@@ -29,8 +29,8 @@ export function CircleButtonGroup({
 						{cloneElement(child as React.ReactElement<any>, {
 							className: clsx(
 								(child as any).props.className,
-								"!rounded-none !border-0 !backdrop-blur-none !bg-transparent",
-								"hover:!bg-app-box",
+								"rounded-none! border-0! backdrop-blur-none! bg-transparent!",
+								"hover:bg-app-box!",
 							),
 						})}
 						{index < childArray.length - 1 && (

--- a/spaceui/packages/primitives/src/ContextMenu.tsx
+++ b/spaceui/packages/primitives/src/ContextMenu.tsx
@@ -120,7 +120,7 @@ const contextMenuItemStyles = cva(
 		variants: {
 			variant: {
 				default: "group-radix-highlighted:bg-accent",
-				dull: "group-radix-highlighted:bg-app-selected/50 group-radix-highlighted:!text-menu-ink group-radix-state-open:bg-app-selected/50 group-radix-state-open:!text-ink",
+				dull: "group-radix-highlighted:bg-app-selected/50 group-radix-highlighted:text-menu-ink! group-radix-state-open:bg-app-selected/50 group-radix-state-open:text-ink!",
 				danger: [
 					"text-red-600 dark:text-red-400",
 					"group-radix-highlighted:text-white",

--- a/spaceui/packages/primitives/src/Dialog.tsx
+++ b/spaceui/packages/primitives/src/Dialog.tsx
@@ -322,14 +322,14 @@ export function Dialog<S extends FieldValues>({
 				show ? (
 					<RDialog.Portal forceMount>
 						<AnimatedDialogOverlay
-							className="fixed inset-0 z-[102] m-px grid place-items-center overflow-y-auto rounded-xl bg-app/50"
+							className="fixed inset-0 z-102 m-px grid place-items-center overflow-y-auto rounded-xl bg-app/50"
 							style={{
 								opacity: styles.opacity,
 							}}
 						/>
 
 						<AnimatedDialogContent
-							className="!pointer-events-none fixed inset-0 z-[103] grid place-items-center overflow-y-auto"
+							className="pointer-events-none! fixed inset-0 z-103 grid place-items-center overflow-y-auto"
 							style={styles}
 							onInteractOutside={(e) =>
 								props.ignoreClickOutside && e.preventDefault()
@@ -344,14 +344,14 @@ export function Dialog<S extends FieldValues>({
 									}
 								}}
 								className={clsx(
-									"!pointer-events-auto my-8 min-w-[300px] max-w-[400px] rounded-xl",
+									"pointer-events-auto! my-8 min-w-[300px] max-w-[400px] rounded-xl",
 									"border border-app-line bg-app-box text-ink shadow-app-shade",
 									props.formClassName,
 								)}
 							>
 								{!props.hideHeader && (
 									<RDialog.Title className="flex items-center gap-2.5 border-b border-app-line bg-app-input/60 p-3 font-bold">
-										{props.icon && props.icon}
+										{props.icon}
 										{props.title}
 									</RDialog.Title>
 								)}

--- a/spaceui/packages/primitives/src/Dropdown.tsx
+++ b/spaceui/packages/primitives/src/Dropdown.tsx
@@ -32,7 +32,7 @@ const itemStyles = cva(
 	{
 		variants: {
 			selected: {
-				true: "bg-accent text-white hover:!bg-accent",
+				true: "bg-accent text-white hover:bg-accent!",
 				undefined: "hover:bg-sidebar-selected/40",
 				false: "hover:bg-sidebar-selected/40",
 			},
@@ -108,7 +108,7 @@ export const Button = forwardRef<HTMLButtonElement, UIButtonProps>(
 				{children}
 				<span className="grow" />
 				<CaretDown
-					className="ml-2 w-[12px] shrink-0 translate-y-px text-ink-dull transition-transform group-data-[open]:-translate-y-px group-data-[open]:rotate-180 group-radix-state-open:-translate-y-px group-radix-state-open:rotate-180"
+					className="ml-2 w-[12px] shrink-0 translate-y-px text-ink-dull transition-transform group-data-open:-translate-y-px group-data-open:rotate-180 group-radix-state-open:-translate-y-px group-radix-state-open:rotate-180"
 					aria-hidden="true"
 				/>
 			</UIButton>

--- a/spaceui/packages/primitives/src/DropdownMenu.tsx
+++ b/spaceui/packages/primitives/src/DropdownMenu.tsx
@@ -21,7 +21,7 @@ const Content = forwardRef<
 			ref={ref}
 			sideOffset={sideOffset}
 			className={clsx(
-				"z-50 min-w-[8rem] overflow-hidden rounded-md p-1",
+				"z-50 min-w-32 overflow-hidden rounded-md p-1",
 				"border border-menu-line bg-menu/95 backdrop-blur-lg",
 				"text-sm text-menu-ink shadow-xl shadow-menu-shade/30",
 				"animate-in fade-in-0 zoom-in-95",
@@ -46,7 +46,7 @@ const Item = forwardRef<
 			"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
 			"text-menu-ink transition-colors",
 			"focus:bg-accent focus:text-white",
-			"data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+			"data-disabled:pointer-events-none data-disabled:opacity-50",
 			inset && "pl-8",
 			className,
 		)}
@@ -66,7 +66,7 @@ const CheckboxItem = forwardRef<
 			"relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none",
 			"text-menu-ink transition-colors",
 			"focus:bg-accent focus:text-white",
-			"data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+			"data-disabled:pointer-events-none data-disabled:opacity-50",
 			className,
 		)}
 		checked={checked}
@@ -93,7 +93,7 @@ const RadioItem = forwardRef<
 			"relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none",
 			"text-menu-ink transition-colors",
 			"focus:bg-accent focus:text-white",
-			"data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+			"data-disabled:pointer-events-none data-disabled:opacity-50",
 			className,
 		)}
 		{...props}
@@ -172,7 +172,7 @@ const SubContent = forwardRef<
 	<DropdownMenuPrimitive.SubContent
 		ref={ref}
 		className={clsx(
-			"z-50 min-w-[8rem] overflow-hidden rounded-md p-1",
+			"z-50 min-w-32 overflow-hidden rounded-md p-1",
 			"border border-menu-line bg-menu/95 backdrop-blur-lg",
 			"text-sm text-menu-ink shadow-xl shadow-menu-shade/30",
 			"animate-in fade-in-0 zoom-in-95",

--- a/spaceui/packages/primitives/src/Input.tsx
+++ b/spaceui/packages/primitives/src/Input.tsx
@@ -114,10 +114,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 
 				<input
 					className={clsx(
-						"flex-1 truncate border-none bg-transparent px-3 text-sm outline-none placeholder:text-ink-faint focus:!ring-0",
+						"flex-1 truncate border-none bg-transparent px-3 text-sm outline-none placeholder:text-ink-faint focus:ring-0!",
 						(right || (icon && iconPosition === "right")) && "pr-0",
 						icon && iconPosition === "left" && "pl-0",
-						size === "xs" && "!py-0",
+						size === "xs" && "py-0!",
 						inputElementClassName,
 					)}
 					onKeyDown={(e) => {
@@ -216,7 +216,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
 						aria-label={showPassword ? "Hide Password" : "Show Password"}
 						className={clsx(props.buttonClassnames)}
 					>
-						<CurrentEyeIcon className="!pointer-events-none size-4" />
+						<CurrentEyeIcon className="pointer-events-none! size-4" />
 					</Button>
 				}
 			/>

--- a/spaceui/packages/primitives/src/NumberStepper.tsx
+++ b/spaceui/packages/primitives/src/NumberStepper.tsx
@@ -113,11 +113,11 @@ const NumberStepper = forwardRef<HTMLDivElement, NumberStepperProps>(
 								if (e.key === "Enter") commitInput();
 								if (e.key === "Escape") setEditing(false);
 							}}
-							className="min-w-[3rem] w-[4rem] bg-transparent text-center text-sm font-medium text-ink outline-none"
+							className="min-w-12 w-16 bg-transparent text-center text-sm font-medium text-ink outline-none"
 						/>
 					) : (
 						<span
-							className="min-w-[3rem] text-center text-sm font-medium text-ink cursor-text select-none"
+							className="min-w-12 text-center text-sm font-medium text-ink cursor-text select-none"
 							onDoubleClick={() => {
 								if (!disabled) {
 									setInputValue(String(allowFloat ? value.toFixed(1) : value));

--- a/spaceui/packages/primitives/src/Popover.tsx
+++ b/spaceui/packages/primitives/src/Popover.tsx
@@ -26,7 +26,7 @@ const Content = forwardRef<
 			sideOffset={sideOffset}
 			onOpenAutoFocus={(event) => event.preventDefault()}
 			onCloseAutoFocus={(event) => event.preventDefault()}
-			className="z-[9999]"
+			className="z-9999"
 			{...props}
 		>
 			<div

--- a/spaceui/packages/primitives/src/Select.tsx
+++ b/spaceui/packages/primitives/src/Select.tsx
@@ -85,7 +85,7 @@ export const Select = forwardRef(
 				</RS.Trigger>
 
 				<RS.Portal>
-					<RS.Content className="z-[100] rounded-md border border-app-line bg-app-box shadow-2xl shadow-app-shade/20">
+					<RS.Content className="z-100 rounded-md border border-app-line bg-app-box shadow-2xl shadow-app-shade/20">
 						<RS.Viewport className="p-1">{props.children}</RS.Viewport>
 					</RS.Content>
 				</RS.Portal>
@@ -187,7 +187,7 @@ export const SelectContent = ({
 	<RS.Portal>
 		<RS.Content
 			className={clsx(
-				"relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-app-line bg-app-box text-ink shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+				"relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border border-app-line bg-app-box text-ink shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
 				position === "popper" &&
 					"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
 				className,
@@ -200,7 +200,7 @@ export const SelectContent = ({
 				className={clsx(
 					"p-1",
 					position === "popper" &&
-						"h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+						"h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)",
 				)}
 			>
 				{children}
@@ -231,7 +231,7 @@ export const SelectItem = ({
 }: RS.SelectItemProps) => (
 	<RS.Item
 		className={clsx(
-			"relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-app-hover focus:text-ink data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+			"relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-app-hover focus:text-ink data-disabled:pointer-events-none data-disabled:opacity-50",
 			className,
 		)}
 		{...props}

--- a/spaceui/packages/primitives/src/Toast.tsx
+++ b/spaceui/packages/primitives/src/Toast.tsx
@@ -23,7 +23,7 @@ import {Loader} from "./Loader";
 
 export const TOAST_TIMEOUT = 4000;
 
-const actionButtonClassName = "!rounded !px-1.5 !py-0.5 !font-normal";
+const actionButtonClassName = "rounded! px-1.5! py-0.5! font-normal!";
 
 const toastClassName = clsx(
 	"w-full overflow-hidden rounded-md p-3 shadow-lg",
@@ -298,7 +298,7 @@ const PromiseToast = <T extends ToastPromiseData>({
 			icon={
 				!type &&
 				showLoader &&
-				(props.loader ?? <Loader className="!h-4 !w-4" />)
+				(props.loader ?? <Loader className="h-4! w-4!" />)
 			}
 			closable={!!type}
 			onDismiss={props.onDismiss}

--- a/spaceui/packages/primitives/src/Tooltip.tsx
+++ b/spaceui/packages/primitives/src/Tooltip.tsx
@@ -73,7 +73,7 @@ export const Tooltip = ({ position = "bottom", ...props }: TooltipProps) => {
 					sideOffset={props.sideOffset}
 					alignOffset={props.alignOffset}
 					className={clsx(
-						"TooltipContent z-[101] m-2 mt-1 flex max-w-[200px] select-text items-center gap-2 break-words rounded border border-app-line bg-app-box px-2 py-1 text-center text-xs text-ink",
+						"TooltipContent z-101 m-2 mt-1 flex max-w-[200px] select-text items-center gap-2 break-words rounded border border-app-line bg-app-box px-2 py-1 text-center text-xs text-ink",
 						props.tooltipClassName,
 						!props.label && "hidden",
 					)}


### PR DESCRIPTION
## Summary

Tailwind v4 reworked several shortcut forms. This PR updates SpaceUI primitives + explorer to the canonical syntax so utility classes keep their intended effect under v4 parsing, and folds in two small latent fixes surfaced during the sweep.

### Changes

| Category | Files | Examples |
|---|---|---|
| `!class` → `class!` | 9 | `!p-1` → `p-1!`, `hover:!bg-accent` → `hover:bg-accent!` |
| `data-[X]:` → `data-X:` | 3 | `data-[disabled]:` → `data-disabled:`, `group-data-[open]:` → `group-data-open:` |
| `z-[N]` → `z-N` | 4 | `z-[100]` → `z-100`, `z-[103]` → `z-103` |
| `min-w-[Nrem]` → numeric | 4 | `min-w-[8rem]` → `min-w-32`, `min-w-[3rem]` → `min-w-12` |
| `*-[var(--X)]` → `*-(--X)` | 2 | `h-[var(--radix-select-trigger-height)]` → `h-(--radix-select-trigger-height)` |
| Bug fix (S1764) | `Dialog.tsx:354` | `{props.icon && props.icon}` → `{props.icon}` |
| Defensive type annotation | `RenameInput.tsx:100` | `(e)` → `(e: React.ChangeEvent<HTMLInputElement>)` |

Symmetric 30/30 diff — every line change is an in-place rewrite.

## Test plan

- [x] Storybook boots clean on `http://localhost:6006/`
- [x] Primitives → Button → Default renders (validates `p-1!` shortcut on Button)
- [x] Button variants (Subtle, Accent, Outline, Dotted, Colored, Small, Large) apply cva styles correctly
- [x] DevTools console shows only the expected PopoverProvider ariaLabel advisory
- [x] 13 files × symmetric +30/-30 line changes — zero net additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)