### PR TITLE
docs: audit fixes 2026-04-18 — CHANGELOG PR #57, DRY walk-through, policy prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Post-v0.4.1 work on the detached fork. Final section content gets generated at r
 - **Docker Compose variant** (`deploy/docker/`) — one file, six profiles: `default`, `build`, `spacedrive`, `proxy`, `observability`, `tooling`. Includes Caddy proxy, Prometheus + Grafana observability, dbtools SQLite shell, mcp-stub test MCP server, and an in-tree Spacedrive integration harness. Twelve new `just compose-*` recipes plus a dedicated CI workflow validate every profile on push.
 - **`spacedrive/Dockerfile`** for `sd-server` built with `--no-default-features` (skips wasmer).
 - **bjw-s-labs/app-template Helm wrapper** at `deploy/helm/spacebot/` for the Talos deployment target (landed across earlier commits).
+- **Spacedrive fork — stub modules** (PR #57). Ten stub files under `spacedrive/core/src/` (nine declared-but-never-authored `sd-core` modules plus `data/mod.rs`) and an `apps/web/dist/index.html` placeholder unblock `cd spacedrive && cargo build --bin sd-server`. This makes `spacedrive/` a genuine fork with documented local divergence. See `spacedrive/SYNC.md` LOCAL_CHANGES for the per-file retirement triggers.
 
 ### Fixed
 

--- a/docs/design-docs/spacedrive-integration-pairing.md
+++ b/docs/design-docs/spacedrive-integration-pairing.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Accepted 2026-04-17.** Bound to the Track A implementation plan at `.scratchpad/plans/2026-04-17-track-a-spacebot-outbound.md`. Phase 1 of Track A uses the config shape defined in D2. Phase 2 uses the auth patterns from D3.
+**Accepted 2026-04-17.** The Track A implementation plan was drafted at `.scratchpad/plans/2026-04-17-track-a-spacebot-outbound.md` (gitignored historical record); Phase 1 uses the config shape from D2, Phase 2 uses the auth patterns from D3. Track A landed on main via PRs #54 (Phase 1), #55 (Phase 2), and #56 (Phase 3).
 
 ## Context
 
@@ -209,7 +209,7 @@ These belong in the pairing OpenSpec's design/specs artifacts, not here.
 
 ## References
 
-- Self-reliance strategy: `.scratchpad/spacedrive-spaceui-self-reliance.md`
+- Self-reliance strategy (historical, gitignored): `.scratchpad/spacedrive-spaceui-self-reliance.md`. Not a tracked link. Preserved as context for where the fork's independence rationale was drafted.
 - Upstream design docs (treat as aspirational per 2026-04-16 decision): `spacedrive/docs/core/design/spacebot-integration.md`, `spacebot-remote-execution.md`, `spacebot-spacedrive-contract.md`
 - Spacedrive `SpacebotConfig`: `spacedrive/core/src/config/app_config.rs:52`
 - Spacedrive update op: `spacedrive/core/src/ops/config/app/update.rs:81`

--- a/docs/design-docs/spacedrive-tool-response-envelope.md
+++ b/docs/design-docs/spacedrive-tool-response-envelope.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Accepted 2026-04-17.** Binds Track A Phase 3 (`.scratchpad/plans/2026-04-17-track-a-spacebot-outbound.md`, Task 12+).
+**Accepted 2026-04-17.** Binds Track A Phase 3. The original implementation plan was drafted at `.scratchpad/plans/2026-04-17-track-a-spacebot-outbound.md` (gitignored historical record, not a tracked live link); Phase 3 shipped via PRs #55 and #56 on main.
 
 ## Context
 
@@ -107,7 +107,7 @@ Extending the envelope to other tools is out of scope for this ADR. It may becom
 
 - Self-reliance doc reviewer sweep finding S-4
 - Strategy doc §Integration substrate
-- Track A Phase 3 plan: `.scratchpad/plans/2026-04-17-track-a-spacebot-outbound.md`
+- Track A Phase 3 plan (historical, gitignored): `.scratchpad/plans/2026-04-17-track-a-spacebot-outbound.md`. Not a tracked link. Preserved as a record of where the plan was drafted before landing via PRs #55-56.
 - Related: `docs/design-docs/spacedrive-integration-pairing.md`
 
 ## Changelog

--- a/interface/DRY_VIOLATIONS.md
+++ b/interface/DRY_VIOLATIONS.md
@@ -2,7 +2,7 @@
 
 Tracked hardcoded patterns and duplication in `interface/src/` that are worth consolidating. Every entry is grounded in a grep against the current tree (not historical claims).
 
-**Snapshot:** 2026-04-17 — post `@spacedrive/primitives` migration, Tailwind v4.
+**Snapshot:** 2026-04-18. Re-verified against the current tree after the `@spacedrive/primitives` migration.
 
 **How to use this doc:**
 - Before "fixing" anything here, re-run the referenced grep. Counts drift quickly.
@@ -29,24 +29,11 @@ grep -rnE 'h-2 w-2 animate-pulse rounded-full bg-accent' interface/src/
 
 ---
 
-## 🟡 Scattered color maps (4 locations, no central tokens file)
+## ⚪ Scattered color maps — ✅ resolved (moved to `interface/src/lib/colors.ts`)
 
-Per-domain color mappings live as inline consts instead of semantic tokens:
+**Status (as of 2026-04-18):** The three per-domain color constants (`TYPE_COLORS`, `EVENT_CATEGORY_COLORS`, `MEMORY_TYPE_COLORS`) and `platformColor()` have been consolidated into `interface/src/lib/colors.ts`. Verified via `grep -rn "TYPE_COLORS\|EVENT_CATEGORY_COLORS\|MEMORY_TYPE_COLORS" interface/src/routes/*.tsx` returning zero hits, and `interface/src/lib/format.ts:53` now reads `export {platformColor} from "./colors";` (a compatibility re-export).
 
-| Const | File:line |
-|-------|-----------|
-| `TYPE_COLORS` (MemoryType → Tailwind classes) | `interface/src/routes/AgentMemories.tsx:34` |
-| `EVENT_CATEGORY_COLORS` (event type → classes) | `interface/src/routes/AgentCortex.tsx:10` |
-| `MEMORY_TYPE_COLORS` (array, positional) | `interface/src/routes/AgentDetail.tsx:390` |
-| `platformColor()` (switch on platform name) | `interface/src/lib/format.ts:50` |
-
-**Verify:**
-```bash
-grep -n "TYPE_COLORS\|EVENT_CATEGORY_COLORS\|MEMORY_TYPE_COLORS" interface/src/routes/*.tsx
-grep -n "platformColor" interface/src/lib/format.ts
-```
-
-**Fix:** These are semantic color mappings, not arbitrary styling. The natural home is `@spacedrive/tokens` as named semantic tokens (e.g. `color.memory.fact`, `color.event.bulletin_generated`), consumed from interface via the existing `@spacedrive/tokens` dependency. A local `interface/src/lib/semantic-colors.ts` is acceptable if the domain is too interface-specific for the shared design system.
+Kept as a tracking marker; not an action item. If `@spacedrive/tokens` ever grows a semantic-color surface (`color.memory.fact`, `color.event.*`), those can migrate from `colors.ts` into the shared design system.
 
 ---
 
@@ -77,7 +64,7 @@ grep -nE "^function Field" interface/src/routes/AgentCron.tsx
 
 ## 🟡 Grid column template duplicated in table rows
 
-**Pattern:** `grid-cols-[80px_1fr_100px_120px_100px]` — appears twice in `interface/src/routes/AgentMemories.tsx` (lines 241 header, 292 row) and nowhere else.
+**Pattern:** `grid-cols-[80px_1fr_100px_120px_100px]` — appears twice in `interface/src/routes/AgentMemories.tsx` (lines 232 header, 282 row) and nowhere else.
 
 **Verify:**
 ```bash
@@ -123,7 +110,7 @@ These were evaluated and deemed not worth consolidating:
 Do these in order:
 
 1. ~~**Pulse-dot component** (🔴, 26 sites — highest leverage)~~ — resolved, see entry above.
-2. **Semantic colors in `@spacedrive/tokens`** (🟡, fixes 4 scattered maps in one move)
+2. ~~**Semantic colors** (🟡, 4 scattered maps)~~ — resolved, now in `interface/src/lib/colors.ts`.
 3. **AgentCron `Field` → `@spacedrive/forms` variants** (🟡, narrow but finishes the forms migration)
 4. **Hoist grid template to const** (🟡, 2-line change)
 

--- a/spacedrive/CONTRIBUTING.md
+++ b/spacedrive/CONTRIBUTING.md
@@ -134,6 +134,8 @@ cargo cli     # Runs sd-cli with ffmpeg,heif features enabled
 
 #### Optional: ML-SHARP for Gaussian Splat Generation
 
+> **Upstream dependency.** `ml-sharp` is maintained by the upstream Spacedrive team at `spacedriveapp/ml-sharp` and is not forked into this `jrmatherly/spacebot` repo. The URLs below point at the upstream source of truth, which is correct for installation.
+
 Spacedrive can generate 3D Gaussian splats from images using [ml-sharp](https://github.com/spacedriveapp/ml-sharp), which implements Apple's SHARP model. This feature is optional and requires manual installation.
 
 > **Note:** We plan to bundle ml-sharp with Spacedrive's native dependencies in a future release. For now, manual installation is required.


### PR DESCRIPTION
## Summary

Applies all four findings from the 2026-04-18 docs audit ([report + verification log](../blob/docs/audit-2026-04-18-fixes/.scratchpad/2026-04-18-docs-audit.md), kept in `.scratchpad/` since the scratchpad is gitignored).

### Finding 1 (🟡) — `spacedrive/CONTRIBUTING.md`: ml-sharp upstream attribution

The `ml-sharp` URLs at lines 137 and 145 point at `spacedriveapp/ml-sharp`, which is a genuine upstream ML dependency — this repo has not forked it. Added a one-paragraph banner at the top of the section making the upstream nature explicit so a future docs-audit sweep correctly recognizes this as non-drift.

### Finding 2 (🔵) — CHANGELOG entry for PR #57

`## Unreleased → ### Added` was missing a bullet for PR #57 (spacedrive fork stubs), even though the Serena memory already documents it. Added a bullet naming the ten stub files + the `apps/web/dist/index.html` placeholder, pointing at `spacedrive/SYNC.md` LOCAL_CHANGES for per-file retirement triggers.

### Finding 3 (🔵) — `interface/DRY_VIOLATIONS.md` walk-through

Grep-verified all five entries against the current tree:

| Entry | Status | Action |
|-------|--------|--------|
| Pulse-dot loading indicator | ✅ already marked resolved | none |
| Scattered color maps | ✅ **newly resolved** — now in `interface/src/lib/colors.ts` | Marked resolved; removed from priority queue |
| `Field` wrapper in AgentCron.tsx:718 | 🟡 still active | unchanged |
| grid-cols template | 🟡 still active (line drift: 241/292 → 232/282) | Line numbers updated |
| `text-tiny text-ink-faint` (133 occurrences) | ⚪ decide-don't-fix | unchanged |

Also refreshed the "Snapshot" date from 2026-04-17 → 2026-04-18.

### Finding 4 (⚪) — scratchpad references in design docs

Tightened four references in `spacedrive-tool-response-envelope.md` and `spacedrive-integration-pairing.md` so they read as historical context, not live links. Two references in `k8s-helm-scaffold.md` and `spaceui/SYNC.md` were already sufficiently explicit (\"ungitted scratch\", table cells describing archival location) — left unchanged.

## Test plan

- [x] `grep '[a-z)"0-9]\s*—\s*[a-z]' <added-lines>` → only bullet-label em-dashes remain (allowed per writing-guide carve-out)
- [x] All entries in DRY_VIOLATIONS.md grep-verified against current tree
- [x] `sd-core` stub file count in CHANGELOG bullet matches PR #57's actual landed count (9 sd-core + data/mod.rs = 10)
- [x] Upstream `spacedriveapp/ml-sharp` URL intentionally preserved (not a fork target)
- [ ] CI green on `ci.yml` + interface workflows (docs-only PR, should pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)