### PR TITLE
feat(spaceui): workspace-protocol self-reliance hygiene

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,7 @@ spaceui/scripts/
 tests/
 scripts/
 !scripts/build-opencode-embed.sh
+!scripts/check-workspace-protocol.sh
 desktop/
 examples/
 packages/

--- a/.github/workflows/spaceui.yml
+++ b/.github/workflows/spaceui.yml
@@ -14,6 +14,9 @@ on:
       - '.github/workflows/spaceui.yml'
       - 'scripts/check-workspace-protocol.sh'
 
+permissions:
+  contents: read
+
 jobs:
   gate:
     name: Typecheck + build spaceui, then interface

--- a/.github/workflows/spaceui.yml
+++ b/.github/workflows/spaceui.yml
@@ -1,0 +1,54 @@
+name: SpaceUI typecheck + build
+
+on:
+  push:
+    paths:
+      - 'spaceui/**'
+      - 'interface/package.json'
+      - '.github/workflows/spaceui.yml'
+      - 'scripts/check-workspace-protocol.sh'
+  pull_request:
+    paths:
+      - 'spaceui/**'
+      - 'interface/package.json'
+      - '.github/workflows/spaceui.yml'
+      - 'scripts/check-workspace-protocol.sh'
+
+jobs:
+  gate:
+    name: Typecheck + build spaceui, then interface
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Workspace-protocol guard
+        run: bash scripts/check-workspace-protocol.sh
+
+      - name: SpaceUI install
+        working-directory: spaceui
+        run: bun install --frozen-lockfile
+
+      - name: SpaceUI typecheck
+        working-directory: spaceui
+        run: bun run typecheck
+
+      - name: SpaceUI build
+        working-directory: spaceui
+        run: bun run build
+
+      - name: Interface install
+        working-directory: interface
+        run: bun install --frozen-lockfile
+
+      - name: Interface typecheck
+        working-directory: interface
+        run: bunx tsc --noEmit
+
+      - name: Interface build
+        working-directory: interface
+        run: bun run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Single binary crate with no workspace **members**. The root `Cargo.toml` carries
 
 - Rust: `cargo`
 - Frontend (`interface/`): `bun` (NEVER npm/pnpm/yarn)
-- SpaceUI (`spaceui/`): `bun` (its own workspace + bun.lock; `interface/` declares `"workspaces": ["../spaceui/packages/*"]` so `bun install` in interface symlinks `@spacedrive/*` to local source)
+- SpaceUI (`spaceui/`): `bun` (its own workspace + bun.lock; `interface/` declares `"workspaces": ["../spaceui/packages/*"]` so `bun install` in interface symlinks `@spacedrive/*` to local source). **Never remove the `workspaces` declaration or change a `workspace:*` dep to a semver range** — bun will silently fall back to the public npm registry and overwrite local customizations. The `scripts/check-workspace-protocol.sh` guard runs on every `interface/` preinstall and in CI (`.github/workflows/spaceui.yml`) to catch this class of regression. See `spaceui/SYNC.md` for the full provenance and drift discipline.
 - Desktop (`desktop/`): `cargo tauri`
 
 ## Database Migrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,9 @@ RUN cd spaceui && bun install --frozen-lockfile && bunx turbo run build --filter
 
 # 3. Install frontend dependencies (resolves @spacedrive/* as workspace
 #    symlinks into the spaceui packages copied above).
+#    The preinstall hook in interface/package.json invokes
+#    scripts/check-workspace-protocol.sh, so copy that script first.
+COPY scripts/check-workspace-protocol.sh scripts/
 COPY interface/package.json interface/bun.lock interface/
 # hadolint ignore=DL3003
 RUN cd interface && bun install --frozen-lockfile

--- a/flake.lock
+++ b/flake.lock
@@ -35,17 +35,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773628058,
-        "narHash": "sha256-hpXH0z3K9xv0fHaje136KY872VT2T5uwxtezlAskQgY=",
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f8573b9c935cfaa162dd62cc9e75ae2db86f85df",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,11 @@
   description = "Spacebot - An AI agent for teams, communities, and multi-user environments";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Pinned to a specific nixpkgs rev so `nix flake update` is an explicit act.
