### PR TITLE
fix(deploy): prepend spacebot binary name to command/args arrays

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -90,6 +90,7 @@ Combining them produces a port collision on 19898 (both services would claim the
 | Grafana empty of SpaceBot metrics | `config.toml` must bind-mount at `/etc/spacebot/config.toml` with `[metrics] enabled = true`. The shipped `./config.toml` does this automatically; verify the mount exists via `docker compose exec spacebot ls /etc/spacebot/`. |
 | Grafana empty of traces | OTLP is off by default. Set `OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317` in `.env` and `docker compose restart spacebot`. |
 | `alloy` logs show no spans | Confirm SpaceBot has `OTEL_EXPORTER_OTLP_ENDPOINT` set; check Alloy's UI at `http://localhost:12345` for pipeline health. |
+| SpaceBot log spam "failed to export OTLP traces" after switching profiles | `OTEL_EXPORTER_OTLP_ENDPOINT` is still set in `.env` but Alloy is no longer running. Comment out the line in `.env` and `docker compose restart spacebot`, or re-run with the `observability` profile. |
 | First browser-tool call hangs for ~30s | SpaceBot lazy-downloads Chromium (~200 MB) on first `browser_*` tool invocation rather than bundling it. Subsequent calls use the cached binary under `/data/chrome_cache` (K8s) or the `spacebot-data` volume (compose). Expected on first use. |
 | Port 19898 already in use | Stop any other spacebot, or change port in `docker-compose.yml` |
 

--- a/deploy/docker/alloy-config.alloy
+++ b/deploy/docker/alloy-config.alloy
@@ -5,6 +5,14 @@
 // proves the OTLP pipeline works end-to-end and lets the operator see
 // traces by tailing `docker compose logs alloy`.
 //
+// Traces only. SpaceBot emits OTLP traces today; it does NOT emit OTLP
+// metrics (those go through the Prometheus scrape path at :9090) or
+// OTLP logs (those go to stdout/stderr for `docker compose logs`).
+// If SpaceBot starts emitting OTLP metrics or logs, add the
+// corresponding `metrics`/`logs` lines to the receiver + processor +
+// exporter output blocks below. Until then, wiring unused pipelines
+// would create a false expectation for future maintainers.
+//
 // For a richer local setup, add an otlphttp exporter pointing at a local
 // Tempo instance; or run the cluster's exact Alloy config for parity.
 // The production cluster forwards traces to Tempo; emulating that
@@ -19,17 +27,13 @@ otelcol.receiver.otlp "default" {
     endpoint = "0.0.0.0:4318"
   }
   output {
-    traces  = [otelcol.processor.batch.default.input]
-    metrics = [otelcol.processor.batch.default.input]
-    logs    = [otelcol.processor.batch.default.input]
+    traces = [otelcol.processor.batch.default.input]
   }
 }
 
 otelcol.processor.batch "default" {
   output {
-    traces  = [otelcol.exporter.debug.default.input]
-    metrics = [otelcol.exporter.debug.default.input]
-    logs    = [otelcol.exporter.debug.default.input]
+    traces = [otelcol.exporter.debug.default.input]
   }
 }
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -36,6 +36,11 @@ services:
       # OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317 in `.env` (or export
       # it in the shell before `docker compose up`). Matches the cluster
       # deployment's Grafana Alloy endpoint.
+      #
+      # Footgun: if you set this in `.env` for an observability session
+      # and later run `just compose-up` (no Alloy), SpaceBot will retry
+      # OTLP exports to a dead endpoint indefinitely. Unset (or comment
+      # out) the line in `.env` when running non-observability profiles.
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-spacebot}
     ports:

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -18,7 +18,12 @@ services:
     # daemon in the foreground; required in containers since the Rust
     # binary daemonizes by default. Matches the K8s deployment's args
     # pattern (see deploy/helm/spacebot/values.yaml).
