### PR TITLE
docs(rules): exempt prompts/ templates from em-dash ban

### DIFF
--- a/.claude/rules/writing-guide.md
+++ b/.claude/rules/writing-guide.md
@@ -19,6 +19,7 @@ Where em dashes ARE allowed (narrow list, do not extend):
 - Numbered-step labels: `1. **Claim** — verbatim quote`
 - Table cells separating a value from its description: `| Foo | path/to/foo — purpose |`
 - Section headers: `## Scale — Targets and Limits`
+- Prompt templates under `prompts/**/*.md.j2`: the rule's rationale ("would a developer think 'AI-generated'?") targets human readers. Prompts are consumed by the LLM at inference time. The credibility concern does not transfer. All other writing-guide rules still apply to prompt templates.
 
 Where em dashes are NOT allowed (these are the violations to watch for):
 - Inside a complete sentence as a substitute for a period, comma, or colon


### PR DESCRIPTION
## Summary

- Adds a single bullet to `.claude/rules/writing-guide.md`'s "Where em dashes ARE allowed" list, exempting `prompts/**/*.md.j2`.
- The writing-guide's em-dash rule targets AI-generated-sounding prose for human readers. Prompt templates are consumed by the LLM at inference time; the credibility concern that motivates the rule does not transfer.
- All other writing-guide rules (banned phrases, generic improvement claims, words to avoid) continue to apply to prompt templates.

## ⚠️ Sequencing note

**This decision must merge before W4-PR2 (per-adapter channel prompts) is opened for review.** W4-PR2 will add new adapter prompts that legitimately use em-dashes (matching the project's established `compactor.md.j2` / `cortex_intraday_synthesis.md.j2` pattern). Without this exemption in place first, a W4-PR2 reviewer will flag those em-dashes as writing-guide violations.

## Context

Part of the 2026-04-18 audit cycle (W4-PR5). Source decision locked in `.scratchpad/2026-04-18-presets-prompts-skills-audit.md` PR 5 (Path A — exempt, not sweep). Rationale: sweeping em-dashes out of existing prompts is busywork that may not improve LLM behavior; exempting the `prompts/` tree preserves current content and frees future prompt authoring from a constraint that does not serve the rule's stated motivation.

## Test plan

- [x] `./scripts/check-sidecar-naming.sh` — green
- [x] `just check-adr-anchors` — green
- [x] `just preflight` — green
- [x] Writing-guide self-check regex (`grep -nE '[a-z)"0-9]\s*—\s*[a-z]' .claude/rules/writing-guide.md`) — no new violations introduced; same 5 legitimate hits (1 table-cell example, 4 quoted "Bad" examples).

Docs-only PR (zero `.rs` / Cargo.toml touches); full `just gate-pr` skipped per the docs-only gate policy clarified in the 2026-04-18 audit cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)