### PR TITLE
docs: reconcile root-level reference docs + freeze SPACEUI_MIGRATION header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ ProcessEvent           — tagged enum for inter-process events
 Channel (struct)       — owns history, spawns branches, routes to workers
 WorkerState            — state machine: Running, WaitingForInput, Done, Failed
 Memory                 — content + type + importance + timestamps + source + associations
-MemoryType             — enum: Fact, Preference, Decision, Identity, Event, Observation
+MemoryType             — enum: Fact, Preference, Decision, Identity, Event, Observation, Goal, Todo
 ChannelId              — Arc<str> type alias
 AgentDeps              — dependency bundle (memory_store, llm_manager, tool_server, event_tx)
 LlmManager             — holds provider clients, routes by model name
@@ -268,7 +268,7 @@ Actual queries live in the modules that use them — `memory/store.rs` has graph
 
 Memories are structured objects, not files. Every memory is a row in SQLite with typed metadata and graph connections, paired with a vector embedding in LanceDB.
 
-**Types:** Fact, Preference, Decision, Identity, Event, Observation.
+**Types:** Fact, Preference, Decision, Identity, Event, Observation, Goal, Todo.
 
 **Graph edges:** RelatedTo, Updates, Contradicts, CausedBy, PartOf. Auto-associated on creation via similarity search. >0.9 similarity marks as `Updates`.
 

--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -32,7 +32,7 @@ spacebot/
 │   └── package.json               - React 19, Tailwind 4, React Router
 ├── docs/                           (40 .mdx files, Fumadocs + Next.js)
 ├── desktop/                        (Tauri 2 app)
-├── migrations/                     (47 SQL migrations)
+├── migrations/                     (42 SQL migrations, 2026-02 → 2026-04)
 ├── presets/                        (9 agent persona presets)
 ├── prompts/                        (86 Jinja2 system prompt templates)
 ├── scripts/                        (7 shell scripts)
@@ -193,14 +193,21 @@ Seven rule files that govern agent behavior across Rust edits, messaging parity,
 
 ---
 
-## Active OpenSpec Changes
+## OpenSpec Changes
 
 Under `openspec/changes/` — structured change proposals with specs + phased tasks.
 
-| Change | Purpose |
+No active changes at present. Recently archived:
+
+| Archived change | Summary |
 |---|---|
-| **security-remediation** | Security hardening workstream |
-| **archive** | Completed change history (includes `2026-04-16-integrate-spacedrive`) |
+| `2026-04-16-security-remediation-obsolete` | Security remediation workstream (superseded / complete) |
+| `2026-04-16-spacebot-dependency-remediation` | Dependency advisory remediation |
+| `2026-04-16-integrate-spacedrive` | Vendor Spacedrive into `spacedrive/` in preparation for HTTP integration |
+| `2026-04-15-integrate-spaceui` | Adopt SpaceUI (`spaceui/`) as the frontend design system |
+| `2026-04-15-fix-rustls-webpki-audit` | Serenity `next` branch pin to resolve rustls-webpki advisories |
+| `2026-04-15-upgrade-dependencies` | Workspace-level dependency wave |
+| `2026-04-15-dependency-upgrades` | Frontend dependency wave (TypeScript 6, HeadlessUI 2, Vite 8, Storybook 10) |
 
 ---
 

--- a/RUST_STYLE_GUIDE.md
+++ b/RUST_STYLE_GUIDE.md
@@ -53,9 +53,9 @@ Enforce these clippy lints in `Cargo.toml`:
 
 ```toml
 [lints.clippy]
-dbg_macro = "forbid"
-todo = "forbid"
-unimplemented = "forbid"
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
 ```
 
 `dbg!` and `todo!`/`unimplemented!` should never ship. Use `tracing::debug!` for debug output. Use `// TODO:` comments for tracked future work instead of `todo!()` panics.

--- a/SPACEUI_MIGRATION.md
+++ b/SPACEUI_MIGRATION.md
@@ -1,8 +1,10 @@
 # SpaceUI Migration
 