-    command: ["-c", "/etc/spacebot/config.toml", "start", "-f"]
+    #
+    # The first element MUST be "spacebot" because the Dockerfile
+    # entrypoint is docker-entrypoint.sh which ends with `exec "$@"`.
+    # Compose `command:` fully REPLACES the Dockerfile CMD, so without
+    # the binary name the entrypoint tries to exec "-c" as a program.
+    command: ["spacebot", "-c", "/etc/spacebot/config.toml", "start", "-f"]
     env_file:
       - path: .env
         required: false
@@ -75,8 +80,10 @@ services:
       dockerfile: Dockerfile
     container_name: spacebot
     restart: unless-stopped
-    # Same -c flag + mount pattern as the `spacebot` service.
-    command: ["-c", "/etc/spacebot/config.toml", "start", "-f"]
+    # Same -c flag + mount pattern as the `spacebot` service. The
+    # binary name is mandatory; see the comment on the `spacebot`
+    # service's command for why.
+    command: ["spacebot", "-c", "/etc/spacebot/config.toml", "start", "-f"]
     env_file:
       - path: .env
         required: false

--- a/deploy/helm/spacebot/values.local.yaml
+++ b/deploy/helm/spacebot/values.local.yaml
@@ -29,7 +29,12 @@ controllers:
         # -c /etc/spacebot/config.toml argument and let the daemon fall
         # back to its default instance_dir resolution ($SPACEBOT_DIR then
         # ~/.spacebot). Keep foreground mode.
+        #
+        # The first element MUST be "spacebot" because the Dockerfile
+        # entrypoint is docker-entrypoint.sh which ends with `exec "$@"`
+        # and app-template's `args:` fully replaces the Dockerfile CMD.
         args:
+          - "spacebot"
           - "start"
           - "-f"
         # Local dev runs without the secret-backed API keys; keep only

--- a/deploy/helm/spacebot/values.yaml
+++ b/deploy/helm/spacebot/values.yaml
@@ -210,6 +210,19 @@ persistence:
   # at /data is RWO and could be reused, but keeping the cache in its own
   # emptyDir makes pod restart semantics cleaner (Chrome cache is
   # regenerable; real user data on the PVC must not be).
+  #
+  # Path: /data/chrome_cache matches the daemon's default
+  # `chrome_cache_dir = instance_dir.join("chrome_cache")` at
+  # src/config/load.rs:944. When SPACEBOT_DIR=/data, the resolved
+  # path is /data/chrome_cache. Do NOT rename this mount without also
+  # overriding `[browser].chrome_cache_dir` in the ConfigMap.
+  #
+  # Migration note for upgraders: pods before this PR wrote Chromium
+  # into the PVC at /data/chrome_cache. On first pod start after
+  # upgrading, the emptyDir here shadows whatever the PVC had at that
+  # subpath. The PVC's cache becomes unreachable and a fresh download
+  # starts on first browser tool use. The download is idempotent and
+  # takes ~30 seconds. No data loss; cache is regenerable by design.
   chrome-cache:
     enabled: true
     type: emptyDir

--- a/deploy/helm/spacebot/values.yaml
+++ b/deploy/helm/spacebot/values.yaml
@@ -66,7 +66,14 @@ controllers:
         # semantics. `start -f` runs the daemon in the foreground; required
         # in containers since the Rust binary daemonizes by default.
         # See .scratchpad/2026-04-18-k8s-G3-config-path-metrics.md.
+        #
+        # The first element MUST be "spacebot" because the Dockerfile
+        # entrypoint is docker-entrypoint.sh which ends with `exec "$@"`.
+        # bjw-s app-template's `args:` maps to the container spec's `args`
+        # field, which fully REPLACES the Dockerfile CMD. Without the
+        # binary name the entrypoint tries to exec "-c" as a program.
         args:
+          - "spacebot"
           - "-c"
           - "/etc/spacebot/config.toml"
           - "start"


### PR DESCRIPTION
## 🚨 Critical fix + code-review follow-ups

Two commits on this branch:

