### PR TITLE
fix(interface): TagInput imports X icon from phosphor, not lucide-react

### DIFF
--- a/interface/src/components/TagInput.tsx
+++ b/interface/src/components/TagInput.tsx
@@ -1,5 +1,5 @@
 import {useState, useRef, KeyboardEvent} from "react";
-import {X} from "lucide-react";
+import {X} from "@phosphor-icons/react";
 
 interface TagInputProps {
 	value: string[];


### PR DESCRIPTION
## Summary

`interface/src/components/TagInput.tsx` imports `{X}` from `lucide-react`, but `lucide-react` is not in `interface/package.json`. Any build path that compiles `TagInput` (which is used by 3 components with 8 call sites — `ChannelEditModal`, `ChannelSettingCard`, `ConfigSectionEditor`) has been failing with:

```
[vite]: Rolldown failed to resolve import "lucide-react" from
"interface/src/components/TagInput.tsx"
```

## Fix

Swap the import to `@phosphor-icons/react`, which is already a dependency and is the icon library used by every other component in the interface (`PortalComposer`, `ChannelCard`, `CortexChatPanel`, `Wiki`, etc. already import `X` from phosphor). Phosphor's `X` takes the same `size` prop, so this is a drop-in rename.

**Net dep change: zero.**
**Net behavior change: build goes from failing to passing.**

## How this was discovered

While auditing the tree during the workspace-protocol analysis, `bun run build` in `interface/` surfaced the error. It was masked in CI because:
- `interface-ci.yml` runs `bunx tsc --noEmit`, which does NOT fail on missing runtime deps (tsc only checks types)
- Docker build + Nix build use `@/components/ChannelEditModal` etc., which transitively import `TagInput` — should have failed there, but release/Nix builds appear to have been blocked or skipped for other reasons

## Test plan

- [x] `bunx tsc --noEmit` in `interface/` passes
- [x] `bun run build` in `interface/` succeeds (previously: failed)
- [x] Icon renders visually identical: phosphor's `X` is a near-identical glyph, both accept `size` prop

🤖 Generated with [Claude Code](https://claude.com/claude-code)