### PR TITLE
feat(spaceui): LoadingDot primitive + color-token consolidation + storybook typecheck

### DIFF
--- a/interface/src/components/MemoryGraph.tsx
+++ b/interface/src/components/MemoryGraph.tsx
@@ -13,7 +13,7 @@ import {
 	type RelationType,
 } from "@/api/client";
 import {formatTimeAgo} from "@/lib/format";
-import {Button, CircleButton} from "@spacedrive/primitives";
+import {Button, CircleButton, LoadingDot} from "@spacedrive/primitives";
 import {
 	Crosshair,
 	Plus,
@@ -517,10 +517,7 @@ export function MemoryGraph({agentId, sort, typeFilter}: MemoryGraphProps) {
 			{/* Loading / error / empty states */}
 			{isLoading && (
 				<div className="absolute inset-0 flex items-center justify-center bg-app/80">
-					<div className="flex items-center gap-2 text-ink-dull">
-						<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-						Loading graph...
-					</div>
+					<LoadingDot>Loading graph...</LoadingDot>
 				</div>
 			)}
 			{error && (

--- a/interface/src/components/OpenCodeEmbed.tsx
+++ b/interface/src/components/OpenCodeEmbed.tsx
@@ -1,4 +1,5 @@
 import {useState, useEffect, useRef} from "react";
+import {LoadingDot} from "@spacedrive/primitives";
 
 /** RFC 4648 base64url encoding (no padding), matching OpenCode's directory encoding. */
 export function base64UrlEncode(value: string): string {
@@ -375,10 +376,9 @@ export function OpenCodeEmbed({
 			/>
 			{state === "loading" && (
 				<div className="absolute inset-0 flex items-center justify-center bg-app-dark-box/80">
-					<div className="flex items-center gap-2 text-xs text-ink-faint">
-						<span className="h-2 w-2 animate-pulse rounded-full bg-accent" />
+					<LoadingDot className="text-xs text-ink-faint">
 						Loading OpenCode...
-					</div>
+					</LoadingDot>
 				</div>
 			)}
 			{state === "error" && (

--- a/interface/src/components/org/OrgGraphInner.tsx
+++ b/interface/src/components/org/OrgGraphInner.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {MagnifyingGlassMinus, MagnifyingGlassPlus, CornersOut} from "@phosphor-icons/react";
-import {CircleButton} from "@spacedrive/primitives";
+import {CircleButton, LoadingDot} from "@spacedrive/primitives";
 import {
 	ReactFlow,
 	Background,
@@ -561,10 +561,7 @@ export function OrgGraphInner({activeEdges, agents}: OrgGraphInnerProps) {
 	if (isLoading) {
 		return (
 			<div className="flex h-full items-center justify-center">
-				<div className="flex items-center gap-2 text-ink-dull">
-					<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-					Loading topology...
-				</div>
+				<LoadingDot>Loading topology...</LoadingDot>
 			</div>
 		);
 	}

--- a/interface/src/components/settings/ApiKeysSection.tsx
+++ b/interface/src/components/settings/ApiKeysSection.tsx
@@ -10,6 +10,7 @@ import {
 	DialogTitle,
 	DialogDescription,
 	DialogFooter,
+	LoadingDot,
 } from "@spacedrive/primitives";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faSearch} from "@fortawesome/free-solid-svg-icons";
@@ -61,10 +62,7 @@ export function ApiKeysSection({settings, isLoading}: GlobalSettingsSectionProps
 			</div>
 
 			{isLoading ? (
-				<div className="flex items-center gap-2 text-ink-dull">
-					<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-					Loading settings...
-				</div>
+				<LoadingDot>Loading settings...</LoadingDot>
 			) : (
 				<div className="flex flex-col gap-3">
 					<div className="rounded-lg border border-app-line bg-app-box p-4">

--- a/interface/src/components/settings/ChangelogSection.tsx
+++ b/interface/src/components/settings/ChangelogSection.tsx
@@ -1,4 +1,5 @@
 import {useQuery} from "@tanstack/react-query";
+import {LoadingDot} from "@spacedrive/primitives";
 import {api} from "@/api/client";
 import {Markdown} from "@/components/Markdown";
 import type {ChangelogRelease} from "./types";
@@ -48,10 +49,7 @@ export function ChangelogSection() {
 			</div>
 
 			{isLoading ? (
-				<div className="flex items-center gap-2 text-ink-dull">
-					<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-					Loading changelog...
-				</div>
+				<LoadingDot>Loading changelog...</LoadingDot>
 			) : releases.length > 0 ? (
 				<div className="flex flex-col gap-4">
 					{releases.map((release) => (

--- a/interface/src/components/settings/ChannelsSection.tsx
+++ b/interface/src/components/settings/ChannelsSection.tsx
@@ -1,5 +1,6 @@
 import {useState} from "react";
 import {useQuery} from "@tanstack/react-query";
+import {LoadingDot} from "@spacedrive/primitives";
 import {api} from "@/api/client";
 import {
 	PlatformCatalog,
@@ -45,10 +46,7 @@ export function ChannelsSection() {
 			</div>
 
 			{isLoading ? (
-				<div className="flex items-center gap-2 text-ink-dull">
-					<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-					Loading channels...
-				</div>
+				<LoadingDot>Loading channels...</LoadingDot>
 			) : (
 				<div className="grid grid-cols-[200px_1fr] gap-6">
 					{/* Left column: Platform catalog */}

--- a/interface/src/components/settings/ChatGptOAuthDialog.tsx
+++ b/interface/src/components/settings/ChatGptOAuthDialog.tsx
@@ -6,6 +6,7 @@ import {
 	DialogTitle,
 	DialogDescription,
 	DialogFooter,
+	LoadingDot,
 } from "@spacedrive/primitives";
 import {ProviderIcon} from "@/lib/providerIcons";
 import type {ChatGptOAuthDialogProps} from "./types";
@@ -60,10 +61,7 @@ export function ChatGptOAuthDialog({
 							{message.text}
 						</div>
 					) : isRequesting && !deviceCodeInfo ? (
-						<div className="flex items-center gap-2 text-sm text-ink-dull">
-							<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-							Requesting device code...
-						</div>
+						<LoadingDot className="text-sm">Requesting device code...</LoadingDot>
 					) : deviceCodeInfo ? (
 						<div className="space-y-4">
 							<div className="rounded-md border border-app-line p-3">
@@ -111,10 +109,9 @@ export function ChatGptOAuthDialog({
 							</div>
 
 							{isPolling && !message && (
-								<div className="flex items-center gap-2 text-sm text-ink-faint">
-									<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
+								<LoadingDot className="text-sm text-ink-faint">
 									Waiting for sign-in confirmation...
-								</div>
+								</LoadingDot>
 							)}
 
 							{message && (

--- a/interface/src/components/settings/ConfigFileSection.tsx
+++ b/interface/src/components/settings/ConfigFileSection.tsx
@@ -1,7 +1,7 @@
 import {useState, useEffect, useRef} from "react";
 import {useQuery, useMutation, useQueryClient} from "@tanstack/react-query";
 import {api} from "@/api/client";
-import {Button} from "@spacedrive/primitives";
+import {Button, LoadingDot} from "@spacedrive/primitives";
 import {parse as parseToml} from "smol-toml";
 
 export function ConfigFileSection() {
@@ -209,10 +209,7 @@ export function ConfigFileSection() {
 			{/* Editor */}
 			<div className="flex-1 overflow-hidden">
 				{isLoading ? (
-					<div className="flex items-center gap-2 p-6 text-ink-dull">
-						<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-						Loading config...
-					</div>
+					<LoadingDot className="p-6">Loading config...</LoadingDot>
 				) : (
 					<div ref={editorRef} className="h-full" />
 				)}

--- a/interface/src/components/settings/InstanceSection.tsx
+++ b/interface/src/components/settings/InstanceSection.tsx
@@ -1,7 +1,7 @@
 import {useState, useEffect} from "react";
 import {useMutation, useQueryClient} from "@tanstack/react-query";
 import {api} from "@/api/client";
-import {Button, Input} from "@spacedrive/primitives";
+import {Button, Input, LoadingDot} from "@spacedrive/primitives";
 import type {GlobalSettingsSectionProps} from "./types";
 
 export function InstanceSection({settings, isLoading}: GlobalSettingsSectionProps) {
@@ -51,10 +51,7 @@ export function InstanceSection({settings, isLoading}: GlobalSettingsSectionProp
 			</div>
 
 			{isLoading ? (
-				<div className="flex items-center gap-2 text-ink-dull">
-					<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-					Loading settings...
-				</div>
+				<LoadingDot>Loading settings...</LoadingDot>
 			) : (
 				<div className="flex flex-col gap-4">
 					<div className="rounded-lg border border-app-line bg-app-box p-4">

--- a/interface/src/components/settings/OpenCodeSection.tsx
+++ b/interface/src/components/settings/OpenCodeSection.tsx
@@ -4,6 +4,7 @@ import {api} from "@/api/client";
 import {
 	Button,
 	Input,
+	LoadingDot,
 	SelectRoot,
 	SelectTrigger,
 	SelectValue,
@@ -128,10 +129,7 @@ export function OpenCodeSection({settings, isLoading}: GlobalSettingsSectionProp
 			</div>
 
 			{isLoading ? (
-				<div className="flex items-center gap-2 text-ink-dull">
-					<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-					Loading settings...
-				</div>
+				<LoadingDot>Loading settings...</LoadingDot>
 			) : (
 				<div className="flex flex-col gap-4">
 					{/* Enable toggle */}

--- a/interface/src/components/settings/SecretsSection.tsx
+++ b/interface/src/components/settings/SecretsSection.tsx
@@ -16,6 +16,7 @@ import {
 	DialogTitle,
 	DialogDescription,
 	DialogFooter,
+	LoadingDot,
 	SelectRoot,
 	SelectTrigger,
 	SelectValue,
@@ -391,10 +392,7 @@ export function SecretsSection() {
 
 			{/* Secret list */}
 			{isLoading ? (
-				<div className="flex items-center gap-2 text-ink-dull">
-					<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-					Loading secrets...
-				</div>
+				<LoadingDot>Loading secrets...</LoadingDot>
 			) : filteredSecrets.length === 0 ? (
 				<div className="flex flex-col items-center rounded-lg border border-dashed border-app-line py-12">
 					<p className="text-sm font-medium text-ink-dull">

--- a/interface/src/components/settings/ServerSection.tsx
+++ b/interface/src/components/settings/ServerSection.tsx
@@ -1,7 +1,7 @@
 import {useState, useEffect} from "react";
 import {useMutation, useQueryClient} from "@tanstack/react-query";
 import {api} from "@/api/client";
-import {Button, Input, Switch} from "@spacedrive/primitives";
+import {Button, Input, LoadingDot, Switch} from "@spacedrive/primitives";
 import type {GlobalSettingsSectionProps} from "./types";
 
 export function ServerSection({settings, isLoading}: GlobalSettingsSectionProps) {
@@ -72,10 +72,7 @@ export function ServerSection({settings, isLoading}: GlobalSettingsSectionProps)
 			</div>
 
 			{isLoading ? (
-				<div className="flex items-center gap-2 text-ink-dull">
-					<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-					Loading settings...
-				</div>
+				<LoadingDot>Loading settings...</LoadingDot>
 			) : (
 				<div className="flex flex-col gap-4">
 					<div className="rounded-lg border border-app-line bg-app-box p-4">

--- a/interface/src/components/settings/UpdatesSection.tsx
+++ b/interface/src/components/settings/UpdatesSection.tsx
@@ -1,7 +1,7 @@
 import {useState} from "react";
 import {useQuery, useMutation, useQueryClient} from "@tanstack/react-query";
 import {api, type UpdateStatus} from "@/api/client";
-import {Button} from "@spacedrive/primitives";
+import {Button, LoadingDot} from "@spacedrive/primitives";
 
 function formatCheckedAt(checkedAt: string | null): string {
 	if (!checkedAt) return "Never";
@@ -139,10 +139,7 @@ export function UpdatesSection() {
 			</div>
 
 			{isLoading ? (
-				<div className="flex items-center gap-2 text-ink-dull">
-					<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-					Loading update status...
-				</div>
+				<LoadingDot>Loading update status...</LoadingDot>
 			) : (
 				<div className="flex flex-col gap-4">
 					<div className="rounded-lg border border-app-line bg-app-box p-4">

--- a/interface/src/components/settings/WorkerLogsSection.tsx
+++ b/interface/src/components/settings/WorkerLogsSection.tsx
@@ -1,7 +1,7 @@
 import {useState, useEffect} from "react";
 import {useMutation, useQueryClient} from "@tanstack/react-query";
 import {api} from "@/api/client";
-import {Button} from "@spacedrive/primitives";
+import {Button, LoadingDot} from "@spacedrive/primitives";
 import type {GlobalSettingsSectionProps} from "./types";
 
 export function WorkerLogsSection({settings, isLoading}: GlobalSettingsSectionProps) {
@@ -70,10 +70,7 @@ export function WorkerLogsSection({settings, isLoading}: GlobalSettingsSectionPr
 			</div>
 
 			{isLoading ? (
-				<div className="flex items-center gap-2 text-ink-dull">
-					<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-					Loading settings...
-				</div>
+				<LoadingDot>Loading settings...</LoadingDot>
 			) : (
 				<div className="flex flex-col gap-4">
 					<div className="flex flex-col gap-3">

--- a/interface/src/lib/colors.ts
+++ b/interface/src/lib/colors.ts
@@ -1,0 +1,143 @@
+// Central color mappings for the interface.
+//
+// The pigment vocabulary is a small palette of Tailwind color names —
+// blue, pink, amber, purple, green, cyan, orange, red, violet, indigo.
+// Each domain (MemoryType, cortex event category, messaging platform)
+// maps a typed key onto one of those names, and the helpers here
+// derive both the Tailwind class pair (`bg-*/15 text-*-400`) and the
+// raw hex (for recharts / non-Tailwind consumers) from the same source.
+//
+// Keep additions here rather than re-declaring another ad-hoc map at
+// a call site — that's the whole point of this file.
+
+import type {MemoryType} from "@/api/client";
+
+type Pigment =
+	| "blue"
+	| "pink"
+	| "amber"
+	| "purple"
+	| "green"
+	| "cyan"
+	| "orange"
+	| "red"
+	| "violet"
+	| "indigo"
+	| "gray";
+
+const PIGMENT_HEX: Record<Pigment, string> = {
+	blue: "#3b82f6",
+	pink: "#ec4899",
+	amber: "#f59e0b",
+	purple: "#8b5cf6",
+	green: "#10b981",
+	cyan: "#06b6d4",
+	orange: "#f97316",
+	red: "#ef4444",
+	violet: "#8b5cf6",
+	indigo: "#6366f1",
+	gray: "#6b7280",
+};
+
+/**
+ * `bg-{color}-500/{alpha} text-{color}-400` pair. Use the Tailwind classes
+ * directly rather than constructing them dynamically so Tailwind's source
+ * scanner sees them at build time.
+ */
+type ClassPair = string;
+
+const PIGMENT_CLASS_15: Record<Pigment, ClassPair> = {
+	blue: "bg-blue-500/15 text-blue-400",
+	pink: "bg-pink-500/15 text-pink-400",
+	amber: "bg-amber-500/15 text-amber-400",
+	purple: "bg-purple-500/15 text-purple-400",
+	green: "bg-green-500/15 text-green-400",
+	cyan: "bg-cyan-500/15 text-cyan-400",
+	orange: "bg-orange-500/15 text-orange-400",
+	red: "bg-red-500/15 text-red-400",
+	violet: "bg-violet-500/15 text-violet-400",
+	indigo: "bg-indigo-500/15 text-indigo-400",
+	gray: "bg-gray-500/15 text-gray-400",
+};
+
+const PIGMENT_CLASS_20: Record<Pigment, ClassPair> = {
+	blue: "bg-blue-500/20 text-blue-400",
+	pink: "bg-pink-500/20 text-pink-400",
+	amber: "bg-amber-500/20 text-amber-400",
+	purple: "bg-purple-500/20 text-purple-400",
+	green: "bg-green-500/20 text-green-400",
+	cyan: "bg-cyan-500/20 text-cyan-400",
+	orange: "bg-orange-500/20 text-orange-400",
+	red: "bg-red-500/20 text-red-400",
+	violet: "bg-violet-500/20 text-violet-400",
+	indigo: "bg-indigo-500/20 text-indigo-400",
+	gray: "bg-gray-500/20 text-gray-400",
+};
+
+// --- MemoryType ---
+
+const MEMORY_TYPE_PIGMENT: Record<MemoryType, Pigment> = {
+	fact: "blue",
+	preference: "pink",
+	decision: "amber",
+	identity: "purple",
+	event: "green",
+	observation: "cyan",
+	goal: "orange",
+	todo: "red",
+};
+
+export function memoryTypeClass(type: MemoryType): ClassPair {
+	return PIGMENT_CLASS_15[MEMORY_TYPE_PIGMENT[type]];
+}
+
+export function memoryTypeHex(type: MemoryType): string {
+	return PIGMENT_HEX[MEMORY_TYPE_PIGMENT[type]];
+}
+
+/**
+ * Hex list in `MemoryType` declaration order — handy for charts that
+ * iterate a palette by index (e.g. recharts Pie `Cell` arrays).
+ */
+export const MEMORY_TYPE_HEX_PALETTE: readonly string[] = Object.values(
+	MEMORY_TYPE_PIGMENT,
+).map((p) => PIGMENT_HEX[p]);
+
+// --- Cortex event category ---
+
+const EVENT_CATEGORY_PIGMENT: Record<string, Pigment> = {
+	bulletin_generated: "blue",
+	bulletin_failed: "red",
+	maintenance_run: "green",
+	memory_merged: "green",
+	memory_decayed: "green",
+	memory_pruned: "green",
+	association_created: "violet",
+	contradiction_flagged: "violet",
+	worker_killed: "amber",
+	branch_killed: "amber",
+	circuit_breaker_tripped: "amber",
+	observation_created: "cyan",
+	health_check: "blue",
+};
+
+export function eventCategoryClass(eventType: string): ClassPair {
+	const pigment = EVENT_CATEGORY_PIGMENT[eventType];
+	if (!pigment) return "bg-app-dark-box text-ink-faint";
+	return PIGMENT_CLASS_15[pigment];
+}
+
+// --- Messaging platform ---
+
+const PLATFORM_PIGMENT: Record<string, Pigment> = {
+	discord: "indigo",
+	slack: "green",
+	telegram: "blue",
+	twitch: "purple",
+	cron: "amber",
+};
+
+export function platformColor(platform: string): ClassPair {
+	const pigment = PLATFORM_PIGMENT[platform] ?? "gray";
+	return PIGMENT_CLASS_20[pigment];
+}

--- a/interface/src/lib/format.ts
+++ b/interface/src/lib/format.ts
@@ -47,16 +47,10 @@ export function platformIcon(platform: string): string {
 	}
 }
 
-export function platformColor(platform: string): string {
-	switch (platform) {
-		case "discord": return "bg-indigo-500/20 text-indigo-400";
-		case "slack": return "bg-green-500/20 text-green-400";
-		case "telegram": return "bg-blue-500/20 text-blue-400";
-		case "twitch": return "bg-purple-500/20 text-purple-400";
-		case "cron": return "bg-amber-500/20 text-amber-400";
-		default: return "bg-gray-500/20 text-gray-400";
-	}
-}
+// Re-exported from the central color module so existing call sites keep
+// importing `platformColor` from "@/lib/format" without change. The
+// authoritative mapping lives in `@/lib/colors`.
+export {platformColor} from "./colors";
 
 // E.164 Phone Number Validation
 // Validates international phone numbers in format: + followed by country code and 6-15 digits

--- a/interface/src/routes/AgentChannels.tsx
+++ b/interface/src/routes/AgentChannels.tsx
@@ -2,7 +2,7 @@ import {useMemo, useState} from "react";
 import {useQuery} from "@tanstack/react-query";
 import {api} from "@/api/client";
 import {ChannelCard} from "@/components/ChannelCard";
-import {Button, SearchBar} from "@spacedrive/primitives";
+import {Button, LoadingDot, SearchBar} from "@spacedrive/primitives";
 import type {ChannelLiveState} from "@/hooks/useChannelLiveState";
 import {GearSix} from "@phosphor-icons/react";
 import {useNavigate} from "@tanstack/react-router";
@@ -52,10 +52,7 @@ export function AgentChannels({agentId, liveStates}: AgentChannelsProps) {
 			)}
 			<div className="flex-1 overflow-y-auto p-6">
 				{isLoading ? (
-					<div className="flex items-center gap-2 text-ink-dull">
-						<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-						Loading channels...
-					</div>
+					<LoadingDot>Loading channels...</LoadingDot>
 				) : hasChannels ? (
 					<div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
 						{channels.map((channel) => (

--- a/interface/src/routes/AgentConfig.tsx
+++ b/interface/src/routes/AgentConfig.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, useState, useRef} from "react";
 import {useQuery, useMutation, useQueryClient} from "@tanstack/react-query";
 import {useSearch, useNavigate} from "@tanstack/react-router";
+import {LoadingDot} from "@spacedrive/primitives";
 import {
 	api,
 	type AgentConfigResponse,
@@ -162,10 +163,7 @@ export function AgentConfig({agentId}: AgentConfigProps) {
 	if (isLoading) {
 		return (
 			<div className="flex h-full items-center justify-center">
-				<div className="flex items-center gap-2 text-ink-dull">
-					<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-					Loading configuration...
-				</div>
+				<LoadingDot>Loading configuration...</LoadingDot>
 			</div>
 		);
 	}

--- a/interface/src/routes/AgentCortex.tsx
+++ b/interface/src/routes/AgentCortex.tsx
@@ -2,26 +2,12 @@ import {useState} from "react";
 import {useQuery} from "@tanstack/react-query";
 import {AnimatePresence, motion} from "framer-motion";
 import {api, type CortexEvent, type CortexEventType} from "@/api/client";
+import {eventCategoryClass} from "@/lib/colors";
 import {formatTimeAgo} from "@/lib/format";
 import {FilterButton, LoadingDot} from "@spacedrive/primitives";
 
 const PAGE_SIZE = 50;
 
-const EVENT_CATEGORY_COLORS: Record<string, string> = {
-	bulletin_generated: "bg-blue-500/15 text-blue-400",
-	bulletin_failed: "bg-red-500/15 text-red-400",
-	maintenance_run: "bg-green-500/15 text-green-400",
-	memory_merged: "bg-green-500/15 text-green-400",
-	memory_decayed: "bg-green-500/15 text-green-400",
-	memory_pruned: "bg-green-500/15 text-green-400",
-	association_created: "bg-violet-500/15 text-violet-400",
-	contradiction_flagged: "bg-violet-500/15 text-violet-400",
-	worker_killed: "bg-amber-500/15 text-amber-400",
-	branch_killed: "bg-amber-500/15 text-amber-400",
-	circuit_breaker_tripped: "bg-amber-500/15 text-amber-400",
-	observation_created: "bg-cyan-500/15 text-cyan-400",
-	health_check: "bg-blue-500/15 text-blue-400",
-};
 
 /** Groups for the filter pills — reduces clutter vs showing all 13 types. */
 const FILTER_GROUPS: {label: string; types: CortexEventType[]}[] = [
@@ -55,8 +41,7 @@ const FILTER_GROUPS: {label: string; types: CortexEventType[]}[] = [
 ];
 
 function EventTypeBadge({eventType}: {eventType: string}) {
-	const color =
-		EVENT_CATEGORY_COLORS[eventType] ?? "bg-app-dark-box text-ink-faint";
+	const color = eventCategoryClass(eventType);
 	const label = eventType.replace(/_/g, " ");
 	return (
 		<span

--- a/interface/src/routes/AgentCortex.tsx
+++ b/interface/src/routes/AgentCortex.tsx
@@ -3,7 +3,7 @@ import {useQuery} from "@tanstack/react-query";
 import {AnimatePresence, motion} from "framer-motion";
 import {api, type CortexEvent, type CortexEventType} from "@/api/client";
 import {formatTimeAgo} from "@/lib/format";
-import {FilterButton} from "@spacedrive/primitives";
+import {FilterButton, LoadingDot} from "@spacedrive/primitives";
 
 const PAGE_SIZE = 50;
 
@@ -195,10 +195,7 @@ export function AgentCortex({agentId}: AgentCortexProps) {
 			{/* Event list */}
 			{isLoading ? (
 				<div className="flex flex-1 items-center justify-center">
-					<div className="flex items-center gap-2 text-ink-dull">
-						<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-						Loading cortex events...
-					</div>
+					<LoadingDot>Loading cortex events...</LoadingDot>
 				</div>
 			) : isError ? (
 				<div className="flex flex-1 items-center justify-center">

--- a/interface/src/routes/AgentCron.tsx
+++ b/interface/src/routes/AgentCron.tsx
@@ -34,7 +34,7 @@ import {
 	SelectContent,
 	SelectItem,
 } from "@spacedrive/primitives";
-import {Switch} from "@spacedrive/primitives";
+import {LoadingDot, Switch} from "@spacedrive/primitives";
 
 // -- Helpers --
 
@@ -327,7 +327,7 @@ export function AgentCron({agentId}: AgentCronProps) {
 			<div className="flex-1 overflow-auto p-6">
 				{isLoading && (
 					<div className="flex items-center justify-center py-12">
-						<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
+						<LoadingDot className="gap-0" />
 					</div>
 				)}
 
@@ -914,7 +914,7 @@ function JobExecutions({agentId, jobId}: {agentId: string; jobId: string}) {
 	if (isLoading) {
 		return (
 			<div className="flex items-center justify-center py-3">
-				<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
+				<LoadingDot className="gap-0" />
 			</div>
 		);
 	}

--- a/interface/src/routes/AgentDetail.tsx
+++ b/interface/src/routes/AgentDetail.tsx
@@ -8,6 +8,7 @@ import {
 	MEMORY_TYPES,
 } from "@/api/client";
 import type {ChannelLiveState} from "@/hooks/useChannelLiveState";
+import {MEMORY_TYPE_HEX_PALETTE} from "@/lib/colors";
 import {formatTimeAgo, formatCronSchedule} from "@/lib/format";
 import {DeleteAgentDialog} from "@/components/DeleteAgentDialog";
 import {
@@ -387,16 +388,6 @@ const CHART_COLORS = {
 	},
 };
 
-const MEMORY_TYPE_COLORS = [
-	"#3b82f6", // fact - blue
-	"#ec4899", // preference - pink
-	"#f59e0b", // decision - amber
-	"#10b981", // identity - green
-	"#06b6d4", // event - cyan
-	"#8b5cf6", // observation - purple
-	"#f97316", // goal - orange
-	"#ef4444", // todo - red
-];
 
 function MemoryGrowthChart({data}: {data: {date: string; count: number}[]}) {
 	if (data.length === 0) {
@@ -669,7 +660,7 @@ function MemoryDonut({counts}: {counts: Record<string, number>}) {
 	const data = MEMORY_TYPES.map((type, idx) => ({
 		name: type,
 		value: counts[type] ?? 0,
-		color: MEMORY_TYPE_COLORS[idx % MEMORY_TYPE_COLORS.length],
+		color: MEMORY_TYPE_HEX_PALETTE[idx % MEMORY_TYPE_HEX_PALETTE.length],
 	})).filter((d) => d.value > 0);
 	const total = data.reduce((sum, item) => sum + item.value, 0);
 

--- a/interface/src/routes/AgentIngest.tsx
+++ b/interface/src/routes/AgentIngest.tsx
@@ -2,7 +2,7 @@ import {useState, useRef, useCallback} from "react";
 import {useQuery, useMutation, useQueryClient} from "@tanstack/react-query";
 import {api, type IngestFileInfo} from "@/api/client";
 import {formatTimeAgo} from "@/lib/format";
-import {Badge} from "@spacedrive/primitives";
+import {Badge, LoadingDot} from "@spacedrive/primitives";
 import {clsx} from "clsx";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faTrash} from "@fortawesome/free-solid-svg-icons";
@@ -208,7 +208,7 @@ export function AgentIngest({agentId}: AgentIngestProps) {
 				{/* File list */}
 				{isLoading && (
 					<div className="flex items-center justify-center py-12">
-						<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
+						<LoadingDot className="gap-0" />
 					</div>
 				)}
 

--- a/interface/src/routes/AgentMemories.tsx
+++ b/interface/src/routes/AgentMemories.tsx
@@ -13,12 +13,13 @@ import {MemoryGraph} from "@/components/MemoryGraph";
 import {
 	CircleButton,
 	CircleButtonGroup,
-	SearchBar,
 	FilterButton,
-	SelectPill,
-	Popover,
+	LoadingDot,
 	OptionList,
 	OptionListItem,
+	Popover,
+	SearchBar,
+	SelectPill,
 } from "@spacedrive/primitives";
 import {formatTimeAgo} from "@/lib/format";
 import {List, TreeStructure} from "@phosphor-icons/react";
@@ -249,10 +250,9 @@ export function AgentMemories({agentId}: AgentMemoriesProps) {
 					{/* Virtualized rows */}
 					{isLoading ? (
 						<div className="flex flex-1 items-center justify-center">
-							<div className="flex items-center gap-2 text-ink-dull">
-								<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
+							<LoadingDot>
 								{isSearching ? "Searching..." : "Loading memories..."}
-							</div>
+							</LoadingDot>
 						</div>
 					) : isError ? (
 						<div className="flex flex-1 items-center justify-center">

--- a/interface/src/routes/AgentMemories.tsx
+++ b/interface/src/routes/AgentMemories.tsx
@@ -21,6 +21,7 @@ import {
 	SearchBar,
 	SelectPill,
 } from "@spacedrive/primitives";
+import {memoryTypeClass} from "@/lib/colors";
 import {formatTimeAgo} from "@/lib/format";
 import {List, TreeStructure} from "@phosphor-icons/react";
 
@@ -32,21 +33,10 @@ const SORT_OPTIONS: {value: MemorySort; label: string}[] = [
 	{value: "most_accessed", label: "Most Accessed"},
 ];
 
-const TYPE_COLORS: Record<MemoryType, string> = {
-	fact: "bg-blue-500/15 text-blue-400",
-	preference: "bg-pink-500/15 text-pink-400",
-	decision: "bg-amber-500/15 text-amber-400",
-	identity: "bg-purple-500/15 text-purple-400",
-	event: "bg-green-500/15 text-green-400",
-	observation: "bg-cyan-500/15 text-cyan-400",
-	goal: "bg-orange-500/15 text-orange-400",
-	todo: "bg-red-500/15 text-red-400",
-};
-
 function TypeBadge({type: memoryType}: {type: MemoryType}) {
 	return (
 		<span
-			className={`inline-flex items-center rounded px-1.5 py-0.5 text-tiny font-medium ${TYPE_COLORS[memoryType]}`}
+			className={`inline-flex items-center rounded px-1.5 py-0.5 text-tiny font-medium ${memoryTypeClass(memoryType)}`}
 		>
 			{memoryType}
 		</span>

--- a/interface/src/routes/Overview.tsx
+++ b/interface/src/routes/Overview.tsx
@@ -5,7 +5,7 @@ import {Sparkle, Lightbulb, FolderSimplePlus} from "@phosphor-icons/react";
 import {api} from "@/api/client";
 import {CreateAgentDialog} from "@/components/CreateAgentDialog";
 import {OrgGraph} from "@/components/org";
-import {Button, CircleButton} from "@spacedrive/primitives";
+import {Button, CircleButton, LoadingDot} from "@spacedrive/primitives";
 import {UpdatePill} from "@/components/UpdatePill";
 import type {ChannelLiveState} from "@/hooks/useChannelLiveState";
 import {formatUptime} from "@/lib/format";
@@ -173,10 +173,7 @@ export function Overview({liveStates, activeLinks}: OverviewProps) {
 			<div className="flex-1 overflow-hidden">
 				{overviewLoading ? (
 					<div className="flex h-full items-center justify-center">
-						<div className="flex items-center gap-2 text-ink-dull">
-							<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-							Loading...
-						</div>
+						<LoadingDot>Loading...</LoadingDot>
 					</div>
 				) : agents.length === 0 ? (
 					<div className="flex h-full items-center justify-center">

--- a/interface/src/routes/Settings.tsx
+++ b/interface/src/routes/Settings.tsx
@@ -10,6 +10,7 @@ import {
 	DialogTitle,
 	DialogDescription,
 	DialogFooter,
+	LoadingDot,
 } from "@spacedrive/primitives";
 import {SettingSidebarButton} from "@/ui/SettingSidebarButton";
 import {useSearch, useNavigate} from "@tanstack/react-router";
@@ -578,10 +579,7 @@ export function Settings() {
 							</div>
 
 							{isLoading ? (
-								<div className="flex items-center gap-2 text-ink-dull">
-									<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-									Loading providers...
-								</div>
+								<LoadingDot>Loading providers...</LoadingDot>
 							) : (
 								<div className="flex flex-col gap-3">
 									{PROVIDERS.map((provider) => [

--- a/interface/src/routes/Workbench.tsx
+++ b/interface/src/routes/Workbench.tsx
@@ -1,5 +1,6 @@
 import {useMemo, useEffect, useRef} from "react";
 import {useQuery, useQueryClient, useQueries} from "@tanstack/react-query";
+import {LoadingDot} from "@spacedrive/primitives";
 import {api} from "@/api/client";
 import {useLiveContext} from "@/hooks/useLiveContext";
 import {
@@ -168,10 +169,7 @@ export function Workbench() {
 			<div className="flex min-w-0 flex-1">
 				{isLoading && filteredWorkers.length === 0 ? (
 					<div className="flex h-full flex-1 items-center justify-center">
-						<div className="flex items-center gap-2 text-xs text-ink-faint">
-							<span className="h-2 w-2 animate-pulse rounded-full bg-accent" />
-							Loading workers...
-						</div>
+						<LoadingDot className="text-xs text-ink-faint">Loading workers...</LoadingDot>
 					</div>
 				) : filteredWorkers.length === 0 ? (
 					<EmptyState />

--- a/spaceui/.storybook/package.json
+++ b/spaceui/.storybook/package.json
@@ -18,13 +18,14 @@
     "@storybook/addon-themes": "^10.3.5",
     "@storybook/react": "^10.3.5",
     "@storybook/react-vite": "^10.3.5",
-    "storybook": "^10.3.5",
+    "@tailwindcss/vite": "^4.1.0",
+    "@types/node": "^22.10.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "storybook": "^10.3.5",
+    "tailwindcss": "^4.1.0",
     "typescript": "^6.0.2",
-    "vite": "^8.0.8",
-    "@tailwindcss/vite": "^4.1.0",
-    "tailwindcss": "^4.1.0"
+    "vite": "^8.0.8"
   },
   "dependencies": {
     "@spacedrive/tokens": "workspace:*",

--- a/spaceui/.storybook/shims.d.ts
+++ b/spaceui/.storybook/shims.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/spaceui/.storybook/tsconfig.json
+++ b/spaceui/.storybook/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
-  "include": ["*.ts", "*.tsx"],
+  "include": ["*.ts", "*.tsx", "*.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/spaceui/bun.lock
+++ b/spaceui/bun.lock
@@ -31,6 +31,7 @@
         "@storybook/react": "^10.3.5",
         "@storybook/react-vite": "^10.3.5",
         "@tailwindcss/vite": "^4.1.0",
+        "@types/node": "^22.10.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "storybook": "^10.3.5",
@@ -709,7 +710,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -1387,6 +1388,8 @@
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
@@ -1438,6 +1441,8 @@
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 

--- a/spaceui/docs/COMPONENT-AUDIT.md
+++ b/spaceui/docs/COMPONENT-AUDIT.md
@@ -101,12 +101,15 @@ Not audited yet. These components were extracted from the Spacebot interface and
 ## Migration Checklist
 
 ### Phase 1 — Fix the good ones
-- [ ] Button — add missing variants (subtle, gray, accent, colored, bare), add link mode
-- [ ] Checkbox — add RadixCheckbox extended variant
-- [ ] Tooltip — add keybind display support
-- [ ] RadioGroup — match real wrapper/layout pattern
-- [ ] TagPill — align props API (color+children vs tag object)
-- [ ] RenameInput — add extension handling, async save, blur cancellation
+
+Verified complete as of 2026-04-16 during PR II prep (grep against the current tree, not the 2026-03-26 snapshot):
+
+- [x] Button — all 8 variants present (default, subtle, outline, dotted, gray, accent, colored, bare) + link mode via `href?` / `LinkButtonProps` union
+- [x] Checkbox — both `CheckBox` and `RadixCheckbox` exported
+- [x] Tooltip — `keybinds` prop + `Kbd` component present
+- [x] RadioGroup — custom `Root` + `Item` wrappers with Spacedrive's bordered-box pattern
+- [x] TagPill — `color: string, children: ReactNode, size, onClick, onRemove, className` API
+- [x] RenameInput — extension handling, async save, blur cancellation (`name`, `extension`, `onSave`, `onCancel`)
 
 ### Phase 2 — Rework the mediocre ones
 - [ ] Input — rebuild with sizes, icon support, SearchInput, PasswordInput, TextArea

--- a/spaceui/packages/primitives/src/LoadingDot.tsx
+++ b/spaceui/packages/primitives/src/LoadingDot.tsx
@@ -1,0 +1,36 @@
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+export interface LoadingDotProps {
+	/**
+	 * Label rendered next to the dot. Most call sites say "Loading..." or
+	 * similar; pass the verbatim copy to preserve the exact user-visible text.
+	 */
+	children?: ReactNode;
+	/**
+	 * Extra classes merged onto the wrapper. Use to adjust typography
+	 * (`text-sm`, `text-ink-faint`, etc.) without rebuilding the component.
+	 */
+	className?: string;
+	/**
+	 * Extra classes merged onto the dot element itself. Useful for tuning
+	 * color (`bg-status-warning`) or size for a specific surface.
+	 */
+	dotClassName?: string;
+}
+
+/**
+ * Accent-colored pulsing dot with an inline label. The canonical Spacebot
+ * "loading..." indicator, consolidated from 26 inline copies across the
+ * interface.
+ */
+export function LoadingDot({ children, className, dotClassName }: LoadingDotProps) {
+	return (
+		<div className={clsx("flex items-center gap-2 text-ink-dull", className)}>
+			<div
+				className={clsx("h-2 w-2 animate-pulse rounded-full bg-accent", dotClassName)}
+			/>
+			{children}
+		</div>
+	);
+}

--- a/spaceui/packages/primitives/src/index.ts
+++ b/spaceui/packages/primitives/src/index.ts
@@ -94,6 +94,8 @@ export type { ToastId, ToastMessage } from "./Toast";
 
 // Loader
 export { Loader } from "./Loader";
+export { LoadingDot } from "./LoadingDot";
+export type { LoadingDotProps } from "./LoadingDot";
 
 // Divider
 export { Divider } from "./Divider";


### PR DESCRIPTION
## Summary

PR II in the SpaceUI modernization sequence (PR I = #45 Tailwind v4 canonical syntax). Four focused commits, each independently reviewable:

| # | Commit | Scope |
|---|---|---|
| 1 | `fix(spaceui-storybook)` | Restore `bun run typecheck` green in `.storybook/` |
| 2 | `feat(spaceui/primitives): LoadingDot` | New primitive + consolidate 25 pulse-dot copies across 23 files |
| 3 | `docs(spaceui): COMPONENT-AUDIT Phase 1 complete` | Phase 1 items were already done in the code; checklist now reflects reality |
| 4 | `refactor(interface): centralize scattered color maps` | 4 ad-hoc color maps → `interface/src/lib/colors.ts` |

**Diff:** 33 files, +269/-166.

## Per-commit detail

### 1. Storybook typecheck fix (`96706a1`)

Three `tsc --noEmit` errors:
- `main.ts` used `node:url`/`node:path` without `@types/node` installed or enabled in tsconfig `types`
- `preview.ts` side-effect imports `./storybook.css` with no ambient `*.css` declaration

Fix: add `@types/node` to devDependencies, `types: ["node"]` in tsconfig, add `shims.d.ts` declaring `*.css`. `bun run typecheck` passes all 9 workspace tasks.

### 2. LoadingDot primitive (`bc6d6e4`)

The interface repeated `<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />` inside `<div className="flex items-center gap-2 text-ink-dull">...</div>` across 26 sites — the canonical Spacebot "Loading..." indicator.

- New `LoadingDot` in `@spacedrive/primitives` with `children`, `className`, `dotClassName` — preserves every site's exact user-visible text and lets a few variants (`text-sm`, `text-xs`, `text-ink-faint`) tune typography without forking.
- 25 of 26 sites replaced. One site skipped: `interface/src/routes/ChannelDetail.tsx:134` — same CSS classes, different semantics (active-branch status chip with "Branch" label + description + cancel button). Folding it into `LoadingDot` would couple unrelated behaviors.

### 3. COMPONENT-AUDIT Phase 1 verification (`f734258`)

All six "Fix the good ones" items were already done in the workspace between the 2026-03-26 audit snapshot and now:

- Button: 8 variants (default/subtle/outline/dotted/gray/accent/colored/bare) + link mode via `href?` / `LinkButtonProps` union
- Checkbox: both `CheckBox` and `RadixCheckbox` exported
- Tooltip: `keybinds` prop + `Kbd` component
- RadioGroup: custom `Root` + `Item` wrappers with Spacedrive's bordered-box pattern
- TagPill: `color + children + size/onClick/onRemove` API
- RenameInput: extension handling, async save, blur cancellation

Checklist updated — no code change needed.

### 4. Color-map centralization (`825f60f`)

Consolidate 4 scattered ad-hoc color maps into `interface/src/lib/colors.ts`:

- `TYPE_COLORS` (AgentMemories.tsx) → `memoryTypeClass(type)`
- `EVENT_CATEGORY_COLORS` (AgentCortex.tsx) → `eventCategoryClass(eventType)`
- `MEMORY_TYPE_COLORS` (AgentDetail.tsx, hex array for recharts) → `MEMORY_TYPE_HEX_PALETTE`
- `platformColor()` (format.ts) → re-exports from `colors.ts`, call sites unchanged

Single `Pigment` vocabulary (blue/pink/amber/purple/green/cyan/orange/red/violet/indigo/gray) with pre-computed Tailwind class maps (full string literals so Tailwind source scanner sees them at build time) and hex map all derived from the same source.

**Small intentional behavior change:** MemoryType donut chart colors now match the badge colors (identity=purple, event=green, observation=cyan). The two were cosmetically drifted before; aligning them reduces visual confusion for users.

## Deferred (future session)

`flex-shrink-0 → shrink-0` canonical-class sweep — 53 occurrences across 22 files in both `interface/src` and `spaceui/packages/*/src`. Same motive as PR #45 (Tailwind v4 canonical syntax). Will be a dedicated mechanical-sweep PR, not mixed into this one.

## Test plan

- [x] `bun run typecheck` passes all 9 workspace tasks in spaceui
- [x] `bunx tsc --noEmit` passes in `interface/`
- [x] `bun run build` succeeds across all 6 packages in spaceui
- [x] Storybook boots clean on `http://localhost:6006/`, Button variants render
- [x] Interface boots clean on `http://localhost:19840/`
- [x] Manual smoke test: LoadingDot renders correctly on sampled routes (Settings, Agent/Config, Agent/Cortex, Agent/Memories, Workbench, Org graph) — pulsing accent dot + gray label, no layout shift, no console errors
- [x] Only expected `PopoverProvider` ariaLabel warning in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)