1. **`76c76fe` — Critical fix**: PRs #70 + #71 command/args arrays dropped the `spacebot` binary name. Dockerfile ENTRYPOINT is `docker-entrypoint.sh` ending in `exec "$@"`, so overrides tried to exec `-c` as a binary. **Container fails to start in both Compose and Kubernetes.** Fixed by prepending `spacebot` to all 4 command/args arrays.

2. **`c131b69` — Code-review follow-ups**: I1, I2, I3, M1 from the post-merge review.

## C1: Critical fix (first commit)

Four arrays updated:

| File | Change |
|---|---|
| `deploy/docker/docker-compose.yml` `spacebot` service | `command: ["spacebot", "-c", "/etc/spacebot/config.toml", "start", "-f"]` |
| `deploy/docker/docker-compose.yml` `spacebot-build` service | Same |
| `deploy/helm/spacebot/values.yaml` | `args: ["spacebot", "-c", "/etc/spacebot/config.toml", "start", "-f"]` |
| `deploy/helm/spacebot/values.local.yaml` | `args: ["spacebot", "start", "-f"]` |

Each site gets a comment explaining why the binary name is mandatory, so future editors don't drop it again.

## Follow-ups (second commit)

### I3 — Alloy config stripped of unused metrics + logs pipelines
`deploy/docker/alloy-config.alloy` receiver/processor/exporter were wired for traces + metrics + logs. SpaceBot only emits OTLP traces. Removed the unused outputs so the config matches the stated purpose; updated the file-level comment.

### I1 — Chromium cache migration note
`deploy/helm/spacebot/values.yaml` persistence.chrome-cache gains a migration note for operators upgrading from pre-PR-#70 deploys. The emptyDir shadows any warm cache the PVC previously held. Documented as expected (~200 MB re-download on first pod start after upgrade; no data loss).

### M1 — Chromium cache path verified + comment added
Confirmed `/data/chrome_cache` matches the daemon's default `chrome_cache_dir = instance_dir.join("chrome_cache")` at `src/config/load.rs:944`. Added inline comment citing that source line so future contributors can trace the connection. No behavioral change.

### I2 — OTLP env-var footgun documented
`deploy/docker/docker-compose.yml`: comment expanded explaining that setting `OTEL_EXPORTER_OTLP_ENDPOINT` in `.env` for an observability session causes SpaceBot to retry exports to a dead endpoint when later running a non-observability profile. Operator must unset when switching profiles. `deploy/docker/README.md`: new troubleshooting row matching the symptom.

## Why local gates missed the C1 breakage

`just compose-validate` runs `docker compose config` — a static YAML parser. Doesn't execute containers. The bug surfaces only at runtime when `exec("-c")` fails. Follow-up CI improvement: compose-up smoke test that checks for a SpaceBot startup banner in logs. Not in scope for this PR.

## Test plan

- [x] Dockerfile shape verified: `Dockerfile:149-150` (ENTRYPOINT docker-entrypoint.sh + CMD ["spacebot", "start", "--foreground"])
- [x] `docker-entrypoint.sh` ends with `exec "$@"`
- [x] K8s ENTRYPOINT/CMD vs `args:` behavior validated (only `args:` is set → ENTRYPOINT stays, CMD is replaced by args, so `spacebot` must be in the array)
- [x] Chromium cache path verified against `src/config/load.rs:944`
- [x] `just compose-validate` green across all six profiles
- [x] `yq eval` confirms all three YAML files + alloy config parse
- [x] `check-sidecar-naming`, `check-adr-anchors`, `preflight` all green
- [x] Writing-guide self-check: one first-pass violation fixed in place

Docs-only PR (zero `.rs` / Cargo.toml touches); full `just gate-pr` skipped per the 2026-04-18 gate-policy clarification.

## Credit

C1 caught by `superpowers:code-reviewer` subagent dispatched after PR #71 merged. I re-verified each claim against source before accepting, per `superpowers:receiving-code-review` discipline. Follow-up items I1/I2/I3/M1 from the same review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)