### PR TITLE
docs: session sync — SpaceUI package inventory + Tailwind v4 drift fixes

### DIFF
--- a/interface/DRY_VIOLATIONS.md
+++ b/interface/DRY_VIOLATIONS.md
@@ -1,8 +1,8 @@
 # Interface DRY Violations & Hardcoded Patterns
 
-A comprehensive audit of ugly hardcoded stuff and DRY violations in the interface codebase.
+A comprehensive audit of hardcoded patterns and DRY violations in the interface codebase.
 
-**Last updated:** After round 2 of fixes
+**Last snapshot:** Round 2 of fixes (pre-2026-04). Several of the items below predate the `@spacedrive/primitives` migration and may no longer exist after the interface was retargeted onto the spaceui design system. Before fixing any entry, verify the pattern still appears in the current code.
 
 ---
 

--- a/interface/PLAN.md
+++ b/interface/PLAN.md
@@ -1,4 +1,6 @@
-# Spacebot Control UI
+# Spacebot Control UI — Original Bootstrap Plan (Historical)
+
+> **Status:** This document captures the original Phase 1–5 bootstrap plan for `interface/`. Phases 1–3 are complete: the axum HTTP server, Vite + React + TypeScript scaffolding, and the UI component set now live in the tree (the UI set migrated from an inline `src/ui/` tree to `@spacedrive/primitives` + siblings from the `spaceui/` workspace). Tailwind is on v4, not v3 as this document originally specified. Use it for historical context only; for current-state conventions, see `CLAUDE.md`, `spaceui/README.md`, and `spaceui/INTEGRATION.md`.
 
 A self-contained React web app living at `interface/` in the Spacebot repo, served by the Rust daemon via an embedded axum HTTP server. Copies Spacedrive's UI component library and color system. Uses spec-first OpenAPI with `openapi-fetch` + `openapi-typescript` for the data layer, TanStack Query for caching, and `rust-embed` to bake the built assets into the single binary.
 

--- a/spaceui/CONTRIBUTING.md
+++ b/spaceui/CONTRIBUTING.md
@@ -99,9 +99,10 @@ spaceui/
 
 ### Code Style
 
-- **TypeScript**: Strict mode enabled. No `any` types.
+- **TypeScript**: Strict mode enabled (TypeScript 6). No `any` types.
 - **Components**: Use `forwardRef` for ref forwarding.
-- **Styling**: Use Tailwind's semantic classes (e.g., `bg-app`, `text-ink`).
+- **Styling**: Tailwind v4. Use semantic classes (e.g., `bg-app`, `text-ink`).
+- **Tailwind v4 syntax**: Use canonical shortcuts — `class!` (not `!class`), `data-disabled:` (not `data-[disabled]:`), `z-100` (not `z-[100]`), `*-(--X)` (not `*-[var(--X)]`).
 - **Colors**: Never use `var()` directly. Use semantic classes only.
 - **Naming**: PascalCase for components, camelCase for utilities.
 
@@ -227,9 +228,11 @@ Ensure peer dependencies are installed:
 
 ## Resources
 
