### PR TITLE
deps(spaceui): Tailwind v4 shrink-0 canonical form + fix Interface CI

### DIFF
--- a/.github/workflows/interface-ci.yml
+++ b/.github/workflows/interface-ci.yml
@@ -26,9 +26,6 @@ jobs:
     name: Interface Quality
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    defaults:
-      run:
-        working-directory: interface
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -36,8 +33,38 @@ jobs:
         with:
           bun-version: "1.3"
 
-      - name: Install dependencies
+      # Build spaceui first so the latest source — including exports not yet
+      # published to npm — lands in `spaceui/packages/*/dist/`. Without this
+      # step, `interface/` resolves `@spacedrive/*` to whichever version npm
+      # has published, which lags behind HEAD whenever a local PR adds a new
+      # export (the failure mode seen in Interface CI run 24538318930, where
+      # LoadingDot was added in PR #48 but not yet on npm).
+      - name: Install spaceui dependencies
+        working-directory: spaceui
         run: bun install --frozen-lockfile
 
+      - name: Build spaceui packages
+        working-directory: spaceui
+        run: bun run build
+
+      - name: Install interface dependencies
+        working-directory: interface
+        run: bun install --frozen-lockfile
+
+      # Sync the freshly-built spaceui dists into interface/node_modules so
+      # `tsc --noEmit` resolves to HEAD's exports. Vite's dev-server aliases
+      # handle this at runtime; this step is the build-time equivalent.
+      - name: Sync spaceui dists into interface
+        run: |
+          for pkg in primitives ai forms explorer; do
+            src="spaceui/packages/$pkg/dist"
+            dst="interface/node_modules/@spacedrive/$pkg/dist"
+            if [ -d "$src" ] && [ -d "$dst" ]; then
+              cp -R "$src/." "$dst/"
+              echo "Synced $pkg"
+            fi
+          done
+
       - name: Typecheck
+        working-directory: interface
         run: bunx tsc --noEmit

