### PR TITLE
fix(daemon): give OTLP exporter tests a multi-thread Tokio runtime

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -420,6 +420,28 @@ fn warn_on_port_protocol_mismatch(endpoint: &str, protocol: &str) {
 
 #[cfg(test)]
 mod otlp_protocol_tests {
+    // Tests that exercise build_otlp_provider's full path (constructing the
+    // BatchSpanProcessor with `opentelemetry_sdk::runtime::Tokio`) MUST use
+    // #[tokio::test(flavor = "multi_thread")] because:
+    //   1. runtime::Tokio::spawn calls tokio::spawn() at BatchSpanProcessor::new
+    //      time, which requires an active Tokio runtime handle.
+    //   2. The BatchSpanProcessor worker task blocks on tokio::time::sleep to
+    //      drive its scheduled-delay ticker. A current-thread runtime can only
+    //      make progress on one task at a time, so when the test function exits
+    //      and the runtime goes out of scope, the worker blocks runtime shutdown
+    //      indefinitely — producing the same deadlock documented upstream in
+    //      opentelemetry_sdk/src/runtime.rs comment on `TokioCurrentThread`.
+    // A multi-thread runtime avoids the deadlock by running the worker on a
+    // separate worker thread, letting `Runtime::drop`'s task-cancellation path
+    // complete cleanly. Mirrors the upstream test pattern in
+    // opentelemetry_sdk-0.31.0/src/trace/span_processor_with_async_runtime.rs
+    // (tests `test_timeout_tokio_timeout`, `test_concurrent_exports_expected`,
+    // etc., all use `flavor = "multi_thread"` for the same reason).
+    //
+    // Tests that early-return before reaching that code path can stay as plain
+    // #[test] — that asymmetry preserves signal about which tests exercise the
+    // runtime-requiring path. See PR #77 follow-up and
+    // .scratchpad/2026-04-20-otlp-test-runtime-fix-findings.md.
     use super::*;
 
     fn cfg(endpoint: Option<&str>, protocol: Option<&str>) -> TelemetryConfig {
@@ -437,8 +459,8 @@ mod otlp_protocol_tests {
         assert!(build_otlp_provider(&cfg(None, None)).is_none());
     }
 
-    #[test]
-    fn http_proto_default_when_protocol_unset() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn http_proto_default_when_protocol_unset() {
         // Absence of panic + Some return proves the http path was taken.
         let p = build_otlp_provider(&cfg(Some("http://localhost:4318"), None));
         assert!(p.is_some());
@@ -454,8 +476,8 @@ mod otlp_protocol_tests {
     }
 
     #[cfg(feature = "otlp-grpc")]
-    #[test]
-    fn grpc_protocol_with_feature_builds_exporter() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn grpc_protocol_with_feature_builds_exporter() {
         // When the feature is enabled, build_otlp_provider must NOT panic and
         // must return Some (the exporter builds even if the endpoint is not
         // actually reachable — gRPC connection is lazy until the first export).
@@ -463,8 +485,8 @@ mod otlp_protocol_tests {
         assert!(p.is_some());
     }
 
-    #[test]
-    fn http_json_protocol_builds_exporter() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn http_json_protocol_builds_exporter() {
         // http/json shares the HTTP transport arm with http/protobuf; this
         // test pins the case-sensitivity-insensitive match on the distinct
         // input string so a future refactor can't drop one arm silently.
@@ -472,8 +494,8 @@ mod otlp_protocol_tests {
         assert!(p.is_some());
     }
 
-    #[test]
-    fn protocol_matching_is_case_insensitive() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn protocol_matching_is_case_insensitive() {
         // Operators frequently set OTEL_EXPORTER_OTLP_PROTOCOL=GRPC (uppercase).
         // Without the feature, the uppercase form must still match the grpc
         // arm and return None rather than falling through to the "unsupported"


### PR DESCRIPTION
## Summary

Fixes three failing unit tests in \`src/daemon.rs::otlp_protocol_tests\` and proactively hardens one latent feature-gated test. The fix is a single attribute change per test: \`#[test]\` → \`#[tokio::test(flavor = "multi_thread")]\`, plus \`fn\` → \`async fn\`. No product code changes.

## Failing tests (on main)

- \`http_proto_default_when_protocol_unset\`
- \`http_json_protocol_builds_exporter\`
- \`protocol_matching_is_case_insensitive\`

All three panic with \`"there is no reactor running, must be called from the context of a Tokio 1.x runtime"\`.

Proactive fourth flip:
- \`grpc_protocol_with_feature_builds_exporter\` (currently hidden by \`#[cfg(feature = "otlp-grpc")]\` — preserves the fix when the feature is enabled)

Three sibling tests intentionally remain as plain \`#[test]\` because they short-circuit before reaching the runtime-requiring code path. That asymmetry preserves signal about which tests exercise the runtime path.

## Root cause (two layers)

**Layer 1 — missing runtime:** \`build_otlp_provider\` constructs a \`BatchSpanProcessor\` with \`opentelemetry_sdk::runtime::Tokio\`. At \`.build()\` time, \`BatchSpanProcessor::new\` calls \`runtime.spawn(async move { ... })\` which dispatches to \`tokio::spawn()\`, requiring an active Tokio runtime handle on the calling thread. Plain \`#[test]\` has no runtime, so \`tokio::spawn\` panics.

**Layer 2 — current-thread deadlock:** Swapping to a bare \`#[tokio::test]\` (which defaults to a current-thread runtime) fixes the panic but introduces a deadlock. The \`BatchSpanProcessor\` worker blocks on \`tokio::time::sleep\` driving the scheduled-delay ticker. On a current-thread runtime, only one task runs at a time, so when the test function exits and \`Runtime::drop\` waits for the worker to reach a yield point, shutdown blocks indefinitely.

I verified Layer 2 reproduces: a first pass of this change using bare \`#[tokio::test]\` hung the test runner with cargo's "running for over 60 seconds" warning on all three converted tests.

The upstream \`opentelemetry_sdk\` crate documents this exact deadlock at \`opentelemetry_sdk-0.31.0/src/runtime.rs:120\` as the reason its \`TokioCurrentThread\` runtime variant spawns worker tasks on a separate \`std::thread\`. The upstream's own tests for \`runtime::Tokio\` uniformly use \`#[tokio::test(flavor = "multi_thread")]\` (\`span_processor_with_async_runtime.rs:618, 626, 631\`). This PR follows the same pattern.

## Why \`flavor = "multi_thread"\` is the long-term correct fix

| Option | Verdict |
|---|---|
| \`#[tokio::test(flavor = "multi_thread")]\` | ✅ **Chosen.** Matches upstream test pattern. Matches production runtime (\`#[tokio::main]\` is multi-thread by default). Avoids the deadlock by running the worker on a separate worker thread so \`Runtime::drop\`'s task-cancellation path completes cleanly. |
| \`#[tokio::test(start_paused = true)]\` | ❌ Rejected. \`start_paused\` controls the test runtime's timer, but the \`BatchSpanProcessor\` worker runs on \`inner_runtime.spawn\` (its own runtime reference), so pausing the test's timer has no effect. |
| Change production \`runtime::Tokio\` → \`runtime::TokioCurrentThread\` | ❌ Rejected. Would alter production behavior (spawns a dedicated \`std::thread\` per provider instance) for a test-only concern. |
| Restructure tests to explicitly construct a \`SdkTracerProvider\` and call \`.shutdown()\` | ❌ Rejected. Larger surface change; doesn't match the narrow intent of these tests, which only validate that \`build_otlp_provider\` returns \`Some/None\` for the right inputs. |

## Verification

\`\`\`
cargo test --lib daemon::otlp_protocol_tests
# test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 865 filtered out; finished in 0.07s
\`\`\`

## Background

Introduced by PR #77 (commit \`a23650a\`). First exposed on main when CI finally completed end-to-end after the cache-deadlock fix in \`b94b089\`. Surfaced during the gate run on PR #78 (LiteLLM Phase 0 + 1) — unblocks that PR's CI once merged.

Plan and investigation notes: \`.scratchpad/plans/2026-04-20-otlp-test-runtime-fix.md\` and \`.scratchpad/2026-04-20-otlp-test-runtime-fix-findings.md\`.

## Test plan

- [x] \`cargo test --lib daemon::otlp_protocol_tests\` passes 6/6 locally
- [ ] CI \`just gate-pr\` passes (no longer fails on OTLP tests)
- [ ] PR #78 (LiteLLM) rebase / "Update branch" → CI goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)