-- [SHARED-UI-STRATEGY.md](./SHARED-UI-STRATEGY.md) - Migration plan
+- [docs/SHARED-UI-STRATEGY.md](./docs/SHARED-UI-STRATEGY.md) - Migration plan
+- [docs/TAILWIND-V4-MIGRATION.md](./docs/TAILWIND-V4-MIGRATION.md) - Tailwind v3→v4 migration spec
+- [docs/COMPONENT-AUDIT.md](./docs/COMPONENT-AUDIT.md) - Fidelity audit vs real Spacedrive
 - [Radix UI docs](https://www.radix-ui.com/) - Primitives we build on
-- [Tailwind docs](https://tailwindcss.com/) - Styling system
+- [Tailwind docs](https://tailwindcss.com/) - Styling system (v4)
 - [CVA docs](https://cva.style/) - Component variants
 
 ## Questions?

--- a/spaceui/README.md
+++ b/spaceui/README.md
@@ -11,11 +11,12 @@ SpaceUI is a standalone repository that houses all shared UI components, design 
 ```
 spaceui/
 ├── packages/
-│   ├── tokens/         # @spacedrive/tokens - CSS design tokens + raw colors
-│   ├── primitives/     # @spacedrive/primitives - Base UI components (40+)
-│   ├── forms/          # @spacedrive/forms - react-hook-form wrappers
-│   ├── ai/             # @spacedrive/ai - AI agent components (18)
-│   └── explorer/       # @spacedrive/explorer - File management (14)
+│   ├── tokens/         # @spacedrive/tokens - CSS-first design tokens (Tailwind v4)
+│   ├── primitives/     # @spacedrive/primitives - Base UI components (41)
+│   ├── forms/          # @spacedrive/forms - react-hook-form wrappers (7)
+│   ├── icons/          # @spacedrive/icons - file-type icons + extension badges (SVG)
+│   ├── ai/             # @spacedrive/ai - AI agent components (12)
+│   └── explorer/       # @spacedrive/explorer - File management (3)
 ├── examples/
 │   └── showcase/       # Interactive demo app
 ├── .storybook/         # Component documentation
@@ -88,11 +89,14 @@ import { Button, Card, Dialog } from '@spacedrive/primitives';
 // Import form fields
 import { InputField, SelectField } from '@spacedrive/forms';
 
+// Import file-type icons and resolution helpers
+import { getIcon } from '@spacedrive/icons/util';
+
 // Import AI components
 import { ToolCall, ChatComposer, Markdown } from '@spacedrive/ai';
 
 // Import explorer components
-import { FileGrid, PathBar, Inspector } from '@spacedrive/explorer';
+import { FileThumb, RenameInput, TagPill } from '@spacedrive/explorer';
 ```
 
 ### Tailwind Configuration
@@ -148,6 +152,15 @@ Form field wrappers built on react-hook-form.
 
 [Read more →](./packages/forms/README.md)
 
+### @spacedrive/icons
+
+File-type icons, extension badges, and icon resolution utilities. Ships raw SVG assets plus a `getIcon` resolver keyed on kind/extension. No React components — consumers render the SVGs themselves.
+
+**Exports:**
+- `@spacedrive/icons/icons` - React icon index
+- `@spacedrive/icons/svgs/*` - raw SVG assets
+- `@spacedrive/icons/util` - `getIcon(name, kind?)` resolver
+
 ### @spacedrive/ai
 
 AI agent interaction components.
@@ -155,36 +168,24 @@ AI agent interaction components.
 **Components:**
 - `ToolCall` - Tool invocation display
 - `Markdown` - Agent response renderer
-- `InlineWorkerCard` - Worker task card with transcript
+- `InlineWorkerCard`, `InlineBranchCard` - Worker/branch task cards with transcript
 - `ChatComposer` - Message input with model selection
-- `ModelSelect` - LLM model picker
-- `ProfileAvatar` - Deterministic avatar from seed
-- `AgentSelector` - Agent switching dropdown
-- `ConnectionStatus` - Connection state indicator
-- `TaskBoard`, `TaskCard` - Kanban task management
-- `MemoryGraph`, `MemoryList` - Memory visualization and list
-- `CronJobList` - Cron job management
-- `AutonomyPanel` - Autonomy level control
+- `ModelSelector` - LLM model picker
+- `MessageBubble` - Agent/user message shell
+- `TaskList`, `TaskRow`, `TaskDetail`, `TaskCreateForm` - Task surface
+- `TaskStatusIcon`, `TaskPriorityIcon` - Task metadata glyphs
 
 [Read more →](./packages/ai/README.md)
 
 ### @spacedrive/explorer
 
-File management and explorer components.
+File-surface primitives. Larger explorer views (FileGrid/FileList/PathBar/Inspector/QuickPreview) live in each consuming app — the UI library keeps only the self-contained pieces.
 
 **Components:**
-- `KindIcon` - File type icons
 - `FileThumb` - File thumbnail renderer
-- `TagPill` - Colored tag pill
-- `RenameInput` - Inline rename field
-- `FileRow` - Single row in list view
-- `FileGrid` - Grid layout of files
-- `FileList` - Table/list layout
-- `PathBar` - Breadcrumb navigation
-- `Inspector` - File metadata panel
-- `InspectorPanel` - Collapsible inspector section
-- `DragOverlay` - Drag and drop visual feedback
-- `QuickPreview` - Spacebar preview modal
+- `GridItem` - Grid cell shell
+- `RenameInput` - Inline rename field with extension awareness
+- `TagPill` - Colored tag pill with optional remove button
 
 [Read more →](./packages/explorer/README.md)
 
@@ -243,7 +244,7 @@ bun run publish
 
 ## Migration Guide
 
-See [SHARED-UI-STRATEGY.md](./SHARED-UI-STRATEGY.md) for the complete migration plan from existing Spacedrive and Spacebot UI codebases.
+See [docs/SHARED-UI-STRATEGY.md](./docs/SHARED-UI-STRATEGY.md) for the complete migration plan from existing Spacedrive and Spacebot UI codebases, and [docs/TAILWIND-V4-MIGRATION.md](./docs/TAILWIND-V4-MIGRATION.md) for the Tailwind v3→v4 migration spec.
 
 Quick start for migration:
 
@@ -286,8 +287,12 @@ Quick contributing workflow:
 
 ## Resources
 
-- [Design Strategy](./SHARED-UI-STRATEGY.md) - Migration plan & architecture
+- [Design Strategy](./docs/SHARED-UI-STRATEGY.md) - Migration plan & architecture
+- [Tailwind v4 Migration](./docs/TAILWIND-V4-MIGRATION.md) - v3→v4 migration spec
+- [Component Audit](./docs/COMPONENT-AUDIT.md) - Fidelity check vs real Spacedrive
+- [Repository Summary](./docs/REPO_SUMMARY.md) - Monorepo stats & tooling
 - [Contributing Guide](./CONTRIBUTING.md) - Development setup & guidelines
+- [Integration Guide](./INTEGRATION.md) - Consuming SpaceUI from an external project
 - [Package READMEs](./packages/) - Individual package documentation
 - [Radix UI](https://www.radix-ui.com/) - Primitives we build on
 - [Tailwind CSS](https://tailwindcss.com/) - Styling system

--- a/spaceui/docs/COMPONENT-AUDIT.md
+++ b/spaceui/docs/COMPONENT-AUDIT.md
@@ -2,6 +2,8 @@
 
 Assessment of spaceui components vs the real Spacedrive implementations. Generated 2026-03-26.
 
+> **Note:** This is a snapshot. Several of the "Explorer — Removed" decisions below have been acted on — see `packages/explorer/README.md`, which now documents only the surviving primitives (FileThumb, GridItem, RenameInput, TagPill). Primitives-side rework is ongoing. Treat percentages as the baseline assessment at the time of generation, not current state.
+
 Use this to track migration progress as components are faithfully rebuilt from the real codebase.
 
 **Real Spacedrive UI source:** `spacedrive/packages/ui/src/`

--- a/spaceui/docs/REPO_SUMMARY.md
+++ b/spaceui/docs/REPO_SUMMARY.md
@@ -2,122 +2,108 @@
 
 ## Overview
 
-A complete monorepo with 5 packages, 100+ components, CI/CD, documentation, and development tooling.
-
-## Repository Statistics
-
-- **Total Files**: 124 source files
-- **Packages**: 5 published packages
-- **Components**: 100+ React components
-- **Lines of Code**: ~15,000+
+A monorepo housing the Spacedrive ecosystem design system: 6 packages covering design tokens, base primitives, form wrappers, file-type icons, AI-agent surfaces, and explorer primitives.
 
 ## Package Structure
 
-### @spacedrive/tokens
-- **Components**: Design tokens, Tailwind preset, CSS themes
-- **Files**: 8
-- **Key Exports**: `spaceUiPreset`, `colors`, CSS themes
+### @spacedrive/tokens (0.2.3)
+- CSS-first design tokens for Tailwind v4 (`@theme` block)
+- Semantic color system, spacing, radii, fonts
+- Themes: dark (default), light, midnight, noir, slate, nord, mocha
+- Key exports: `@spacedrive/tokens/theme`, `@spacedrive/tokens/css`, `@spacedrive/tokens/raw-colors`
 
-### @spacedrive/primitives  
-- **Components**: 41 base UI components
-- **Files**: 34
-- **Key Exports**: Button, Card, Dialog, Input, Select, Tabs, etc.
+### @spacedrive/primitives (0.2.3)
+- 41 base UI components built on Radix + Headless UI
+- Key exports: Button, Input, Dialog, Dropdown, Popover, Select, Tabs, Tooltip, Toast, Card, Badge, and more
 
-### @spacedrive/forms
-- **Components**: 8 form field wrappers
-- **Files**: 10
-- **Key Exports**: InputField, SelectField, CheckboxField, etc.
+### @spacedrive/forms (0.2.3)
+- 7 form field wrappers built on react-hook-form
+- Key exports: Form, InputField, TextAreaField, SelectField, CheckboxField, RadioGroupField, SwitchField
 
-### @spacedrive/ai
-- **Components**: 18 AI/agent components
-- **Files**: 21
-- **Key Exports**: ToolCall, ChatComposer, TaskBoard, MemoryGraph, etc.
+### @spacedrive/icons (0.2.3)
+- Spacedrive file-type icons, extension badges, and icon resolution utilities
+- Ships raw SVG assets (no React components) plus a `getIcon` resolver
+- Key exports: `@spacedrive/icons/icons`, `@spacedrive/icons/svgs/*`, `@spacedrive/icons/util`
 
-### @spacedrive/explorer
-- **Components**: 14 file management components
-- **Files**: 17
-- **Key Exports**: FileGrid, PathBar, Inspector, KindIcon, etc.
+### @spacedrive/ai (0.2.3)
+- 12 AI/agent interaction components
+- Key exports: ToolCall, Markdown, MessageBubble, ChatComposer, ModelSelector, InlineWorkerCard, InlineBranchCard, TaskList, TaskRow, TaskDetail, TaskCreateForm, TaskStatusIcon, TaskPriorityIcon
+
+### @spacedrive/explorer (0.2.3)
+- 3 file-surface primitives (FileThumb, GridItem, RenameInput, TagPill)
+- Larger explorer views (FileGrid/FileList/PathBar/Inspector/QuickPreview) live in each consuming app
 
 ## Development Tooling
 
 ### Build System
-- **Package Manager**: Bun workspaces
-- **Build Tool**: tsup (fast ESM builds)
+- **Package Manager**: Bun workspaces (bun 1.1.0+)
+- **Build Tool**: tsup for JS/TS packages; tokens is CSS-only
 - **Orchestration**: Turbo
-- **TypeScript**: Strict mode, 5.4+
+- **TypeScript**: Strict mode, TypeScript 6
 
 ### Development Environment
-- **Showcase App**: Vite + React demo app (port 19850)
-- **Storybook**: Component documentation (port 6006)
+- **Showcase App**: Vite + React demo app
+- **Storybook**: 10.3.5 (component documentation, port 6006)
 - **Scripts**: link-packages.sh, unlink-packages.sh, build-watch.sh
 
-### CI/CD
-- **GitHub Actions**: CI workflow for PRs
-- **Release**: Automated versioning with Changesets
-- **Publishing**: npm registry integration
+### Styling
+- Tailwind v4 (CSS-first configuration via `@theme`)
+- Consumers `@source` spaceui package source paths
+- `@plugin` directive for Tailwind plugins (consumers decide)
+
+### Release
+- **Changesets**: versioning with linked packages (primitives/forms/ai/explorer/icons release together)
+- **Publishing**: manual `bunx changeset publish` to npm under `@spacedrive` scope
+- **Pre-release**: `bunx changeset pre enter <tag>` for alpha/beta trains
 
 ## Documentation
 
-### Main Docs
-- README.md - Main overview and quick start
-- SHARED-UI-STRATEGY.md - Migration plan from existing codebases
-- CONTRIBUTING.md - Development setup and guidelines
-- LICENSE - MIT license
+### Repo-level
+- `README.md` - overview & quick start
+- `CONTRIBUTING.md` - contributor guide
+- `INTEGRATION.md` - consuming from an external project
+- `LICENSE` - MIT
 
-### Package Docs
-- packages/tokens/README.md
-- packages/primitives/README.md
-- packages/forms/README.md
-- packages/ai/README.md
-- packages/explorer/README.md
+### docs/
+- `SHARED-UI-STRATEGY.md` - migration plan & architecture
+- `TAILWIND-V4-MIGRATION.md` - v3→v4 migration spec
+- `COMPONENT-AUDIT.md` - fidelity audit against real Spacedrive UI
+- `REPO_SUMMARY.md` - this file
 
-### Configuration Files
-- .gitignore
-- turbo.json
-- tailwind.config.ts
-- tsconfig.base.json
-- .changeset/config.json
-- .changeset/initial-release.md
-- .github/workflows/ci.yml
-- .github/workflows/release.yml
-- .storybook/main.ts
-- .storybook/preview.ts
-- .storybook/package.json
+### Package READMEs
+- `packages/tokens/README.md`
+- `packages/primitives/README.md`
+- `packages/forms/README.md`
+- `packages/ai/README.md`
+- `packages/explorer/README.md`
+- (icons has no README — see `packages/icons/package.json` description)
 
-## Next Steps for Phase 1
-
-1. Install dependencies: `bun install`
-2. Build packages: `bun run build`
-3. Copy actual implementations:
-   - `ToolCall.tsx` from spacebot/spacedrive
-   - `Markdown.tsx` from spacebot/spacedrive
-   - Update types if needed
-4. Test in showcase app: `bun run showcase`
-5. Link to consuming apps: `bun run link`
-
-## Repository Ready For
-
-✅ Phase 0 - Bootstrap complete
-✅ Phase 1 - Ready for ToolCall/Markdown migration
-✅ Phase 2+ - All infrastructure in place
+## Key Configuration Files
+- `turbo.json`
+- `tsconfig.base.json`
+- `.changeset/config.json`
+- `.storybook/main.ts`, `.storybook/preview.ts`
+- `.github/workflows/ci.yml` (bot-authored PRs skipped via claude-review config)
 
 ## Quick Commands
 
 ```bash
 # Development
 bun install          # Install dependencies
-bun run build       # Build all packages
-bun run dev         # Watch mode
-bun run showcase    # Run demo app
+bun run build        # Build all packages (turbo)
+bun run dev          # Watch mode
+bun run typecheck    # Type check all packages
+bun run showcase     # Run demo app
+bun run storybook    # Start Storybook
 
-# Local development
-bun run link        # Link packages
-bun run unlink      # Unlink packages
+# Local linking
+bun run link         # Link packages into global registry
+bun run unlink       # Unlink
 
 # Publishing
-bun run changeset          # Create changeset
-bun run version-packages   # Bump versions
-bun run publish           # Publish to npm
+bun run changeset           # Create changeset
+bun run version-packages    # Bump versions
+bun run publish             # Build + publish to npm
 ```
 
 ---

--- a/spaceui/docs/SHARED-UI-STRATEGY.md
+++ b/spaceui/docs/SHARED-UI-STRATEGY.md
@@ -29,7 +29,7 @@ A standalone repo — `spacedriveapp/spaceui` — that owns the entire shared de
 
 ### Package Structure
 
-The repo publishes multiple packages from a single monorepo. Domain-specific composites live in scoped packages under `packages/` — `ai/` for agent and AI interaction components, `explorer/` for file management components, with room for more as product surfaces grow.
+The repo publishes multiple packages from a single monorepo. Domain-specific composites live in scoped packages under `packages/` — `ai/` for agent and AI interaction components, `explorer/` for file-surface primitives, `icons/` for the Spacedrive file-type icon set, with room for more as product surfaces grow.
 
 ```
 spacedriveapp/spaceui/
@@ -119,23 +119,33 @@ spacedriveapp/spaceui/
 │   │   │   └── index.ts
 │   │   └── package.json         # peer deps: @spacedrive/primitives
 │   │
-│   └── tokens/                  # @spacedrive/tokens
+│   ├── icons/                   # @spacedrive/icons
+│   │   ├── svgs/                # raw SVG assets (kinds + extension badges)
+│   │   ├── icons/               # React icon index
+│   │   ├── util/                # getIcon resolver
+│   │   └── package.json
+│   │
+│   └── tokens/                  # @spacedrive/tokens (CSS-first, Tailwind v4)
 │       ├── src/
-│       │   ├── colors.ts        # semantic color definitions
-│       │   ├── tailwind-preset.ts
-│       │   ├── css/
-│       │   │   ├── base.css     # CSS custom properties
-│       │   │   └── themes/
-│       │   │       ├── dark.css
-│       │   │       └── light.css
-│       │   └── index.ts
+│       │   └── css/
+│       │       ├── theme.css    # @theme block — generates utilities
+│       │       ├── base.css     # base layer + default theme
+│       │       └── themes/
+│       │           ├── dark.css
+│       │           ├── light.css
+│       │           ├── midnight.css
+│       │           ├── noir.css
+│       │           ├── slate.css
+│       │           ├── nord.css
+│       │           └── mocha.css
 │       └── package.json
 │
 ├── turbo.json                   # or bun workspace config
 ├── tsconfig.base.json
-├── tailwind.config.ts           # base config using @spacedrive/tokens
 └── package.json                 # workspace root
 ```
+
+Tailwind is configured CSS-first (no `tailwind.config.ts` at root). See [TAILWIND-V4-MIGRATION.md](./TAILWIND-V4-MIGRATION.md) for the full migration spec.
 
 ### Package Responsibilities
 

--- a/spaceui/docs/TAILWIND-V4-MIGRATION.md
+++ b/spaceui/docs/TAILWIND-V4-MIGRATION.md
@@ -4,6 +4,8 @@ Migration spec for upgrading the entire Spacedrive stack from Tailwind CSS v3 to
 
 **Scope:** spaceui, spacedrive (app), spacedrive-web (marketing site)
 
+**Status (as of 2026-04-16):** spaceui migration complete. Canonical v4 class syntax adopted across primitives + explorer (see PR #45: `!class` → `class!`, `data-[X]:` → `data-X:`, `z-[N]` → `z-N`, `*-[var(--X)]` → `*-(--X)`, numeric spacing). spacedrive app and spacedrive-web migrations remain out-of-scope here and may still be in progress.
+
 ---
 
 ## Why

--- a/spaceui/packages/explorer/CHANGELOG.md
+++ b/spaceui/packages/explorer/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @spacedrive/explorer
 
+> Changelog entries between 0.1.1 and the current `package.json` version were not authored via changesets; see `git log packages/explorer` for the detail. The 0.1.0 "Packages Included" bullet list below predates the addition of `@spacedrive/icons` — spaceui now ships 6 packages. The explorer package itself now exports only self-contained primitives (FileThumb, GridItem, RenameInput, TagPill); see `packages/explorer/README.md` and `docs/COMPONENT-AUDIT.md`.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/spaceui/packages/explorer/README.md
+++ b/spaceui/packages/explorer/README.md
@@ -1,6 +1,8 @@
 # @spacedrive/explorer
 
-File management and explorer components for SpaceUI.
+File-surface primitives for Spacedrive and Spacebot applications.
+
+The explorer package ships only the self-contained building blocks. Larger, stateful views (FileGrid, FileList, PathBar, Inspector, QuickPreview, DragOverlay, KindIcon, FileRow, etc.) live in each consuming app because they are tightly coupled to the app's data layer, virtualization strategy, drag-drop context, and platform behaviors. See [`../../docs/COMPONENT-AUDIT.md`](../../docs/COMPONENT-AUDIT.md) for rationale.
 
 ## Installation
 
@@ -13,403 +15,73 @@ npm install @spacedrive/explorer @spacedrive/primitives
 Peer dependencies:
 - `react` ^18.0.0 || ^19.0.0
 - `react-dom` ^18.0.0 || ^19.0.0
-- `@tanstack/react-virtual` ^3.0.0
 
 ## Usage
 
 ```tsx
-import { FileGrid, PathBar, Inspector, KindIcon, TagPill } from '@spacedrive/explorer';
-import type { FileInfo, TagInfo } from '@spacedrive/explorer';
-
-const file: FileInfo = {
-  id: '1',
-  name: 'document.pdf',
-  path: '/docs/document.pdf',
-  kind: 'document',
-  size: 1024000,
-  modifiedAt: new Date(),
-  createdAt: new Date(),
-  isDirectory: false,
-  extension: 'pdf',
-};
-
-const tag: TagInfo = {
-  id: '1',
-  name: 'Important',
-  color: '#ef4444',
-};
-
-function FileBrowser() {
-  return (
-    <div className="flex gap-4">
-      <div className="flex-1">
-        <PathBar 
-          path={['Home', 'Documents', 'Projects']} 
-          onNavigate={(index) => console.log('Navigate to', index)} 
-        />
-        <div className="mt-4">
-          <KindIcon kind="document" />
-          <TagPill tag={tag} onRemove={() => console.log('Remove tag')} />
-        </div>
-      </div>
-      <Inspector file={file} tags={[tag]} />
-    </div>
-  );
-}
+import { FileThumb, GridItem, RenameInput, TagPill } from '@spacedrive/explorer';
 ```
 
 ## Components
 
-### Display Components
+### FileThumb
 
-#### KindIcon
+File thumbnail renderer. Accepts a thumbnail URL or a kind identifier and renders an appropriate visual.
 
-File type icons:
+### GridItem
 
-```tsx
-import { KindIcon } from '@spacedrive/explorer';
-import type { FileKind } from '@spacedrive/explorer';
+Grid-cell shell used by consuming apps to wrap any content (thumbnail + label + selection state) in a consistent layout. Does not own selection or DnD — the app passes handlers via props.
 
-<KindIcon kind="document" />      {/* Document icon */}
-<KindIcon kind="image" />         {/* Image icon */}
-<KindIcon kind="video" />         {/* Video icon */}
-<KindIcon kind="audio" />         {/* Audio icon */}
-<KindIcon kind="archive" />       {/* Archive icon */}
-<KindIcon kind="code" />          {/* Code icon */}
-<KindIcon kind="unknown" />       {/* Question mark */}
-```
+### RenameInput
 
-Sizes: `sm` | `md` | `lg`
+Inline rename field. Extension-aware (preserves file extension through edit), async save, blur cancellation. Generic over the item shape being renamed.
 
 ```tsx
-<KindIcon kind="image" size="lg" />
-```
-
-#### TagPill
-
-Colored tag pill:
-
-```tsx
-import { TagPill } from '@spacedrive/explorer';
-import type { TagInfo } from '@spacedrive/explorer';
-
-const tag: TagInfo = {
-  id: '1',
-  name: 'Important',
-  color: '#ef4444',  // Any valid CSS color
-};
-
-<TagPill tag={tag} />
-
-// With remove button
-<TagPill tag={tag} onRemove={() => console.log('Remove')} />
-```
-
-#### FileThumb
-
-File thumbnail renderer:
-
-```tsx
-import { FileThumb } from '@spacedrive/explorer';
-import type { FileInfo } from '@spacedrive/explorer';
-
-const file: FileInfo = {
-  id: '1',
-  name: 'photo.jpg',
-  kind: 'image',
-  thumbnailUrl: '/thumbs/photo.jpg',
-  // ... other fields
-};
-
-<FileThumb file={file} size="sm" />  {/* 32px */}
-<FileThumb file={file} size="md" />  {/* 48px */}
-<FileThumb file={file} size="lg" />  {/* 64px */}
-```
-
-For images with `thumbnailUrl`, displays the image. Otherwise shows kind icon.
-
-### Navigation Components
-
-#### PathBar
-
-Breadcrumb navigation:
-
-```tsx
-import { PathBar } from '@spacedrive/explorer';
-
-<PathBar
-  path={['Home', 'Documents', 'Projects', 'MyProject']}
-  onNavigate={(index) => {
-    // index -1 = home, 0 = Home, 1 = Documents, etc.
-    console.log('Navigate to level', index);
-  }}
-  homeLabel="Home"  // Optional, defaults to "Home"
-/>
-```
-
-Features:
-- Home button always shown
-- Long paths collapsed with dropdown
-- Click any segment to navigate
-
-### File Views
-
-#### FileGrid
-
-Grid layout of files:
-
-```tsx
-import { FileGrid } from '@spacedrive/explorer';
-import type { FileInfo } from '@spacedrive/explorer';
-
-const files: FileInfo[] = [
-  { id: '1', name: 'file1.txt', kind: 'document', /* ... */ },
-  { id: '2', name: 'file2.jpg', kind: 'image', /* ... */ },
-];
-
-const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-
-<FileGrid
-  files={files}
-  selectedIds={selectedIds}
-  onFileClick={(file, event) => {
-    // Handle selection logic
-    console.log('Clicked:', file.name);
-  }}
-  onFileDoubleClick={(file) => {
-    console.log('Open:', file.name);
-  }}
-/>
-```
-
-Features:
-- Responsive grid (2-6 columns based on viewport)
-- Checkbox selection (appears on hover)
-- Thumbnail display
-- Multi-select support via `selectedIds`
-
-#### FileList
-
-Table/list layout:
-
-```tsx
-import { FileList } from '@spacedrive/explorer';
-
-<FileList
-  files={files}
-  selectedIds={selectedIds}
-  onFileClick={(file, event) => {}}
-  onFileDoubleClick={(file) => {}}
-  sort={{ field: 'name', direction: 'asc' }}
-  onSort={(field) => {
-    console.log('Sort by', field);
-  }}
-/>
-```
-
-Columns:
-- Name (always visible)
-- Size (hidden on mobile)
-- Modified date (hidden on mobile)
-- Kind (hidden on mobile)
-
-Click column headers to sort.
-
-#### FileRow
-
-Single row (used internally by FileList):
-
-```tsx
-import { FileRow } from '@spacedrive/explorer';
-
-<FileRow
-  file={file}
-  selected={selectedIds.has(file.id)}
-  onClick={() => {}}
-  onDoubleClick={() => {}}
-/>
-```
-
-### Inspector Components
-
-#### Inspector
-
-File metadata panel:
-
-```tsx
-import { Inspector } from '@spacedrive/explorer';
-
-<Inspector
-  file={file}
-  tags={tags}
-  onTagRemove={(tagId) => console.log('Remove tag', tagId)}
-/>
-```
-
-Displays:
-- File name
-- Tags (with remove buttons if `onTagRemove` provided)
-- File metadata (kind, size, dates, path)
-- Custom metadata from `file.metadata`
-
-#### InspectorPanel
-
-Collapsible section for inspector:
-
-```tsx
-import { InspectorPanel } from '@spacedrive/explorer';
-
-<InspectorPanel title="EXIF Data" defaultOpen={true}>
-  <dl>
-    <dt>Camera</dt>
-    <dd>iPhone 14 Pro</dd>
-    <dt>Aperture</dt>
-    <dd>f/1.78</dd>
-  </dl>
-</InspectorPanel>
-```
-
-### Interaction Components
-
-#### RenameInput
-
-Inline file rename:
-
-```tsx
-import { RenameInput } from '@spacedrive/explorer';
-
 <RenameInput
-  initialValue="old-filename.txt"
-  onRename={(newName) => console.log('Rename to', newName)}
-  onCancel={() => console.log('Cancelled')}
+  initialValue="document.pdf"
+  onRename={async (next) => save(next)}
+  onCancel={() => setEditing(false)}
 />
 ```
 
-Features:
-- Auto-focused and selected on mount
-- Enter to confirm
-- Escape to cancel
-- Validates extension preservation
+### TagPill
 
-#### DragOverlay
-
-Visual feedback during drag:
+Colored tag pill with optional remove button. Accepts a `color` + `children` API.
 
 ```tsx
-import { DragOverlay } from '@spacedrive/explorer';
+<TagPill color="#ef4444">Important</TagPill>
 
-<DragOverlay files={draggedFiles} />
+<TagPill color="#3b82f6" onRemove={() => removeTag(id)}>
+  Project X
+</TagPill>
 ```
 
-Shows:
-- Stack of thumbnails (up to 3)
-- Count badge (+N for more)
-- "X items" label
+## What lives in consuming apps
 
-#### QuickPreview
+The following Explorer pieces intentionally stay in `@sd/interface` or each app's codebase, not here:
 
-Spacebar preview modal:
+- `FileGrid` / `FileList` / `FileRow` — TanStack Virtual + Table, dnd-kit, context menus
+- `PathBar` — SdPath, device system, routing, animations
+- `Inspector` / `InspectorPanel` — polymorphic variants tied to data types
+- `KindIcon` — Rust-generated asset system
+- `FileThumb` (full variant) — sidecar system, caching, video scrubber
+- `QuickPreview` — standalone Tauri window
+- `DragOverlay` — integrated with DndProvider
 
-```tsx
-import { QuickPreview } from '@spacedrive/explorer';
-
-<QuickPreview
-  file={selectedFile}
-  isOpen={previewOpen}
-  onClose={() => setPreviewOpen(false)}
-  onNext={() => selectNextFile()}
-  onPrevious={() => selectPreviousFile()}
-/>
-```
-
-Supports:
-- Images (with zoom)
-- Video (native controls)
-- Audio (native controls)
-- Other files (placeholder)
-
-Keyboard shortcuts:
-- Escape: Close
-- Arrow keys: Navigate
-
-## Types
-
-All components export their prop types:
-
-```typescript
-import type {
-  FileKind,
-  FileInfo,
-  TagInfo,
-  ViewMode,
-  SortField,
-  SortDirection,
-  SortState,
-  SelectionState,
-} from '@spacedrive/explorer';
-```
-
-### FileKind
-
-```typescript
-type FileKind = 
-  | 'document'
-  | 'image'
-  | 'video'
-  | 'audio'
-  | 'archive'
-  | 'executable'
-  | 'code'
-  | 'unknown';
-```
-
-### FileInfo
-
-```typescript
-interface FileInfo {
-  id: string;
-  name: string;
-  path: string;
-  kind: FileKind;
-  size: number;
-  modifiedAt: Date;
-  createdAt: Date;
-  thumbnailUrl?: string;
-  isDirectory: boolean;
-  extension?: string;
-  tags?: string[];
-  metadata?: Record<string, unknown>;
-}
-```
-
-### TagInfo
-
-```typescript
-interface TagInfo {
-  id: string;
-  name: string;
-  color: string;
-}
-```
+See [`../../docs/COMPONENT-AUDIT.md`](../../docs/COMPONENT-AUDIT.md) for the full breakdown.
 
 ## Design Principles
 
-1. **Data via props** - Components don't fetch data
-2. **Platform-agnostic** - React DOM only, no platform APIs
-3. **Virtual-scroll ready** - Works with `@tanstack/react-virtual`
-4. **Thumbnail contract** - URL or kind identifier
-5. **Callback-driven** - Events via props, not internal state
+1. **Data via props** — Components don't fetch data
+2. **Platform-agnostic** — React DOM only, no platform APIs
+3. **Callback-driven** — Events via props, not internal state
+4. **Small surface** — We export the pieces apps can genuinely share, and resist the urge to re-platform the whole explorer here
 
 ## Browser Support
 
 - Chrome/Edge 88+
 - Firefox 78+
 - Safari 14+
-
-Requires:
-- CSS Grid
-- CSS Custom Properties
-- Intersection Observer (for virtual scrolling)
 
 ## License
 

--- a/spaceui/packages/forms/CHANGELOG.md
+++ b/spaceui/packages/forms/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @spacedrive/forms
 
+> Changelog entries between 0.1.1 and the current `package.json` version were not authored via changesets; see `git log packages/forms` for the detail. The 0.1.0 "Packages Included" bullet list below predates the addition of `@spacedrive/icons` — spaceui now ships 6 packages: tokens, primitives, forms, icons, ai, explorer.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/spaceui/packages/icons/CHANGELOG.md
+++ b/spaceui/packages/icons/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @spacedrive/icons
 
+> This package was added after the 0.1.0 initial release documented in the other packages' CHANGELOGs. It ships Spacedrive file-type icons, extension badges, and icon resolution utilities (SVG assets + a `getIcon` resolver). No React components — consumers render the SVGs themselves. Changelog entries between 0.0.2 and the current `package.json` version were not authored via changesets; see `git log packages/icons` for the detail.
+
 ## 0.0.2
 
 ### Patch Changes

--- a/spaceui/packages/primitives/CHANGELOG.md
+++ b/spaceui/packages/primitives/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @spacedrive/primitives
 
+> Changelog entries between 0.1.1 and the current `package.json` version were not authored via changesets; see `git log packages/primitives` for the detail. The 0.1.0 "Packages Included" bullet list below predates the addition of `@spacedrive/icons` — spaceui now ships 6 packages: tokens, primitives, forms, icons, ai, explorer.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/spaceui/packages/primitives/README.md
+++ b/spaceui/packages/primitives/README.md
@@ -17,15 +17,17 @@ Peer dependencies:
 
 ## Setup
 
-1. **Configure your CSS entrypoint**
+1. **Configure your CSS entrypoint (Tailwind v4)**
    ```css
-   @import '@spacedrive/tokens/theme';
+   @import "tailwindcss";
+   @import "@spacedrive/tokens/theme";
+   @import "@spacedrive/tokens/css";
+
+   /* Tell Tailwind to scan primitives for classes */
+   @source "../../node_modules/@spacedrive/primitives/src";
    ```
 
-2. **Import CSS**
-   ```css
-   @import '@spacedrive/tokens/css';
-   ```
+   See [`../../INTEGRATION.md`](../../INTEGRATION.md) for the full consumer-side setup, including Vite aliases for local development.
 
 ## Usage
 
@@ -51,6 +53,7 @@ function MyComponent() {
 
 ### Interactive
 - **Button** - Multiple variants (default, subtle, outline, dotted, gray, accent, colored, bare)
+- **CircleButton**, **CircleButtonGroup** - Icon-only circular buttons
 - **Input** - Form input with error states
 - **Checkbox** - Accessible checkbox with Radix
 - **Switch** - Toggle switch with 3 sizes
@@ -65,34 +68,42 @@ function MyComponent() {
 - **ContextMenu** - Right-click menus
 
 ### Navigation
-- **Tabs** - Tabbed interfaces
-- **Select** - Dropdown selects
+- **Tabs**, **TabBar** - Tabbed interfaces
+- **Select**, **SelectPill**, **SelectTriggerButton** - Dropdown selects
 - **Dropdown** - Simple expanding dropdowns
 
 ### Display
 - **Badge** - Status badges (6 variants, 2 sizes)
 - **Card** - Container with header/content/footer
-- **Banner** - Alert banners (5 variants)
+- **Banner**, **InfoBanner** - Alert banners
 - **Toast** - Notification toasts
 - **Loader** - Loading spinners and dots
 - **Divider** - Horizontal/vertical dividers
 - **Typography** - Text components (6 heading, 3 body)
-- **Shortcut** - Keyboard shortcut display
+- **Shortcut** - Keyboard shortcut display (uses `keys.ts` for key constants)
 
 ### Form
 - **NumberStepper** - Increment/decrement with min/max
 - **FilterButton** - Toggle buttons for filters
 - **ToggleGroup** - Radio-like button groups
 - **SearchBar** - Search inputs with icons
+- **OptionList** - List of selectable options
+- **SpaceItem** - Named item with optional selection
 
 ### Progress
 - **ProgressBar** - Linear progress (with variants)
 - **CircularProgress** - Circular/spinner progress
 
 ### Layout
+- **Layout** - Application layout primitives
 - **Resizable** - Resizable panel groups
 - **Collapsible** - Expand/collapse sections
-- **TopBarButton** - Top bar navigation buttons
+
+### Decorative
+- **ShinyButton**, **ShinyToggle** - Animated accent buttons
+
+### Forms (sub-export)
+The `forms/` subfolder re-exports field primitives consumed by `@spacedrive/forms`. Prefer importing from `@spacedrive/forms` directly for form usage.
 
 ## Component API
 

--- a/spaceui/packages/tokens/CHANGELOG.md
+++ b/spaceui/packages/tokens/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @spacedrive/tokens
 
+> Changelog entries between 0.1.1 and the current `package.json` version were not authored via changesets; see `git log packages/tokens` for the detail. The 0.1.0 "Packages Included" bullet list below predates the addition of `@spacedrive/icons` — spaceui now ships 6 packages: tokens, primitives, forms, icons, ai, explorer.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/spaceui/packages/tokens/README.md
+++ b/spaceui/packages/tokens/README.md
@@ -1,7 +1,6 @@
 # @spacedrive/tokens
 
-Design tokens for SpaceUI.
-This package is CSS-first for Tailwind v4, with optional raw color exports for programmatic consumers.
+Design tokens for SpaceUI. CSS-first for Tailwind v4, with optional raw color exports for programmatic consumers.
 
 ## Installation
 
@@ -13,18 +12,26 @@ npm install @spacedrive/tokens
 
 ## Usage
 
-### Theme Entry Layer
+### Theme Entry Layer (Tailwind v4)
 
 ```css
-/* In your global CSS entrypoint */
-@import '@spacedrive/tokens/theme';
-```
+@import "tailwindcss";
 
-### CSS Import
+/* @theme block — generates all bg-*, text-*, border-*, ring-* utilities */
+@import "@spacedrive/tokens/theme";
 
-```css
-/* In your base CSS file */
-@import '@spacedrive/tokens/css';
+/* Base layer + default (dark) theme variables */
+@import "@spacedrive/tokens/css";
+
+/* Optional additional themes (opt in as needed) */
+@import "@spacedrive/tokens/css/themes/light";
+@import "@spacedrive/tokens/css/themes/midnight";
+@import "@spacedrive/tokens/css/themes/noir";
+@import "@spacedrive/tokens/css/themes/slate";
+@import "@spacedrive/tokens/css/themes/nord";
+@import "@spacedrive/tokens/css/themes/mocha";
+
+@custom-variant dark (&:where(.dark, .dark *));
 ```
 
 ### Programmatic Access
@@ -32,9 +39,9 @@ npm install @spacedrive/tokens
 ```typescript
 import colors from '@spacedrive/tokens/raw-colors';
 
-// Access color values
-console.log(colors.accent.DEFAULT); // "200, 100%, 60%"
-console.log(colors.ink.dull);       // "0, 0%, 70%"
+// Access color values (returned as complete CSS color strings)
+console.log(colors.accent.DEFAULT); // "hsl(208, 100%, 57%)"
+console.log(colors.ink.dull);       // "hsl(235, 10%, 70%)"
 ```
 
 ## Color System
@@ -43,12 +50,12 @@ console.log(colors.ink.dull);       // "0, 0%, 70%"
 
 All colors use semantic names rather than literal colors:
 
-- **accent** - Primary brand color (blue in dark mode)
-- **ink** - Text colors (white → gray scale)
+- **accent** - Primary brand color
+- **ink** - Text colors (foreground)
 - **app** - App backgrounds and surfaces
 - **sidebar** - Sidebar-specific colors
 - **menu** - Dropdown/menu colors
-- **status** - Success, warning, error states
+- **status** - Success, warning, error, info states
 
 ### Color Variants
 
@@ -60,34 +67,33 @@ Each color has variants:
 
 Example:
 ```css
-/* Accent colors */
-accent           /* Primary blue */
-accent-faint     /* Light blue */
-accent-deep      /* Dark blue */
+accent           /* Primary accent */
+accent-faint     /* Lighter */
+accent-deep      /* Darker */
 
-/* Text colors */
-ink              /* Primary text (white in dark) */
+ink              /* Primary text */
 ink-dull         /* Secondary text */
 ink-faint        /* Tertiary text */
 ```
 
 ### CSS Custom Properties
 
-Colors are exposed as CSS custom properties:
+Under Tailwind v4, the `@theme` block defines tokens as full CSS color values:
 
 ```css
---color-accent: 200, 100%, 60%;
---color-accent-faint: 200, 100%, 90%;
---color-ink: 0, 0%, 100%;
---color-ink-dull: 0, 0%, 70%;
-/* etc. */
+@theme {
+  --color-accent: hsl(208, 100%, 57%);
+  --color-ink: hsl(235, 35%, 92%);
+  --color-app: hsl(235, 15%, 13%);
+  /* ... */
+}
 ```
 
-**Note:** Values are bare HSL numbers (not wrapped in `hsl()`) for Tailwind alpha support.
+Opacity modifiers still work: `bg-accent/50`, `border-ink/20`, etc. — Tailwind v4 derives them automatically from `@theme` colors.
 
 ## Tailwind Classes
 
-With the preset installed, use semantic classes directly:
+With `@import "@spacedrive/tokens/theme"` in your CSS, use semantic classes directly:
 
 ```tsx
 <div className="bg-app text-ink">
@@ -102,62 +108,48 @@ With the preset installed, use semantic classes directly:
 
 ### Opacity Modifiers
 
-Works with Tailwind's opacity syntax:
-
 ```tsx
 <div className="bg-accent/10">    {/* 10% opacity */}
-<div className="bg-sidebar/65">    {/* 65% opacity */}
+<div className="bg-sidebar/65">   {/* 65% opacity */}
 ```
 
 ## Themes
 
-### Dark Theme (Default)
-
-```css
-@import '@spacedrive/tokens/css/themes/dark';
-```
-
-### Light Theme
-
-```css
-@import '@spacedrive/tokens/css/themes/light';
-```
-
-Or toggle via class:
+Themes override the base `--color-*` variables via CSS classes. The default theme is `dark` (loaded by `@spacedrive/tokens/css`). Opt in to any additional theme by importing it and toggling the class on `<html>` or any ancestor element.
 
 ```html
-<html class="dark">
-  <!-- Dark mode -->
-</html>
-
-<html class="light">
-  <!-- Light mode -->
+<html class="midnight-theme">
+  <!-- all --color-* vars overridden to midnight values -->
 </html>
 ```
 
-## API
+Available themes: `dark` (default), `light`, `midnight`, `noir`, `slate`, `nord`, `mocha`.
 
-### `raw-colors`
+## Consumer Pattern Summary
 
-An object containing all color definitions:
+```css
+@import "tailwindcss";
+@import "@spacedrive/tokens/theme";         /* @theme block — generates utilities */
+@import "@spacedrive/tokens/css";           /* base + default theme */
+@import "@spacedrive/tokens/css/themes/midnight";  /* optional override */
 
-```typescript
-{
-  accent: { DEFAULT: string, faint: string, deep: string },
-  ink: { DEFAULT: string, dull: string, faint: string },
-  app: { DEFAULT: string, box: string, line: string, hover: string, selected: string },
-  sidebar: { DEFAULT: string, box: string, line: string, ink: string, inkDull: string, ... },
-  menu: { DEFAULT: string, line: string, hover: string, ink: string },
-  status: { success: string, warning: string, error: string, info: string }
-}
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* Tell Tailwind to scan your SpaceUI packages */
+@source "../node_modules/@spacedrive/primitives/src";
+@source "../node_modules/@spacedrive/ai/src";
+@source "../node_modules/@spacedrive/forms/src";
+@source "../node_modules/@spacedrive/explorer/src";
 ```
+
+No `tailwind.config.js`. No JS preset. No build step for tokens.
 
 ## Design Principles
 
-1. **Semantic naming** - Use purpose-based names, not literal colors
-2. **Theme-agnostic** - Components work in both dark and light modes
-3. **HSL format** - Bare HSL values for Tailwind alpha support
-4. **Consistent scale** - Predictable variants (faint, dull, deep)
+1. **CSS-first** — Tokens live in CSS. No JS build, no preset file.
+2. **Semantic naming** — `ink`, `app-box`, `sidebar-selected`, not `gray-900`.
+3. **Theme-agnostic** — Components use semantic classes; themes remap the variables.
+4. **Native Tailwind v4 integration** — `@theme` drives utility generation; opacity modifiers work automatically.
 
 ## License
 


### PR DESCRIPTION
## Summary

Reconcile documentation with actual workspace state after the April 2026 SpaceUI dependency wave (TypeScript 6, HeadlessUI 2, Storybook 10, Vite 8, react-spring 10) and PR #45 (Tailwind v4 canonical class syntax).

## Key drift fixed

| Surface | What was wrong | What changed |
|---|---|---|
| `spaceui/README.md` | Said "5 packages", listed 12 explorer components that don't exist here, 18 AI components | 6 packages, actual counts, icons pkg listed, explorer trimmed to the 4 that survived |
| `spaceui/docs/REPO_SUMMARY.md` | 5 pkgs, TS 5.4+, pre-Tailwind-v4, missing icons | 6 pkgs, TS 6, Storybook 10, CSS-first Tailwind, all versions reflected |
| `spaceui/docs/SHARED-UI-STRATEGY.md` | `icons/` missing from structure diagram, tokens structure pre-v4 | icons added, tokens structure rewritten for CSS-first v4 |
| `spaceui/docs/TAILWIND-V4-MIGRATION.md` | Reads as pre-migration spec | Status header added — spaceui complete per PR #45 |
| `spaceui/docs/COMPONENT-AUDIT.md` | Snapshot read as current | Freshness note added |
| `spaceui/packages/explorer/README.md` | Documented 10+ removed components (FileGrid, FileList, Inspector, PathBar, QuickPreview, etc.) | Rewritten — only FileThumb, GridItem, RenameInput, TagPill |
| `spaceui/packages/primitives/README.md` | Missing Tailwind v4 `@source` directive, stale component list | v4 `@source` shown, full 41-component list reflected |
| `spaceui/packages/tokens/README.md` | Claimed bare HSL triplets for Tailwind alpha | Rewritten for v4 — `hsl()` values in `@theme`, 7 themes listed, no preset/build |
| `spaceui/CONTRIBUTING.md` | TS default, no v4 class syntax guidance | TS6, canonical v4 syntax rules (`class!`, `data-X:`, `z-N`, `*-(--X)`) |
| All 5 package CHANGELOGs | 0.1.1 tail with stale \"Packages Included\" | Top-of-file note flagging undocumented 0.1.1→0.2.3 history + icons context |
| `interface/PLAN.md` | Documented v3 Tailwind, pre-SpaceUI migration state as current plan | Marked historical (Phases 1–3 complete) |
| `interface/DRY_VIOLATIONS.md` | No date, pre-SpaceUI patterns presented as live | Caveat about pre-migration state added |

## Not touched

- `spaceui/.changeset/README.md` — boilerplate from changesets CLI, no value in editing
- `spaceui/packages/ai/README.md` / `ai/CHANGELOG.md` — not in the audit scope you listed

## Ground truth verified

- `spaceui/packages/`: tokens, primitives, forms, icons, ai, explorer (6)
- All packages at `0.2.3`
- Source file counts: primitives=41, ai=12, forms=7, explorer=3 components + icons=0 (SVG resource)
- 7 themes: dark (default), light, midnight, noir, slate, nord, mocha

## Test plan

- [x] `git diff --stat` shows docs-only changes (16 files, +271/-576)
- [x] No Rust source touched — `cargo fmt` unnecessary
- [x] All internal doc cross-links resolve (`./docs/SHARED-UI-STRATEGY.md`, `./docs/TAILWIND-V4-MIGRATION.md`, `./docs/COMPONENT-AUDIT.md`, `./INTEGRATION.md`)
- [x] Code-review graph rebuilt against PR #45 base

🤖 Generated with [Claude Code](https://claude.com/claude-code)