--- a/interface/src/components/ApprovalModal.tsx
+++ b/interface/src/components/ApprovalModal.tsx
@@ -91,7 +91,7 @@ export function ApprovalModal({notification, onClose}: ApprovalModalProps) {
 		<DialogRoot open={open} onOpenChange={(v) => {if (!v) onClose();}}>
 			<DialogContent className="!flex max-h-[80vh] w-full max-w-xl !flex-col !gap-0 overflow-hidden !p-0">
 				{/* Header */}
-				<DialogHeader className="flex-shrink-0 border-b border-app-line/50 px-5 pt-5 pb-4">
+				<DialogHeader className="shrink-0 border-b border-app-line/50 px-5 pt-5 pb-4">
 					<div className="flex items-center gap-2.5">
 						<Icon className={`size-5 shrink-0 ${config.iconClass}`} weight="fill" />
 						<div className="min-w-0 flex-1">
@@ -134,7 +134,7 @@ export function ApprovalModal({notification, onClose}: ApprovalModalProps) {
 				</div>
 
 				{/* Footer */}
-				<DialogFooter className="flex-shrink-0 border-t border-app-line/50 px-5 py-3">
+				<DialogFooter className="shrink-0 border-t border-app-line/50 px-5 py-3">
 					<div className="flex w-full items-center justify-end gap-2">
 						<Button
 							variant="subtle"

--- a/interface/src/components/PromptInspectModal.tsx
+++ b/interface/src/components/PromptInspectModal.tsx
@@ -86,7 +86,7 @@ export function PromptInspectModal({
 	return (
 		<DialogRoot open={open} onOpenChange={onOpenChange}>
 			<DialogContent className="!flex h-[85vh] w-[80vw] !max-w-[80vw] !flex-col !gap-0 overflow-hidden !p-0">
-				<DialogHeader className="flex-shrink-0 border-b border-app-line/50 px-6 pt-6 pb-4">
+				<DialogHeader className="shrink-0 border-b border-app-line/50 px-6 pt-6 pb-4">
 					<DialogTitle>Prompt Inspector</DialogTitle>
 					{showContent && !contentLoading && systemPrompt != null && (
 						<div className="mt-1 flex items-center gap-4 text-tiny text-ink-faint">
@@ -103,7 +103,7 @@ export function PromptInspectModal({
 
 				<div className="flex min-h-0 flex-1">
 					{/* Sidebar */}
-					<div className="flex w-48 flex-shrink-0 flex-col border-r border-app-line/50 bg-app-dark-box/30">
+					<div className="flex w-48 shrink-0 flex-col border-r border-app-line/50 bg-app-dark-box/30">
 						<div className="flex flex-col gap-0.5 p-2">
 							<SidebarButton
 								active={view === "current"}
@@ -209,7 +209,7 @@ export function PromptInspectModal({
 					</div>
 				</div>
 
-				<div className="flex flex-shrink-0 items-center justify-end border-t border-app-line/50 px-6 py-3">
+				<div className="flex shrink-0 items-center justify-end border-t border-app-line/50 px-6 py-3">
 					<Button variant="bare" size="sm" onClick={() => onOpenChange(false)}>
 						Close
 					</Button>

--- a/interface/src/components/agent-config/ConfigSidebar.tsx
+++ b/interface/src/components/agent-config/ConfigSidebar.tsx
@@ -15,7 +15,7 @@ export function ConfigSidebar({
 	identityData,
 }: ConfigSidebarProps) {
 	return (
-		<div className="flex w-52 flex-shrink-0 flex-col border-r border-app-line/50 bg-app-dark-box/20 overflow-y-auto">
+		<div className="flex w-52 shrink-0 flex-col border-r border-app-line/50 bg-app-dark-box/20 overflow-y-auto">
 			{/* General Group */}
 			<div className="flex flex-col gap-0.5 px-2 pt-3">
 				{SECTIONS.filter((s) => s.group === "general").map((section) => (

--- a/interface/src/components/org/GroupConfigPanel.tsx
+++ b/interface/src/components/org/GroupConfigPanel.tsx
@@ -79,7 +79,7 @@ export function GroupConfigPanel({
 							}`}
 						>
 							<span
-								className={`h-2 w-2 rounded-full flex-shrink-0 ${
+								className={`h-2 w-2 rounded-full shrink-0 ${
 									agentIds.has(id) ? "bg-accent" : "bg-app-line"
 								}`}
 							/>

--- a/interface/src/components/portal/PortalComposer.tsx
+++ b/interface/src/components/portal/PortalComposer.tsx
@@ -121,7 +121,7 @@ export function PortalComposer({
 							<button
 								type="button"
 								onClick={() => onRemoveFile(i)}
-								className="text-ink-faint hover:text-ink ml-0.5 flex-shrink-0 transition-colors"
+								className="text-ink-faint hover:text-ink ml-0.5 shrink-0 transition-colors"
 							>
 								<X size={12} weight="bold" />
 							</button>

--- a/interface/src/components/portal/PortalTimeline.tsx
+++ b/interface/src/components/portal/PortalTimeline.tsx
@@ -57,7 +57,7 @@ function UserMessageWithAttachments({
 								download={att.filename}
 								className="flex items-center gap-1.5 rounded-md bg-white/20 px-2 py-1 text-xs transition-colors hover:bg-white/30"
 							>
-								<FileIcon size={12} className="flex-shrink-0" />
+								<FileIcon size={12} className="shrink-0" />
 								<span className="max-w-[160px] truncate">{att.filename}</span>
 								<span className="opacity-70">{formatFileSize(att.size_bytes)}</span>
 							</a>
@@ -123,7 +123,7 @@ function AssistantAttachments({
 							download={att.filename}
 							className="border-app-line bg-app-box hover:bg-app-box/80 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors"
 						>
-							<FileIcon size={16} className="text-ink-faint flex-shrink-0" />
+							<FileIcon size={16} className="text-ink-faint shrink-0" />
 							<div className="min-w-0">
 								<div className="text-ink max-w-[200px] truncate">{att.filename}</div>
 								<div className="text-ink-faint text-xs">{formatFileSize(att.size_bytes)}</div>

--- a/interface/src/components/settings/ChannelsSection.tsx
+++ b/interface/src/components/settings/ChannelsSection.tsx
@@ -50,7 +50,7 @@ export function ChannelsSection() {
 			) : (
 				<div className="grid grid-cols-[200px_1fr] gap-6">
 					{/* Left column: Platform catalog */}
-					<div className="flex-shrink-0">
+					<div className="shrink-0">
 						<PlatformCatalog onAddInstance={handleAddInstance} />
 					</div>
 

--- a/interface/src/components/settings/ConfigFileSection.tsx
+++ b/interface/src/components/settings/ConfigFileSection.tsx
@@ -174,7 +174,7 @@ export function ConfigFileSection() {
 					Edit the raw configuration file. Changes are validated as TOML before
 					saving.
 				</p>
-				<div className="flex items-center gap-2 flex-shrink-0 ml-4">
+				<div className="flex items-center gap-2 shrink-0 ml-4">
 					{isDirty && (
 						<Button onClick={handleRevert} variant="outline" size="md">
 							Revert

--- a/interface/src/components/skills/SkillInspector.tsx
+++ b/interface/src/components/skills/SkillInspector.tsx
@@ -92,7 +92,7 @@ export function SkillInspector({
 		selected.type === "installed" ? installedContentQuery.data?.base_dir : null;
 
 	return (
-		<div className="flex w-80 flex-shrink-0 flex-col border-l border-app-line/50 bg-app-dark-box/10">
+		<div className="flex w-80 shrink-0 flex-col border-l border-app-line/50 bg-app-dark-box/10">
 			{/* Header */}
 			<div className="flex items-start justify-between gap-2 border-b border-app-line/50 px-4 py-3">
 				<div className="min-w-0 flex-1">

--- a/interface/src/components/skills/SkillsSidebar.tsx
+++ b/interface/src/components/skills/SkillsSidebar.tsx
@@ -42,7 +42,7 @@ export function SkillsSidebar({
 		selectedSkill?.type === "installed" ? selectedSkill.skill.name : null;
 
 	return (
-		<div className="flex w-52 flex-shrink-0 flex-col border-r border-app-line/50 bg-app-dark-box/20">
+		<div className="flex w-52 shrink-0 flex-col border-r border-app-line/50 bg-app-dark-box/20">
 			{/* Top actions */}
 			<div className="flex flex-col gap-0.5 px-2 pt-3">
 				{TOP_VIEWS.map(({view, label, icon: Icon}) => (

--- a/interface/src/components/workbench/WorkbenchSidebar.tsx
+++ b/interface/src/components/workbench/WorkbenchSidebar.tsx
@@ -12,7 +12,7 @@ export function WorkbenchSidebar({
 	onSelectWorker: (id: string) => void;
 }) {
 	return (
-		<aside className="flex h-full w-[270px] flex-shrink-0 flex-col overflow-hidden rounded-2xl border border-app-line bg-app">
+		<aside className="flex h-full w-[270px] shrink-0 flex-col overflow-hidden rounded-2xl border border-app-line bg-app">
 			<div className="flex h-[60px] flex-col justify-center gap-0.5 border-b border-app-line px-3 pt-1">
 				<h2 className="text-xs font-medium text-ink">Workbench</h2>
 				<div className="text-tiny text-ink-faint">
@@ -142,7 +142,7 @@ function WorkerRow({
 		>
 			<span
 				className={cx(
-					"h-2 w-2 flex-shrink-0 rounded-full",
+					"h-2 w-2 shrink-0 rounded-full",
 					isRunning && "animate-pulse bg-green-500",
 					isIdle && "bg-yellow-500",
 					!isRunning && !isIdle && "bg-ink-faint/40",

--- a/interface/src/components/workbench/WorkerColumn.tsx
+++ b/interface/src/components/workbench/WorkerColumn.tsx
@@ -14,14 +14,14 @@ export function WorkerColumn({worker}: {worker: OrchestrationWorker}) {
 	const taskText = worker.task.replace(/^\[opencode\]\s*/i, "");
 
 	return (
-		<div className="flex h-full w-[560px] flex-shrink-0 flex-col overflow-hidden rounded-2xl border border-app-line bg-app-box">
+		<div className="flex h-full w-[560px] shrink-0 flex-col overflow-hidden rounded-2xl border border-app-line bg-app-box">
 			{/* Column header */}
 			<div className="flex flex-col gap-1 h-[60px] border-b border-app-line px-3 py-2">
 				<div className="flex items-center gap-2">
 					{/* Status dot */}
 					<span
 						className={cx(
-							"h-2 w-2 bg-ink-faint flex-shrink-0 rounded-full",
+							"h-2 w-2 bg-ink-faint shrink-0 rounded-full",
 							isRunning && "animate-pulse bg-green-500",
 							isIdle && "bg-yellow-500",
 							!isRunning && !isIdle && "bg-ink-faint",
@@ -90,7 +90,7 @@ function CancelButton({
 					.catch(console.warn)
 					.finally(() => setCancelling(false));
 			}}
-			className="flex-shrink-0 rounded-md border border-app-line px-1.5 py-0.5 text-tiny font-medium text-ink-dull transition-colors hover:border-red-500/50 hover:text-red-400 disabled:opacity-50"
+			className="shrink-0 rounded-md border border-app-line px-1.5 py-0.5 text-tiny font-medium text-ink-dull transition-colors hover:border-red-500/50 hover:text-red-400 disabled:opacity-50"
 			title="Cancel worker"
 		>
 			{cancelling ? "..." : "Cancel"}

--- a/interface/src/routes/AgentCortex.tsx
+++ b/interface/src/routes/AgentCortex.tsx
@@ -205,7 +205,7 @@ export function AgentCortex({agentId}: AgentCortexProps) {
 										onClick={() => setExpandedId(isExpanded ? null : event.id)}
 										className="flex w-full items-center gap-4 px-6 py-3 text-left transition-colors hover:bg-app-dark-box/30"
 									>
-										<span className="w-20 flex-shrink-0 text-tiny text-ink-faint">
+										<span className="w-20 shrink-0 text-tiny text-ink-faint">
 											{formatTimeAgo(event.created_at)}
 										</span>
 										<EventTypeBadge eventType={event.event_type} />
@@ -213,7 +213,7 @@ export function AgentCortex({agentId}: AgentCortexProps) {
 											{event.summary}
 										</span>
 										{event.details && (
-											<span className="flex-shrink-0 text-tiny text-ink-faint">
+											<span className="shrink-0 text-tiny text-ink-faint">
 												{isExpanded ? "v" : ">"}
 											</span>
 										)}

--- a/interface/src/routes/AgentDetail.tsx
+++ b/interface/src/routes/AgentDetail.tsx
@@ -972,7 +972,7 @@ function CortexEventsSection({
 							<span className="min-w-0 flex-1 truncate text-ink-dull">
 								{event.summary}
 							</span>
-							<span className="flex-shrink-0 text-tiny tabular-nums text-ink-faint">
+							<span className="shrink-0 text-tiny tabular-nums text-ink-faint">
 								{formatTimeAgo(event.created_at)}
 							</span>
 						</div>
@@ -987,7 +987,7 @@ function CortexEventBadge({type}: {type: string}) {
 	const color = CORTEX_EVENT_COLORS[type] ?? "bg-gray-500/20 text-gray-400";
 	const label = type.replace(/_/g, " ");
 	return (
-		<span className={`flex-shrink-0 rounded px-1.5 py-0.5 text-tiny ${color}`}>
+		<span className={`shrink-0 rounded px-1.5 py-0.5 text-tiny ${color}`}>
 			{label}
 		</span>
 	);

--- a/interface/src/routes/AgentIngest.tsx
+++ b/interface/src/routes/AgentIngest.tsx
@@ -260,7 +260,7 @@ function FileRow({
 	return (
 		<div className="group flex items-center gap-4 rounded-lg border border-app-line bg-app-dark-box/30 px-4 py-3">
 			{/* File icon */}
-			<div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-app-box text-xs text-ink-faint">
+			<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-app-box text-xs text-ink-faint">
 				{file.filename.split(".").pop()?.toUpperCase() ?? "TXT"}
 			</div>
 
@@ -296,7 +296,7 @@ function FileRow({
 			</div>
 
 			{/* Status badge - centered on the right */}
-			<div className="flex-shrink-0">
+			<div className="shrink-0">
 				<StatusBadge status={file.status} />
 			</div>
 
@@ -305,7 +305,7 @@ function FileRow({
 				<button
 					onClick={onDelete}
 					disabled={isDeleting}
-					className="flex-shrink-0 flex h-8 w-8 items-center justify-center rounded-lg text-ink-faint hover:bg-app-box transition-colors disabled:opacity-50"
+					className="shrink-0 flex h-8 w-8 items-center justify-center rounded-lg text-ink-faint hover:bg-app-box transition-colors disabled:opacity-50"
 					title="Delete file"
 				>
 					{isDeleting ? (

--- a/interface/src/routes/AgentWorkers.tsx
+++ b/interface/src/routes/AgentWorkers.tsx
@@ -209,7 +209,7 @@ export function AgentWorkers({agentId}: {agentId: string}) {
 	return (
 		<div className="flex h-full">
 			{/* Left column: worker list */}
-			<div className="flex w-[360px] flex-shrink-0 flex-col border-r border-app-line/50">
+			<div className="flex w-[360px] shrink-0 flex-col border-r border-app-line/50">
 				{/* Toolbar */}
 				<div className="flex items-center gap-3 border-b border-app-line/50 bg-app-dark-box/20 px-4 py-2.5">
 					<input

--- a/interface/src/routes/ChannelDetail.tsx
+++ b/interface/src/routes/ChannelDetail.tsx
@@ -51,7 +51,7 @@ function CancelButton({
 				setCancelling(true);
 				onClick();
 			}}
-			className={`h-7 w-7 flex-shrink-0 text-ink-faint/50 hover:bg-status-error/15 hover:text-status-error ${className ?? ""}`}
+			className={`h-7 w-7 shrink-0 text-ink-faint/50 hover:bg-status-error/15 hover:text-status-error ${className ?? ""}`}
 			title="Cancel"
 		>
 			<X className="h-3.5 w-3.5" />
@@ -125,7 +125,7 @@ function LiveBranchRunItem({
 	const displayTool = live.currentTool ?? live.lastTool;
 	return (
 		<div className="flex gap-3 px-3 py-2">
-			<span className="flex-shrink-0 pt-0.5 text-tiny text-ink-faint">
+			<span className="shrink-0 pt-0.5 text-tiny text-ink-faint">
 				{formatTimestamp(new Date(item.started_at).getTime())}
 			</span>
 			<div className="min-w-0 flex-1">
@@ -181,7 +181,7 @@ function LiveWorkerRunItem({
 
 	return (
 		<div className="flex gap-3 px-3 py-2">
-			<span className="flex-shrink-0 pt-0.5 text-tiny text-ink-faint">
+			<span className="shrink-0 pt-0.5 text-tiny text-ink-faint">
 				{formatTimestamp(new Date(item.started_at).getTime())}
 			</span>
 			<div className="min-w-0 flex-1">
@@ -214,7 +214,7 @@ function LiveWorkerRunItem({
 								>
 									{item.task}
 								</span>
-								<span className="flex-shrink-0 text-tiny leading-5 text-ink-faint">
+								<span className="shrink-0 text-tiny leading-5 text-ink-faint">
 									{expanded ? "▾" : "▸"}
 								</span>
 							</div>
@@ -223,7 +223,7 @@ function LiveWorkerRunItem({
 							to="/agents/$agentId/workers"
 							params={{agentId}}
 							search={{worker: item.id}}
-							className={`flex-shrink-0 rounded border px-1.5 py-0.5 text-tiny font-medium transition-colors ${
+							className={`shrink-0 rounded border px-1.5 py-0.5 text-tiny font-medium transition-colors ${
 								oc
 									? "border-ink-faint/30 text-ink-dull hover:border-ink-faint/60 hover:bg-ink-faint/15"
 									: "border-status-warning/30 text-status-warning hover:border-status-warning/60 hover:bg-status-warning/15"
@@ -272,7 +272,7 @@ function BranchRunItem({item}: {item: TimelineBranchRun}) {
 
 	return (
 		<div className="flex gap-3 px-3 py-2">
-			<span className="flex-shrink-0 pt-0.5 text-tiny text-ink-faint">
+			<span className="shrink-0 pt-0.5 text-tiny text-ink-faint">
 				{formatTimestamp(new Date(item.started_at).getTime())}
 			</span>
 			<div className="min-w-0 flex-1">
@@ -282,7 +282,7 @@ function BranchRunItem({item}: {item: TimelineBranchRun}) {
 					className="w-full rounded-md bg-accent/10 px-3 py-2 text-left hover:bg-accent/15"
 				>
 					<div className="flex min-w-0 items-start gap-2">
-						<span className="inline-flex flex-shrink-0 items-center gap-2 self-start">
+						<span className="inline-flex shrink-0 items-center gap-2 self-start">
 							<span className="h-2 w-2 rounded-full bg-accent/50" />
 							<span className="text-sm font-medium text-accent-faint">
 								Branch
@@ -296,7 +296,7 @@ function BranchRunItem({item}: {item: TimelineBranchRun}) {
 							{item.description}
 						</span>
 						{item.conclusion && (
-							<span className="flex-shrink-0 self-start text-tiny leading-5 text-ink-faint">
+							<span className="shrink-0 self-start text-tiny leading-5 text-ink-faint">
 								{expanded ? "▾" : "▸"}
 							</span>
 						)}
@@ -328,7 +328,7 @@ function WorkerRunItem({
 
 	return (
 		<div className="flex gap-3 px-3 py-2">
-			<span className="flex-shrink-0 pt-0.5 text-tiny text-ink-faint">
+			<span className="shrink-0 pt-0.5 text-tiny text-ink-faint">
 				{formatTimestamp(new Date(item.started_at).getTime())}
 			</span>
 			<div className="min-w-0 flex-1">
@@ -361,7 +361,7 @@ function WorkerRunItem({
 								>
 									{item.task}
 								</span>
-								<span className="flex-shrink-0 text-tiny leading-5 text-ink-faint">
+								<span className="shrink-0 text-tiny leading-5 text-ink-faint">
 									{expanded ? "▾" : "▸"}
 								</span>
 							</div>
@@ -370,7 +370,7 @@ function WorkerRunItem({
 							to="/agents/$agentId/workers"
 							params={{agentId}}
 							search={{worker: item.id}}
-							className={`flex-shrink-0 rounded border px-1.5 py-0.5 text-tiny font-medium transition-colors ${
+							className={`shrink-0 rounded border px-1.5 py-0.5 text-tiny font-medium transition-colors ${
 								oc
 									? "border-ink-faint/30 text-ink-dull hover:border-ink-faint/60 hover:bg-ink-faint/15"
 									: "border-status-warning/30 text-status-warning hover:border-status-warning/60 hover:bg-status-warning/15"
@@ -430,7 +430,7 @@ function TimelineEntry({
 						item.role === "user" ? "bg-app-dark-box/30" : ""
 					}`}
 				>
-					<span className="flex-shrink-0 pt-0.5 text-tiny text-ink-faint">
+					<span className="shrink-0 pt-0.5 text-tiny text-ink-faint">
 						{formatTimestamp(new Date(item.created_at).getTime())}
 					</span>
 					<div className="min-w-0 flex-1">
@@ -643,7 +643,7 @@ export function ChannelDetail({
 						)}
 						{isTyping && (
 							<div className="flex gap-3 px-3 py-2">
-								<span className="flex-shrink-0 pt-0.5 text-tiny text-ink-faint">
+								<span className="shrink-0 pt-0.5 text-tiny text-ink-faint">
 									{formatTimestamp(Date.now())}
 								</span>
 								<div className="flex items-center gap-1.5">

--- a/interface/src/routes/Overlay.tsx
+++ b/interface/src/routes/Overlay.tsx
@@ -465,7 +465,7 @@ export function Overlay() {
 					style={haloStyle}
 				/>
 
-				<div className="relative flex h-9 w-9 flex-shrink-0 items-center justify-center">
+				<div className="relative flex h-9 w-9 shrink-0 items-center justify-center">
 					<div
 						className={cx(
 							"absolute inset-0 transition-all duration-150",
@@ -531,7 +531,7 @@ export function Overlay() {
 						else if (voiceState === "speaking") stopTts();
 					}}
 					className={cx(
-						"relative z-10 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border transition-colors",
+						"relative z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full border transition-colors",
 						voiceState === "idle" &&
 							"border-white/10 bg-white/5 text-ink-faint hover:bg-white/10 hover:text-ink",
 						voiceState === "processing" &&
@@ -552,7 +552,7 @@ export function Overlay() {
 							event.stopPropagation();
 							handleStopRecording();
 						}}
-						className="relative z-10 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-sky-300/30 bg-sky-400/15 text-sky-100 transition-colors hover:bg-sky-400/20"
+						className="relative z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-sky-300/30 bg-sky-400/15 text-sky-100 transition-colors hover:bg-sky-400/20"
 					>
 						<StopIcon />
 					</button>

--- a/interface/src/routes/Settings.tsx
+++ b/interface/src/routes/Settings.tsx
@@ -528,7 +528,7 @@ export function Settings() {
 	return (
 		<div className="flex h-full min-h-0 overflow-hidden">
 			{/* Sidebar */}
-			<div className="flex min-h-0 w-52 flex-shrink-0 flex-col overflow-y-auto border-r border-app-line/50 bg-app-dark-box/20">
+			<div className="flex min-h-0 w-52 shrink-0 flex-col overflow-y-auto border-r border-app-line/50 bg-app-dark-box/20">
 				<div className="px-3 pb-1 pt-4">
 					<span className="text-tiny font-medium uppercase tracking-wider text-ink-faint">
 						Settings

--- a/interface/src/routes/Workbench.tsx
+++ b/interface/src/routes/Workbench.tsx
@@ -181,7 +181,7 @@ export function Workbench() {
 								ref={(el) => {
 									columnRefs.current[worker.id] = el;
 								}}
-								className="flex h-full flex-shrink-0"
+								className="flex h-full shrink-0"
 							>
 								<WorkerColumn worker={worker} />
 							</div>

--- a/spaceui/packages/explorer/src/TagPill.tsx
+++ b/spaceui/packages/explorer/src/TagPill.tsx
@@ -32,7 +32,7 @@ export function TagPill({
 		>
 			<span
 				className={clsx(
-					"flex-shrink-0 rounded-full",
+					"shrink-0 rounded-full",
 					size === "xs" && "size-1",
 					size === "sm" && "size-1.5",
 					size === "md" && "size-2",

--- a/spaceui/packages/primitives/src/SearchBar.tsx
+++ b/spaceui/packages/primitives/src/SearchBar.tsx
@@ -50,7 +50,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
 				)}
 			>
 				<MagnifyingGlass
-					className="size-[18px] flex-shrink-0 text-ink-faint"
+					className="size-[18px] shrink-0 text-ink-faint"
 					weight="bold"
 				/>
 				<input
@@ -71,7 +71,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
 						type="button"
 						onClick={handleClear}
 						aria-label="Clear Search"
-						className="flex-shrink-0 rounded-full p-0.5 transition-colors hover:bg-sidebar-selected/40"
+						className="shrink-0 rounded-full p-0.5 transition-colors hover:bg-sidebar-selected/40"
 					>
 						<X className="size-3 text-sidebar-inkDull" weight="bold" />
 					</button>


### PR DESCRIPTION
## Summary

Two commits, one theme: finish the Tailwind v4 canonical-syntax migration and unblock CI.

| # | Commit | Scope |
|---|---|---|
| 1 | `deps(spaceui): adopt Tailwind v4 shrink-0 canonical form` | 48 `flex-shrink-0 → shrink-0` across 22 source files |
| 2 | `ci(interface): build spaceui before typechecking interface` | Fix Interface CI run 24538318930 failure |

## 1. `flex-shrink-0 → shrink-0` sweep

Tailwind v4 dropped the `flex-` prefix on `shrink-0`, `grow-0`, and `basis-*`. Same motive as PR #45 (canonical class syntax: `!class → class!`, `data-[X]: → data-X:`, `z-[N] → z-N`, numeric spacing, CSS-var utility form).

**48 replacements in 22 files, symmetric +48/-48** — pure in-place rewrites.

- 20 interface files across routes, components, workbench, skills, settings, portal, org, agent-config
- 2 spaceui files: `explorer/TagPill`, `primitives/SearchBar`

Every match was verified to be in a class-name token context (inside `className` attributes or `clsx/cn()` calls). Zero false positives, zero comments/strings touched.

## 2. Interface CI fix

Interface CI [run 24538318930](https://github.com/jrmatherly/spacebot/actions/runs/24538318930/job/71738462103) failed with 23 `LoadingDot` TS2305 errors after PR #48 merged. Root cause: the workflow installed `@spacedrive/primitives@^0.2.3` from npm (stale — `LoadingDot` had not been published) and ran `tsc --noEmit` against it, never touching the local spaceui source that actually contained the new export.

Fix — three steps ahead of Typecheck:

1. `bun install --frozen-lockfile` in `spaceui/`
2. `bun run build` in `spaceui/` (populates `spaceui/packages/*/dist/`)
3. After `bun install` in `interface/`, copy the freshly-built dists into `interface/node_modules/@spacedrive/*/dist/`

This mirrors what every dev does locally. Vite's dev-server aliases already point at local spaceui source at runtime; this is the build-time equivalent for `tsc`.

## Long-term follow-up (future session)

A cleaner fix would be to adopt a proper workspace protocol: add `"workspaces": ["../spaceui/packages/*"]` (or similar) to `interface/package.json` so bun resolves `@spacedrive/*` from local source directly, eliminating the CI dist-sync step entirely.

That's a larger architectural change — it affects bun's hoisting behavior, the spaceui monorepo's own workspace boundaries, and would need coordinated tsconfig/vite/package changes. The dist-sync approach above is the right short-term fix (unblocks CI today, preserves existing resolution semantics); the workspace protocol is the right long-term answer and worth its own dedicated session.

## Test plan

- [x] `bun run typecheck` green across all 9 spaceui tasks
- [x] `bunx tsc --noEmit` in `interface/` exits 0 after spaceui rebuild + dist sync
- [x] `grep -rn 'flex-shrink-0' interface/src/ spaceui/packages/` shows 0 source matches; 0 false positives (all replacements were in `className` contexts)
- [x] Storybook boots clean on `http://localhost:6006/`; Button renders
- [x] Interface boots clean on `http://localhost:19840/`
- [x] Manual smoke test: several of the 22 changed files verified visually — layouts unchanged, icons sized correctly, tag pills intact, no console errors
- [x] CI workflow syntax: no untrusted input in `run:` commands (hard-coded strings + local loop variables only)

## Security review

The `.github/workflows/interface-ci.yml` change:
- No references to `github.event.*`, `github.head_ref`, or any attacker-controllable field
- No `${{ ... }}` interpolation inside `run:` blocks
- Shell loop uses only local variables (`$pkg`, `$src`, `$dst`)
- `permissions: contents: read` retained (least-privilege)

🤖 Generated with [Claude Code](https://claude.com/claude-code)