+    # This rev ships bun 1.3.11, which matches the project-local mise pin and
+    # the `packageManager` field in spaceui/package.json. Update all three
+    # together when bumping. See CLAUDE.md "Package Managers" section.
+    nixpkgs.url = "github:NixOS/nixpkgs/566acc07c54dc807f91625bb286cb9b321b5f42a";
     flake-utils.url = "github:numtide/flake-utils";
     crane = {
       url = "github:ipetkov/crane";

--- a/interface/package.json
+++ b/interface/package.json
@@ -7,6 +7,7 @@
 		"../spaceui/packages/*"
 	],
 	"scripts": {
+		"preinstall": "../scripts/check-workspace-protocol.sh",
 		"dev": "vite",
 		"build": "vite build",
 		"preview": "vite preview"

--- a/interface/vite.config.ts
+++ b/interface/vite.config.ts
@@ -14,6 +14,16 @@ export default defineConfig({
 			"sonner",
 			"clsx",
 			"class-variance-authority",
+			// Shared between interface/ and spaceui/packages/*. Audited by
+			// scripts/check-vite-dedupe.sh (run via `just spaceui-check-dedupe`).
+			"@phosphor-icons/react",
+			"@tanstack/react-query",
+			"@tanstack/react-virtual",
+			"react-hook-form",
+			"react-markdown",
+			"rehype-raw",
+			"remark-gfm",
+			"zod",
 		],
 		alias: [
 			// Pin React to a single copy (prevents "Invalid hook call" when a

--- a/justfile
+++ b/justfile
@@ -192,3 +192,23 @@ compose-validate:
     SPACEBOT_IMAGE_DIGEST=sha256:aaaa SD_AUTH=admin:x GF_ADMIN_USER=admin GF_ADMIN_PASSWORD=x \
         docker compose -f deploy/docker/docker-compose.yml --profile tooling config > /dev/null
     @echo "All profile combinations parse cleanly."
+
+# ============================================
+# SpaceUI hygiene recipes
+# ============================================
+
+# Run the workspace-protocol guard over every package.json in the repo.
+spaceui-check-workspace:
+    bash scripts/check-workspace-protocol.sh
+
+# Typecheck + build spaceui/, then typecheck interface/ (which needs spaceui dist).
+# Add this to the default gate-pr dependency chain if spaceui regressions become
+# common, but the cadence is low today so it stays separate.
+spaceui-gate: spaceui-check-workspace
+    cd spaceui && bun install --frozen-lockfile
+    cd spaceui && bun run typecheck
+    cd spaceui && bun run build
+    cd interface && bun install --frozen-lockfile
+    cd interface && bunx tsc --noEmit
+    cd interface && bun run build
+    @echo "spaceui-gate passed."

--- a/justfile
+++ b/justfile
@@ -209,10 +209,14 @@ compose-validate:
 spaceui-check-workspace:
     bash scripts/check-workspace-protocol.sh
 
+# Audit vite dedupe list against shared spaceui/interface deps.
+spaceui-check-dedupe:
+    bash scripts/check-vite-dedupe.sh
+
 # Typecheck + build spaceui/, then typecheck interface/ (which needs spaceui dist).
 # Add this to the default gate-pr dependency chain if spaceui regressions become
 # common, but the cadence is low today so it stays separate.
-spaceui-gate: spaceui-check-workspace
+spaceui-gate: spaceui-check-workspace spaceui-check-dedupe
     cd spaceui && bun install --frozen-lockfile
     cd spaceui && bun run typecheck
     cd spaceui && bun run build

--- a/justfile
+++ b/justfile
@@ -87,13 +87,21 @@ update-frontend-hash:
     #!/usr/bin/env bash
     set -euo pipefail
     echo "Building frontend-updater to get new hash..."
-    output=$(nix build .#frontend-updater 2>&1 || true)
+    output=$(nix --extra-experimental-features "nix-command flakes" build .#frontend-updater 2>&1 || true)
     new_hash=$(echo "$output" | awk '/got:/ {print $2}' || true)
 
     if [ -z "$new_hash" ]; then
-        echo "Error: Failed to extract hash from build output"
-        echo "Build output:"
-        echo "$output"
+        echo "Error: Failed to extract hash from build output." >&2
+        if echo "$output" | grep -q "experimental Nix feature"; then
+            echo "" >&2
+            echo "Nix rejected the flake command because experimental features are disabled system-wide." >&2
+            echo "This recipe passes --extra-experimental-features inline, so the failure is likely a different" >&2
+            echo "nix.conf setting. To normalize the environment once per machine:" >&2
+            echo "  mkdir -p ~/.config/nix && echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf" >&2
+        fi
+        echo "" >&2
+        echo "Full build output:" >&2
+        echo "$output" >&2
         exit 1
     fi
 
@@ -114,7 +122,7 @@ update-frontend-hash:
     echo ""
     echo "Next steps:"
     echo "  1. Review the changes: git diff nix/default.nix"
-    echo "  2. Test the build: nix build .#frontend"
+    echo "  2. Test the build: nix --extra-experimental-features 'nix-command flakes' build .#frontend"
     echo "  3. Commit the changes: git add nix/default.nix && git commit -m 'update: frontend node_modules hash'"
 
 # Update all Nix flake inputs (flake.lock).

--- a/scripts/check-vite-dedupe.sh
+++ b/scripts/check-vite-dedupe.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Verify interface/vite.config.ts dedupe list covers every dep shared between
+# interface/ and any spaceui/packages/*.
+#
+# Missing dedupe entries cause multi-copy bugs (two Reacts, two framer-motions)
+# that are hard to diagnose.
+
+set -euo pipefail
+
+INTERFACE_DEPS=$(jq -r '.dependencies // {} | keys[]' interface/package.json | sort -u)
+DEDUPE_LIST=$(
+    awk '/dedupe: *\[/,/\]/' interface/vite.config.ts \
+    | grep -oE '"[^"]+"' \
+    | tr -d '"' \
+    | sort -u
+)
+
+# Find every dep declared in any spaceui package.json.
+SPACEUI_DEPS=$(
+    find spaceui/packages -mindepth 2 -maxdepth 2 -name package.json -print0 \
+    | xargs -0 -n1 jq -r '(.dependencies // {}) + (.peerDependencies // {}) | keys[]' \
+    | sort -u
+)
+
+# Shared deps: appear in both interface/ and some spaceui package.
+SHARED=$(comm -12 <(echo "$INTERFACE_DEPS") <(echo "$SPACEUI_DEPS"))
+
+missing=0
+for dep in $SHARED; do
+    # React is handled via alias, not dedupe; skip.
+    if [ "$dep" = "react" ] || [ "$dep" = "react-dom" ]; then
+        continue
+    fi
+    # @spacedrive/* packages are resolved through the bun workspace protocol
+    # (single symlinked copy); vite dedupe is redundant here.
+    case "$dep" in
+        @spacedrive/*) continue ;;
+    esac
+    if ! echo "$DEDUPE_LIST" | grep -qx "$dep"; then
+        echo "WARN: dep '$dep' is shared between interface/ and spaceui but not in vite dedupe list"
+        missing=$((missing + 1))
+    fi
+done
+
+if [ "$missing" -gt 0 ]; then
+    echo ""
+    echo "$missing shared dep(s) missing from interface/vite.config.ts dedupe. Fix:"
+    echo "  add them to the dedupe array, or add them to the known-exception list in this script."
+    exit 1
+fi
+
+echo "OK — all shared deps are in the dedupe list."

--- a/scripts/check-workspace-protocol.sh
+++ b/scripts/check-workspace-protocol.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Enforce that every @spacedrive/* dependency in any package.json under the
+# repo uses the `workspace:*` protocol. Prevents silent npm fallbacks if a
+# `package.json` is edited incorrectly.
+#
+# Why this exists: our spaceui/packages/*/package.json files declare names
+# like `@spacedrive/primitives`, which is also the upstream scope on npm.
+# `workspace:*` makes bun resolve locally. Any non-workspace spec (e.g., a
+# semver range) would silently resolve to the public registry.
+#
+# Usage: run via `just spaceui-check-workspace` or as an interface/ preinstall.
+
+set -euo pipefail
+
+# Any package.json inside the repo, excluding dependencies we don't control.
+mapfile -t PACKAGE_JSONS < <(
+    find . \
+        -name package.json \
+        -not -path '*/node_modules/*' \
+        -not -path '*/target/*' \
+        -not -path '*/.git/*' \
+        -not -path './spacedrive/*'
+)
+
+violations=0
+
+for pj in "${PACKAGE_JSONS[@]}"; do
+    # Skip files with no @spacedrive/* entries at all.
+    if ! grep -q '"@spacedrive/' "$pj"; then
+        continue
+    fi
+    # Look for @spacedrive/* entries whose value does not start with "workspace:".
+    # Multi-line JSON means a simple grep works when each dep is on its own line,
+    # which is the convention we use.
+    bad=$(grep -E '"@spacedrive/[^"]+":\s*"(?!workspace:)' "$pj" 2>/dev/null || true)
+    # Fallback for grep without PCRE (BSD grep on macOS):
+    if [ -z "$bad" ]; then
+        bad=$(grep -E '"@spacedrive/[^"]+":[[:space:]]*"[^w]' "$pj" || true)
+    fi
+    if [ -n "$bad" ]; then
+        echo "ERROR: non-workspace @spacedrive/* dep in $pj:"
+        echo "$bad" | sed 's/^/  /'
+        violations=$((violations + 1))
+    fi
+done
+
+if [ "$violations" -gt 0 ]; then
+    echo ""
+    echo "Found $violations package.json file(s) with @spacedrive/* deps that"
+    echo "do not use the workspace:* protocol. Fix by changing each value to"
+    echo "\"workspace:*\"."
+    exit 1
+fi
+
+echo "OK — all @spacedrive/* deps use workspace:* protocol."

--- a/spaceui/SYNC.md
+++ b/spaceui/SYNC.md
@@ -1,0 +1,189 @@
+# spaceui/ Sync & Provenance
+
+This document describes the discipline for maintaining the `spaceui/` directory, which is a clone (**not** a git fork) of upstream SpaceUI. It is the checked-in source of truth, not a scratchpad.
+
+## Purpose
+
+The `spaceui/` directory is Spacebot's vendored copy of the SpaceUI design system — unlike `spacedrive/`, this one is a **runtime build dependency**. The frontend at `interface/` resolves `@spacedrive/*` imports through the bun workspace protocol to `spaceui/packages/*`. If this directory drifts silently from a working upstream, the frontend build breaks. This document defines:
+
+1. How the tree got here (provenance)
+2. What we've changed since (LOCAL_CHANGES)
+3. How the workspace protocol prevents silent npm fallbacks
+4. How to pull a specific upstream feature when we want one (cherry-pick recipe)
+
+## Provenance
+
+| Fact | Value |
+|---|---|
+| Upstream project | Presumed `spacedriveapp/spaceui` on GitHub (confirm on next pull) |
+| Reference snapshot | `~/dev/spaceui` (a local clone used as "what we started from") |
+| Reference snapshot date | Approximately 2026-04-14 (see `stat ~/dev/spaceui/package.json`) |
+| Upstream commit at snapshot time | **Unknown.** `~/dev/spaceui` has a stale `.git/` directory but no working remote config. |
+| In-tree path | `spaceui/` |
+| In-tree workspace manager | Bun (own workspace, own lockfile at `spaceui/bun.lock`) |
+| Consumption model | `interface/package.json` declares `"workspaces": ["../spaceui/packages/*"]` and imports `@spacedrive/{ai,explorer,forms,primitives,tokens}` as `workspace:*` |
+| Icons package | `@spacedrive/icons` is vendored and built but not yet imported by `interface/src/` (see [Open items](#open-items)) |
+
+## LOCAL_CHANGES (as of 2026-04-16)
+
+Unlike `spacedrive/`, this tree has meaningfully diverged from its reference clone. We did substantial refactors for breaking-change migrations and project-specific hygiene.
+
+### Intentional additions
+
+| File | Purpose |
+|---|---|
+| `spaceui/CLAUDE.md` | Spacebot-specific instructions for AI assistants working in this tree |
+| `spaceui/.storybook/shims.d.ts` | TypeScript shim for storybook's module resolution (local need) |
+| `spaceui/.storybook/tsconfig.json` | Local TS config for storybook (split from root) |
+| `spaceui/examples/showcase/src/vite-env.d.ts` | Vite env types for the local showcase app |
+| `spaceui/packages/icons/README.md` | Icons package docs (upstream may also have this; verify on next sync) |
+
+### Documentation rewrites
+
+| File | Note |
+|---|---|
+| `spaceui/README.md` | Spacebot-flavored intro; preserves the "shared design system" framing but references our integration model |
+| `spaceui/CONTRIBUTING.md` | Rewrites to reflect our workflow (bun workspace protocol, not the upstream link-packages script) |
+| `spaceui/INTEGRATION.md` | Describes how `interface/` consumes the packages; upstream version targets a generic consumer |
+| `spaceui/docs/COMPONENT-AUDIT.md` | Updated component inventory reflecting our refactors |
+| `spaceui/docs/REPO_SUMMARY.md` | Updated to describe our 6-package layout |
+| `spaceui/docs/SHARED-UI-STRATEGY.md` | Spacebot-flavored strategy discussion |
+| `spaceui/docs/TAILWIND-V4-MIGRATION.md` | Post-migration record of the Tailwind v3 → v4 upgrade we did |
+
+### Configuration & build changes
+
+| File | Note |
+|---|---|
+| `spaceui/package.json` | Dependency upgrades and metadata edits |
+| `spaceui/tsconfig.base.json` | Adjusted for TS 6 / stricter options |
+| `spaceui/.storybook/main.ts` | Updated for storybook 10.x and local showcase paths |
+| `spaceui/.storybook/package.json` | Deps aligned with upstream root's dep graph |
+| `spaceui/.storybook/preview.ts` | Theme provider wiring adjusted |
+| `spaceui/.storybook/storybook.css` | Style adjustments for Spacebot's design tokens |
+| `spaceui/examples/showcase/package.json` | Dep upgrades |
+| `spaceui/examples/showcase/src/App.tsx` | Demo app reorganized |
+| `spaceui/examples/showcase/src/index.css` | CSS token imports updated |
+| `spaceui/examples/showcase/vite.config.ts` | Vite config reshaped for our showcase layout |
+| `spaceui/packages/icons/package.json` | Package metadata edits |
+| `spaceui/packages/icons/tsconfig.json` | TS 6 alignment |
+| `spaceui/packages/icons/CHANGELOG.md` | Updated with our changes |
+
+### Build artifacts present in-tree
+
+These are build outputs, gitignored but not in the reference clone:
+
+- `spaceui/examples/showcase/dist/` — showcase app build output
+- `spaceui/.storybook/storybook-static/` — storybook static build
+
+### Directory-level exclusions (enforced by rsync, by design)
+
+| Excluded | Reason |
+|---|---|
+| `.git/` | Clone, not submodule |
+| `.github/` | Upstream's CI would conflict. Archived at `.scratchpad/backups/spaceui-.github/`. Removed in commit `6ce7867`. |
+| `node_modules/` | bun deps |
+| `dist/` (at package level) | Build output |
+
+## Open items
+
+1. **`@spacedrive/icons` is staged but not imported.** `interface/src/` has zero imports of `@spacedrive/icons` as of 2026-04-16. The package is:
+   - Copied in `Dockerfile` stage 3.5 (line 48)
+   - Enumerated in `flake.nix` (line 92)
+   - Present in `spaceui/packages/icons/` with full source
+
+   Decision pending: either import it from a frontend component (and justify the staging cost) or drop it from the workspace (remove 3 line-items). See `.scratchpad/spacedrive-spaceui-self-reliance.md` recommendation #4.
+
+2. **`@spacedrive/*` npm scope not renamed.** Per 2026-04-16 self-reliance decision, the rename to `@spacebot/*` is deferred to a future session. Interim guard (see recommendation #3 in the self-reliance doc) will block silent npm fallbacks.
+
+## Workspace protocol as self-reliance guarantee
+
+`interface/package.json` declares:
+
+```json
+"workspaces": ["../spaceui/packages/*"],
+"dependencies": {
+  "@spacedrive/ai":         "workspace:*",
+  "@spacedrive/explorer":   "workspace:*",
+  "@spacedrive/forms":      "workspace:*",
+  "@spacedrive/primitives": "workspace:*",
+  "@spacedrive/tokens":     "workspace:*"
+}
+```
+
+The `workspace:*` protocol is a hard guarantee. Bun resolves these packages from `../spaceui/packages/*` locally. It does **not** fall back to the npm registry. If a workspace member is missing, `bun install` fails loudly.
+
+The one failure mode: if someone edits `interface/package.json` and removes the `workspaces` declaration, or changes `workspace:*` to a version range like `^0.2.3`, bun will silently fetch the upstream `@spacedrive/*` package from npm — overwriting our local customizations with no warning. This is why the scope rename matters eventually, and why the interim guard exists.
+
+## Cherry-pick recipe
+
+Per the 2026-04-16 self-reliance decision: we do not re-sync en masse. Manual cherry-picks only.
+
+### Manual cherry-pick workflow
+
+```bash
+# 1. Identify the file in the reference clone
+FILE="packages/primitives/src/Button.tsx"
+
+# 2. Diff reference vs in-tree (many of our files have diverged; this is normal)
+/usr/bin/diff ~/dev/spaceui/$FILE spaceui/$FILE
+
+# 3. Review upstream; decide if we want it wholesale or partial
+less ~/dev/spaceui/$FILE
+
+# 4. Apply — copy file or hand-merge with our existing customizations
+cp ~/dev/spaceui/$FILE spaceui/$FILE
+
+# 5. Validate both the spaceui typecheck/build and the downstream interface build
+cd spaceui && bun install && bun run typecheck && bun run build
+cd ../interface && bun install && bun run build
+
+# 6. Record the lift in this file's LOCAL_CHANGES table with a reason line
+```
+
+### Validation before committing a cherry-pick
+
+Minimum gate (not yet wired into `just gate-pr`):
+
+```bash
+cd spaceui && bun run typecheck && bun run build
+cd ../interface && bun run build
+```
+
+A future `just spaceui-gate` recipe should wrap these two commands. See recommendation #7/#8 in `.scratchpad/spacedrive-spaceui-self-reliance.md`.
+
+## Hold-out list (never accept upstream overwrites for these)
+
+Files guaranteed to contain Spacebot-specific content. A future rsync/cherry-pick **must not** blindly overwrite them:
+
+- `spaceui/CLAUDE.md` — our addition
+- `spaceui/README.md` — Spacebot-flavored
+- `spaceui/CONTRIBUTING.md` — describes our workflow
+- `spaceui/INTEGRATION.md` — describes our consumption model
+- `spaceui/docs/*.md` — all four have been rewritten for our project
+- `spaceui/.storybook/shims.d.ts` — our addition
+- `spaceui/.storybook/tsconfig.json` — our addition
+- `spaceui/examples/showcase/src/vite-env.d.ts` — our addition
+- This file (`spaceui/SYNC.md`) — Spacebot-side discipline
+
+If any of these get touched by an upstream pull, re-verify and restore.
+
+## Files of record
+
+| File | Purpose |
+|---|---|
+| `interface/package.json` | `workspaces: ["../spaceui/packages/*"]` + 5× `workspace:*` dep entries |
+| `interface/vite.config.ts` | Dedupes shared deps (react, framer-motion, sonner, clsx, cva) |
+| `interface/src/styles.css` | Imports CSS from `@spacedrive/tokens` |
+| `Dockerfile` (stage 3.5) | Copies all 6 spaceui packages into the build context |
+| `flake.nix` | Enumerates spaceui source paths in the frontend derivation |
+| `justfile` (`spaceui-*` recipes) | Retired helpers — workspace protocol handles linking |
+| `openspec/specs/spaceui-integration/spec.md` | Structural spec for SpaceUI in-tree integration |
+| `~/dev/spaceui/` | Reference snapshot (has stale `.git/` but no working remote) |
+| `.scratchpad/spacedrive-spaceui-self-reliance.md` | Strategy doc |
+
+## Changelog
+
+| Date | Change |
+|---|---|
+| 2026-04-16 | First draft authored in `.scratchpad/`. |
+| 2026-04-17 | Promoted to `spaceui/SYNC.md` alongside SpaceUI hygiene PR. |

--- a/spaceui/package.json
+++ b/spaceui/package.json
@@ -36,7 +36,7 @@
     "turbo": "^2.0.0",
     "typescript": "^6.0.2"
   },
-  "packageManager": "bun@1.1.0",
+  "packageManager": "bun@1.3.11",
   "engines": {
     "node": ">=18"
   },

--- a/spaceui/packages/ai/package.json
+++ b/spaceui/packages/ai/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",
-    "@spacedrive/primitives": "^0.2.3",
+    "@spacedrive/primitives": "workspace:*",
     "clsx": "^2.1.1",
     "framer-motion": "^12.38.0",
     "react-loader-spinner": "^8.0.2",

--- a/spaceui/packages/explorer/package.json
+++ b/spaceui/packages/explorer/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@spacedrive/primitives": "^0.2.3",
+    "@spacedrive/primitives": "workspace:*",
     "@phosphor-icons/react": "^2.1.10",
     "clsx": "^2.1.1"
   },

--- a/spaceui/packages/forms/package.json
+++ b/spaceui/packages/forms/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@spacedrive/primitives": "^0.2.3",
+    "@spacedrive/primitives": "workspace:*",
     "clsx": "^2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Closes the last 15% of SpaceUI self-reliance work flagged in the strategy doc. Mechanical hygiene only — no Rust changes, no frontend logic changes.

Plan: `.scratchpad/plans/2026-04-17-spaceui-hygiene.md`

### What lands

- **Workspace-protocol guard** (`scripts/check-workspace-protocol.sh`) — preinstall hook that grep-validates every `package.json` for silent npm-fallback risk. Wired into `interface/` preinstall and Dockerfile build.
- **`@spacedrive/primitives` sibling deps** pinned to `workspace:*`.
- **`just spaceui-gate` / `just spaceui-check-workspace` / `just spaceui-check-dedupe`** recipes.
- **Vite dedupe audit** (`scripts/check-vite-dedupe.sh`) wired into `spaceui-gate`.
- **Bun pin converged** to `1.3.11` across all workspace roots.
- **CI workflow** (`.github/workflows/spaceui.yml`) — typecheck + build on `spaceui/**` path changes.
- **`spaceui/SYNC.md`** — provenance + cherry-pick discipline, promoted from scratchpad.
- **CLAUDE.md** section documenting the workspace-protocol self-reliance model.

### Not in this PR

- `@spacedrive/icons` removal — deferred by explicit decision (icons stays wired in; revisit when a concrete importer lands or removal pressure returns).

## Verification

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean (34s, warm cache, zero warnings).
- `just preflight` — passed.
- `bash scripts/check-workspace-protocol.sh` — passed (introduced by this branch).

Full `just gate-pr` deferred to post-merge on `main`, with Plan 2 (`feat/spacedrive-pairing-prereqs`) landing alongside. CI gates authoritatively.

## Test plan

- [ ] CI: `.github/workflows/spaceui.yml` typecheck + build passes on first run
- [ ] CI: existing gates still green (no regression from CLAUDE.md / justfile / Dockerfile edits)
- [ ] Post-merge: `just gate-pr` on refreshed `main`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>