-**345 files changed | +39,873 / -17,225**
+**345 files changed | +39,873 / -17,225** (original migration totals)
 
-Migrates the entire frontend to [SpaceUI](https://github.com/spacedriveapp/spaceui), Spacedrive's component library. The local UI primitives (~25 components, ~3000 lines) are gone — replaced by `@spacedrive/primitives`, `@spacedrive/ai`, `@spacedrive/forms`, and `@spacedrive/explorer`. Tailwind v3 is out, Tailwind v4 via `@tailwindcss/vite` is in, with SpaceUI's design token system and theme imports.
+> **Document status:** Frozen historical record of the original frontend migration onto SpaceUI, ending at commit `248d740`. Later work (the April 2026 dependency wave — Vite 8, Storybook 10, HeadlessUI 2, TypeScript 6, react-spring 10, react-markdown 10, graphology 0.26 — plus the Tailwind v4 canonical class syntax cleanup in PR #45 and the documentation drift sync in PR #46) lives in `git log` and the GitHub PR history rather than here. The commit-SHA references in the log below are from the pre-rebase history and may not exist in the current tree.
+
+Migrates the entire frontend to [SpaceUI](https://github.com/spacedriveapp/spaceui), Spacedrive's component library. The local UI primitives (~25 components, ~3000 lines) are gone — replaced by the six `@spacedrive/*` packages: `tokens`, `primitives`, `forms`, `icons`, `ai`, and `explorer`. Tailwind v3 is out, Tailwind v4 via `@tailwindcss/vite` is in, with SpaceUI's design-token system and theme imports.
 
 But this isn't just a component swap. The interface has been restructured from the ground up.
 


### PR DESCRIPTION
## Summary

Follow-up to PR #46 (which fixed SpaceUI package/component drift). This PR cleans the remaining drift in the **root-level** documentation surfaces.

## Changes across 4 files

### `SPACEUI_MIGRATION.md`
- Top-matter "Document status" note added — marks this as a frozen record of the original migration ending at commit `248d740` (which no longer exists in the current tree after rebases). Later work (April 2026 dep wave, PR #45 Tailwind v4 canonical syntax, PR #46 docs drift sync) lives in git/PR history.
- Opening paragraph: package list was missing `@spacedrive/tokens` and `@spacedrive/icons`. Now reflects the six shipping packages.

### `RUST_STYLE_GUIDE.md`
- Clippy lint severity shown as `"forbid"`; **actual `Cargo.toml` uses `"deny"`** for `dbg_macro`, `todo`, `unimplemented`. Corrected to match.

### `AGENTS.md`
- `MemoryType` enum listed 6 variants (Fact, Preference, Decision, Identity, Event, Observation) in two places. Code actually has **8** — `Goal` and `Todo` were added. `README.md` already said "Eight memory types"; the implementation guide was lagging.

### `PROJECT_INDEX.md`
- Migration count `47` → `42` (actual `ls migrations/`).
- "Active OpenSpec Changes" section rewritten. There are **no active changes**; `openspec/changes/` only contains `archive/`. Surfaced the seven recently-archived records worth knowing about.

## Audited clean (no changes needed)

| File | Verified |
|---|---|
| `README.md` | Rig v0.35 correct, 8 memory types, tech stack accurate |
| `METRICS.md` | All `src/` file references resolve |
| `CONTRIBUTING.md` | 7 themes listed, SpaceUI packages correctly scoped |
| `CHANGELOG.md` | Attribution note accurate; ends at v0.4.1, matches Cargo.toml |

## Test plan

- [x] `git diff --stat` shows 4 files, docs-only (+21/-12)
- [x] No Rust source touched
- [x] Each claim verified against code: `grep MemoryType src/memory/types.rs`, `grep lints.clippy Cargo.toml`, `ls migrations/ \| wc -l`, `ls openspec/changes/`
- [x] Builds on PR #46 (merged), continues the session-sync discipline

🤖 Generated with [Claude Code](https://claude.com/claude-code)