### PR TITLE
feat(auth): Phase 6 PR A — /api/auth/config + MSAL.js v5 + AuthGate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,27 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Free disk space on the runner before cargo compiles 50+ integration
+      # test binaries. PR #107's run hit "No space left on device" during
+      # `cargo test --tests --no-run`; ubuntu-24.04 ships ~14 GB free and
+      # target/ for this workspace can exceed 30 GB with every integration
+      # binary linked. Removing preinstalled SDKs we don't use (dotnet,
+      # android, ghc, swift, CodeQL) reclaims ~25 GB in ~30 s.
+      # All paths below are static runner-image paths; no user input.
+      - name: Free disk space
+        run: |
+          echo "=== Before cleanup ==="
+          df -h /
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}"
+          sudo docker system prune -af || true
+          echo "=== After cleanup ==="
+          df -h /
+
       - name: Install protoc
         # Required by prost/tonic (OpenTelemetry OTLP) and chromiumoxide_cdp
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/docs/content/docs/(configuration)/entra-auth.mdx
+++ b/docs/content/docs/(configuration)/entra-auth.mdx
@@ -59,8 +59,11 @@ spa_client_id = "env:ENTRA_SPA_CLIENT_ID"
 # registration exposes, prefixed by its Application ID URI.
 spa_scopes = ["api://{web-api-guid}/api.access"]
 
-# JWKS cache lifetime. Microsoft rotates signing keys roughly weekly;
-# default 3600s is a safe middle ground. Never exceed 86400 (24h).
+# JWKS cache lifetime. Microsoft rotates signing keys roughly weekly and
+# maintains a ~24h overlap window during rollovers, so any TTL under a
+# day stays within the validated-signing-key set. 3600s is the safe
+# default; going materially longer risks caching past a rollover and
+# rejecting valid tokens signed by the new key.
 jwks_cache_ttl_secs = 3600
 
 # Clock-skew tolerance between the daemon and Microsoft. 60s default
@@ -112,7 +115,7 @@ By default the SPA uses **memory storage only** (`cacheLocation: "memoryStorage"
 
 The sign-in screen offers a **"Stay signed in on this device"** opt-in checkbox. When checked, the preference is persisted to `localStorage` under `spacebot.auth.trust_device`, and the *next* load switches MSAL to `localStorage` caching. MSAL.js v5 AES-GCM-encrypts the cache automatically, so the token blob is not plainly readable even by same-origin scripts. It *is*, however, persisted across tab close. Treat this as a user choice: "my laptop is private, keep me signed in" vs "shared kiosk, don't remember me."
 
-The string `"memoryStorage"` is canonical. Do **not** shorten to `"memory"` — MSAL types accept it but silently degrade to `sessionStorage` at runtime.
+The string `"memoryStorage"` is canonical. Do **not** shorten to `"memory"`. MSAL types accept the shorter form but silently degrade to `sessionStorage` at runtime.
 
 ## Local Development (Mock Mode)
 
@@ -164,9 +167,19 @@ The user's token might be in SPA-6 overage (more than 150 group memberships). Th
 
 For long-term observability, check the `auth_first_request_race_total` and `auth_graph_sync_failures_total{reason}` Prometheus counters.
 
+### "Sign-in is unavailable" banner appears in the UI
+
+`AuthGate` displays a red diagnostic banner when bootstrap fails in a way operators should act on. The banner text identifies the specific failure mode:
+
+- **"missing client_id, authority"** means `/api/auth/config` returned `entra_enabled: true` without the SPA-client identifiers. Check the daemon's `[api.auth.entra].spa_client_id` value and restart. Previously this class of error silently fell open to static-token UI where every API call 401'd; Phase 6 surfaces it instead.
+- **"auth-config fetch failed: 500"** means the endpoint itself errored. Check daemon logs.
+- **"auth-config fetch failed: 502"** means a reverse proxy rejected the request. `/api/auth/config` is unauthenticated; confirm the proxy isn't adding an `Authorization` header that a stale middleware branch is rejecting.
+
+The banner is `role="alert"` + `aria-live="assertive"`, so screen readers announce it immediately. Children are NOT rendered while the error state is active.
+
 ### Stuck on "Signing in…" spinner
 
-`AuthGate.useEffect` failed asynchronously without resolving. Check the browser console:
+Rare after Phase 6 (the error banner above should cover most cases), but possible if `useEffect` raced an unmount before the error setState landed. Check the browser console:
 
 - `auth-config fetch failed: 404` → the `/api/auth/config` endpoint is missing. Regenerate `packages/api-client/src/schema.d.ts` via `just typegen` and rebuild the daemon.
 - `auth-config fetch failed: 502` → reverse proxy config. `/api/auth/config` is unauthenticated; confirm the proxy isn't adding an `Authorization` header that a stale middleware branch is rejecting.

--- a/docs/content/docs/(configuration)/entra-auth.mdx
+++ b/docs/content/docs/(configuration)/entra-auth.mdx
@@ -1,0 +1,185 @@
+---
+title: Entra ID Authentication
+description: Gate the Spacebot daemon and SPA behind Microsoft Entra ID. JWT-validated API access with delegated user identity, app-only service principals, MSAL.js in the browser, and a non-secret bootstrap endpoint.
+---
+
+# Entra ID Authentication
+
+The daemon can authenticate API requests against Microsoft Entra ID instead of (or in addition to) the built-in static bearer token. When configured, the HTTP middleware validates JSON Web Tokens against the tenant's JWKS, extracts the caller's identity (`{tid}:{oid}`), and populates an `AuthContext` that flows into every handler, every policy check, and the audit log.
+
+The web UI integrates via [MSAL.js v5](https://learn.microsoft.com/en-us/entra/identity-platform/msal-js-initializing-client-applications). On boot, the SPA fetches a non-secret runtime config from `/api/auth/config`, builds a `PublicClientApplication`, and attaches fresh access tokens to every subsequent API call.
+
+## Architecture
+
+Two Microsoft Entra app registrations are required:
+
+| Registration | Purpose | Sees |
+|---|---|---|
+| **Web API** | The daemon itself. Receives and validates tokens. | `client_id`, `client_secret` (for Graph OBO), exposed scope (`api.access`), exposed app roles. |
+| **SPA** | The browser app. Requests tokens delegated for the Web API. | `client_id`, redirect URIs, `api://{web-api-guid}/api.access` scope. **No client_secret — SPAs are public clients.** |
+
+This split is required by the OAuth 2.0 authorization-code-with-PKCE flow used by modern SPAs. The browser never holds a client secret, and the daemon never accepts an identity claim that wasn't signed by Microsoft for *its* audience.
+
+The full registration schema (redirect URIs, app roles, API permissions, manifest requirements) lives at [`docs/design-docs/entra-app-registrations.md`](https://github.com/jrmatherly/spacebot/blob/main/docs/design-docs/entra-app-registrations.md).
+
+## Enabling Entra
+
+### 1. Register the two apps
+
+Follow the schema in `entra-app-registrations.md`. Key non-obvious requirements:
+
+- Web API registration **must** set `accessTokenAcceptedVersion: 2` in its app manifest. v1 tokens have a different `iss` claim shape and will be rejected.
+- SPA registration redirect URI **must** match `window.location.origin + "/"` exactly, trailing slash included. Spacebot redirects to the root path after sign-in. `/auth/callback` is not used.
+- The Web API registration exposes the scope (e.g. `api.access`) and declares the app roles (e.g. `SpacebotAdmin`, `SpacebotUser`, `SpacebotService`). The SPA registration requests the scope via **API permissions → Add permission → APIs my organization uses → your Web API → Delegated permissions → `api.access`**.
+
+### 2. Configure `config.toml`
+
+Add an `[api.auth.entra]` block. All values resolve the `env:` and `secret:` prefixes documented in [Config](/docs/config).
+
+```toml
+[api.auth.entra]
+enabled = true
+
+# Tenant where the app registrations live. GUID form, not "contoso.onmicrosoft.com".
+tenant_id = "env:ENTRA_TENANT_ID"
+
+# Expected `aud` claim value. For v2.0 tokens, this is the Web API
+# registration's client_id GUID, NOT the Application ID URI.
+audience = "env:ENTRA_API_AUDIENCE"
+
+# Required scope for delegated (user) tokens. Leave empty to skip scope
+# validation, which lets app-only (service principal) tokens through.
+allowed_scopes = ["api.access"]
+
+# SPA app registration's client_id GUID. Returned verbatim to the browser
+# via /api/auth/config. Never a secret.
+spa_client_id = "env:ENTRA_SPA_CLIENT_ID"
+
+# Scopes the SPA requests at sign-in. Must match the scope the Web API
+# registration exposes, prefixed by its Application ID URI.
+spa_scopes = ["api://{web-api-guid}/api.access"]
+
+# JWKS cache lifetime. Microsoft rotates signing keys roughly weekly;
+# default 3600s is a safe middle ground. Never exceed 86400 (24h).
+jwks_cache_ttl_secs = 3600
+
+# Clock-skew tolerance between the daemon and Microsoft. 60s default
+# handles normal NTP drift; never exceed 300.
+clock_skew_leeway_secs = 60
+
+# Per-principal group-membership cache lifetime. Phase 3's middleware
+# resolves overage claims via Graph; this sets how long the resolved list
+# is trusted. Default 300s.
+group_cache_ttl_secs = 300
+```
+
+The static `auth_token` path at `[api]` level stays available as a fallback. Exactly one auth mode is installed per request; the daemon picks at startup time based on `[api.auth.entra].enabled`.
+
+### 3. Wire Microsoft Graph (optional but recommended)
+
+Delegated `User.Read` is required for two features:
+
+- **Group overage resolution.** Entra truncates the `groups` claim at 150 entries. Users in more groups receive a `hasgroups: true` flag; the daemon must call Graph's `/me/getMemberObjects` to materialize the full list.
+- **Display photo caching** (A-19). The SPA renders a user photo or initials fallback; the daemon caches the base64 in `users.display_photo_b64` with a weekly TTL.
+
+See the Graph API permissions section of [`entra-app-registrations.md`](https://github.com/jrmatherly/spacebot/blob/main/docs/design-docs/entra-app-registrations.md) for the exact OBO permission grant. Without Graph, everything still works but overage users see 403s on team resources until their group membership drops below 150, and user avatars fall back to initials.
+
+### 4. Restart the daemon
+
+Entra config is not hot-reloadable. `spacebot restart`, then tail the logs for the Entra validator startup line. Any failure in the TOML-resolution or JWKS-fetch path fails startup rather than silently dropping back to static-token mode.
+
+Verify with:
+
+```bash
+curl http://localhost:19898/api/auth/config
+# {"entra_enabled":true,"client_id":"...","tenant_id":"...","authority":"...","scopes":["..."]}
+```
+
+## SPA Bootstrap Flow
+
+The bundled web UI implements the standard MSAL.js authorization-code-with-PKCE flow. No config is baked into the Vite build; every identifier comes from the daemon at runtime.
+
+1. SPA boots and mounts `<AuthGate>` above the app shell.
+2. `AuthGate` calls `GET /api/auth/config`. This endpoint is unprotected: both auth middleware branches allowlist the path so the SPA can reach it before any token exists.
+3. If `entra_enabled: false`, the gate renders children directly and the deployment runs in static-token mode.
+4. If `entra_enabled: true`, the gate constructs a `PublicClientApplication` with the returned identifiers, processes any redirect return via `handleRedirectPromise`, and sets the active account.
+5. A token-provider closure is wired into the generated `@spacebot/api-client`. Every subsequent API call acquires a silent token from MSAL's in-memory cache.
+6. On `InteractionRequiredAuthError` (refresh token expired, CA policy fired, etc.), the closure kicks off `acquireTokenRedirect` and suspends the caller until the redirect completes.
+
+### Cache-location behavior (A-16 / A-17)
+
+By default the SPA uses **memory storage only** (`cacheLocation: "memoryStorage"`). Tokens live in a JavaScript object that evaporates when the tab closes. This mitigates XSS token-exfiltration at the cost of forcing re-auth on every tab reload.
+
+The sign-in screen offers a **"Stay signed in on this device"** opt-in checkbox. When checked, the preference is persisted to `localStorage` under `spacebot.auth.trust_device`, and the *next* load switches MSAL to `localStorage` caching. MSAL.js v5 AES-GCM-encrypts the cache automatically, so the token blob is not plainly readable even by same-origin scripts. It *is*, however, persisted across tab close. Treat this as a user choice: "my laptop is private, keep me signed in" vs "shared kiosk, don't remember me."
+
+The string `"memoryStorage"` is canonical. Do **not** shorten to `"memory"` — MSAL types accept it but silently degrade to `sessionStorage` at runtime.
+
+## Local Development (Mock Mode)
+
+For work that doesn't need a real Entra tenant (CI, offline dev, reproducing a bug report):
+
+```toml
+[api.auth.entra]
+enabled = true
+mock_mode = true
+# The remaining fields are still required for struct population but
+# their values are not validated in mock mode.
+tenant_id = "00000000-0000-0000-0000-000000000001"
+audience = "api://test"
+spa_client_id = "11111111-1111-1111-1111-111111111111"
+spa_scopes = ["api://test/api.access"]
+```
+
+Then run the SPA with `VITE_AUTH_MOCK=1` (env var in `interface/.env.development.local`). Optional `VITE_MOCK_*` variables shape the fake principal:
+
+| Variable | Effect |
+|---|---|
+| `VITE_MOCK_TID` | Tenant ID in the fake token (default: `tenant-mock`) |
+| `VITE_MOCK_OID` | Object ID / `principal_key` suffix (default: `alice`) |
+| `VITE_MOCK_ROLES` | Comma-separated app roles (default: `SpacebotUser`) |
+
+Mock tokens are JSON-base64-encoded payloads; the daemon's `MockValidator` accepts them without a signature check. **Never set `mock_mode = true` in production.** The daemon refuses to start if `mock_mode = true` is set alongside a non-test binding.
+
+## Troubleshooting
+
+### SPA shows "Sign in" but the redirect fails
+
+Most common causes, in order of frequency:
+
+- Redirect URI mismatch. Check the Entra app registration's SPA redirect URI matches `window.location.origin + "/"` including the trailing slash. Mixed HTTP/HTTPS counts as a mismatch.
+- Conditional Access policy blocking the tenant. Check the sign-in log in Entra ID → Sign-in logs.
+- Browser extension stripping the URL fragment before MSAL can consume it. Try an incognito window.
+
+### All API calls return 401 after sign-in
+
+The token is being acquired but rejected by the daemon. Decode it at [jwt.ms](https://jwt.ms) and compare:
+
+- `aud` must equal the configured `audience` value exactly (it's the Web API client_id GUID, not the Application ID URI).
+- `iss` must be `https://login.microsoftonline.com/{tenant_id}/v2.0`. If you see `https://sts.windows.net/...`, the Web API registration's manifest is missing `accessTokenAcceptedVersion: 2`.
+- `scp` must include at least one value from `allowed_scopes` (for delegated tokens). If this is an app-only token, `scp` will be absent (that's fine), but `roles` must match the `required_role` if set.
+
+### User gets 403 Forbidden on team resources
+
+The user's token might be in SPA-6 overage (more than 150 group memberships). The backend resolves this via Graph but takes up to `group_cache_ttl_secs` to populate. Immediate workarounds: remove the user from some groups, or wait out the cache TTL (default 5 minutes).
+
+For long-term observability, check the `auth_first_request_race_total` and `auth_graph_sync_failures_total{reason}` Prometheus counters.
+
+### Stuck on "Signing in…" spinner
+
+`AuthGate.useEffect` failed asynchronously without resolving. Check the browser console:
+
+- `auth-config fetch failed: 404` → the `/api/auth/config` endpoint is missing. Regenerate `packages/api-client/src/schema.d.ts` via `just typegen` and rebuild the daemon.
+- `auth-config fetch failed: 502` → reverse proxy config. `/api/auth/config` is unauthenticated; confirm the proxy isn't adding an `Authorization` header that a stale middleware branch is rejecting.
+- `[AuthGate] init failed: ...` → MSAL error. Common: `endpoints_resolution_error` means `authority` is malformed; `interaction_in_progress` means two tabs raced the sign-in. Clear `sessionStorage` + reload.
+
+### Audit log shows every request as `legacy_static`
+
+The Entra middleware branch didn't install. Most likely `[api.auth.entra].enabled` is false or the config failed TOML resolution at startup. Re-check logs for the validator startup line. See [`docs/design-docs/entra-audit-log.md`](https://github.com/jrmatherly/spacebot/blob/main/docs/design-docs/entra-audit-log.md) for the full audit-event shape.
+
+## Related
+
+- [`entra-app-registrations.md`](https://github.com/jrmatherly/spacebot/blob/main/docs/design-docs/entra-app-registrations.md) — app registration schema, redirect URIs, API permissions, role claims
+- [`entra-backfill-strategy.md`](https://github.com/jrmatherly/spacebot/blob/main/docs/design-docs/entra-backfill-strategy.md) — no-auto-broadening policy for pre-existing resources when Entra is enabled on an established deployment
+- [`entra-audit-log.md`](https://github.com/jrmatherly/spacebot/blob/main/docs/design-docs/entra-audit-log.md) — hash-chained audit log, WORM export modes, SOC 2 CC6.6 separation-of-duties
+- [`entra-role-permission-matrix.md`](https://github.com/jrmatherly/spacebot/blob/main/docs/design-docs/entra-role-permission-matrix.md) — which app roles grant which capabilities
+- [Secret Store](/docs/secrets) — how `secret:` and `env:` references resolve in the config block above

--- a/docs/content/docs/(configuration)/meta.json
+++ b/docs/content/docs/(configuration)/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Configuration",
-  "pages": ["config", "config-reference", "secrets", "sandbox", "permissions", "litellm"]
+  "pages": ["config", "config-reference", "secrets", "sandbox", "permissions", "litellm", "entra-auth"]
 }

--- a/interface/bun.lock
+++ b/interface/bun.lock
@@ -22,7 +22,6 @@
         "@fortawesome/react-fontawesome": "^3.3.0",
         "@hookform/resolvers": "^5.2.2",
         "@lobehub/icons": "^5.4.0",
-        "@microsoft/fetch-event-source": "^2.0.1",
         "@phosphor-icons/react": "^2.1.10",
         "@react-sigma/core": "^5.0.6",
         "@spacebot/api-client": "workspace:*",
@@ -499,8 +498,6 @@
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
-
-    "@microsoft/fetch-event-source": ["@microsoft/fetch-event-source@2.0.1", "", {}, "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/interface/bun.lock
+++ b/interface/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "spacebot-interface",
       "dependencies": {
+        "@azure/msal-browser": "^5.0.0",
+        "@azure/msal-react": "^5.0.0",
         "@codemirror/language": "^6.12.3",
         "@codemirror/legacy-modes": "^6.5.2",
         "@codemirror/state": "^6.6.0",
@@ -20,6 +22,7 @@
         "@fortawesome/react-fontawesome": "^3.3.0",
         "@hookform/resolvers": "^5.2.2",
         "@lobehub/icons": "^5.4.0",
+        "@microsoft/fetch-event-source": "^2.0.1",
         "@phosphor-icons/react": "^2.1.10",
         "@react-sigma/core": "^5.0.6",
         "@spacebot/api-client": "workspace:*",
@@ -57,13 +60,19 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.2",
+        "@testing-library/dom": "^10",
+        "@testing-library/jest-dom": "^6",
+        "@testing-library/react": "^16",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.1",
+        "@vitejs/plugin-react": "^4",
+        "@vitest/ui": "^3",
+        "jsdom": "^25",
         "openapi-typescript": "^7.13.0",
         "tailwindcss": "^4.2.2",
         "typescript": "^6.0.2",
         "vite": "^8.0.8",
+        "vitest": "^3",
       },
       "optionalDependencies": {
         "@tauri-apps/api": "^2.10.1",
@@ -209,6 +218,8 @@
     },
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
     "@ant-design/colors": ["@ant-design/colors@8.0.1", "", { "dependencies": { "@ant-design/fast-color": "^3.0.0" } }, "sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ=="],
 
     "@ant-design/cssinjs": ["@ant-design/cssinjs@2.1.2", "", { "dependencies": { "@babel/runtime": "^7.11.1", "@emotion/hash": "^0.8.0", "@emotion/unitless": "^0.7.5", "@rc-component/util": "^1.4.0", "clsx": "^2.1.1", "csstype": "^3.1.3", "stylis": "^4.3.4" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-2Hy8BnCEH31xPeSLbhhB2ctCPXE2ZnASdi+KbSeS79BNbUhL9hAEe20SkUk+BR8aKTmqb6+FKFruk7w8z0VoRQ=="],
@@ -225,19 +236,45 @@
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
+    "@azure/msal-browser": ["@azure/msal-browser@5.8.0", "", { "dependencies": { "@azure/msal-common": "16.5.1" } }, "sha512-X7IZV77bN56l7sbLjkcbQJX1t3U4tgxqztDr/XFbUcUfKk+z2FavcLgKP+OYUNj0wl/pEEtV9lldW9siY8BuHQ=="],
+
+    "@azure/msal-common": ["@azure/msal-common@16.5.1", "", {}, "sha512-WS9w9SfI8SEYO7mTnxGeZ3UwQfhAVYCWglYF2/7GNx3ioHiAs2gPkl9eSwVs8cPrmiGh+zi9ai/OOKoq4cyzDw=="],
+
+    "@azure/msal-react": ["@azure/msal-react@5.3.1", "", { "peerDependencies": { "@azure/msal-browser": "^5.8.0", "react": "^16.8.0 || ^17 || ^18 || ^19.2.1" } }, "sha512-yR6BFVPyufFDg9qmtCxqpqMH3axxz/9hBL5ZO7zqMH9X9dZvjhcuAO5BL6zhS33VVPpNEZhJflU0LW1NHI2lIw=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
+    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
     "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
 
     "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
 
     "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
 
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
     "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
@@ -280,6 +317,16 @@
     "@codemirror/theme-one-dark": ["@codemirror/theme-one-dark@6.1.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/highlight": "^1.0.0" } }, "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA=="],
 
     "@codemirror/view": ["@codemirror/view@6.41.0", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.1.0", "", { "dependencies": { "@csstools/color-helpers": "^5.1.0", "@csstools/css-calc": "^2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
 
     "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
 
@@ -453,6 +500,8 @@
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
 
+    "@microsoft/fetch-event-source": ["@microsoft/fetch-event-source@2.0.1", "", {}, "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
@@ -462,6 +511,8 @@
     "@pierre/diffs": ["@pierre/diffs@1.1.15", "", { "dependencies": { "@pierre/theme": "0.0.28", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-Gj863E+aSpc0H3C4cH0fQTaF/tP9yYfhnilR7/dS72qq8thqNpR3fo3jURHRtRKz6KJJ10anxcurHP7b3ZUQkw=="],
 
     "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
+
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
     "@primer/octicons": ["@primer/octicons@19.24.1", "", { "dependencies": { "object-assign": "^4.1.1" } }, "sha512-vgtSHq8IIf3oo/HjPGj0B7NkeatSyyw5mupMjXByPI1gY6uRZ/UQdv7uSJnSOCJYQJF3lVDUwiwp9wM71MYIgA=="],
 
@@ -695,7 +746,7 @@
 
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.1", "", { "os": "android", "cpu": "arm" }, "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA=="],
 
@@ -851,7 +902,25 @@
 
     "@tauri-apps/plugin-shell": ["@tauri-apps/plugin-shell@2.3.5", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 
@@ -917,6 +986,8 @@
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -955,7 +1026,23 @@
 
     "@use-gesture/react": ["@use-gesture/react@10.3.1", "", { "dependencies": { "@use-gesture/core": "10.3.1" }, "peerDependencies": { "react": ">= 16.8.0" } }, "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g=="],
 
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vitest/ui": ["@vitest/ui@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "fflate": "^0.8.2", "flatted": "^3.3.3", "pathe": "^2.0.3", "sirv": "^3.0.1", "tinyglobby": "^0.2.14", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "vitest": "3.2.4" } }, "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
     "@xyflow/react": ["@xyflow/react@12.10.2", "", { "dependencies": { "@xyflow/system": "0.0.76", "classcat": "^5.0.3", "zustand": "^4.4.0" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ=="],
 
@@ -971,6 +1058,10 @@
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
     "antd": ["antd@6.3.5", "", { "dependencies": { "@ant-design/colors": "^8.0.1", "@ant-design/cssinjs": "^2.1.2", "@ant-design/cssinjs-utils": "^2.1.2", "@ant-design/fast-color": "^3.0.1", "@ant-design/icons": "^6.1.1", "@ant-design/react-slick": "~2.0.0", "@babel/runtime": "^7.28.4", "@rc-component/cascader": "~1.14.0", "@rc-component/checkbox": "~2.0.0", "@rc-component/collapse": "~1.2.0", "@rc-component/color-picker": "~3.1.1", "@rc-component/dialog": "~1.8.4", "@rc-component/drawer": "~1.4.2", "@rc-component/dropdown": "~1.0.2", "@rc-component/form": "~1.8.0", "@rc-component/image": "~1.8.0", "@rc-component/input": "~1.1.2", "@rc-component/input-number": "~1.6.2", "@rc-component/mentions": "~1.6.0", "@rc-component/menu": "~1.2.0", "@rc-component/motion": "^1.3.2", "@rc-component/mutate-observer": "^2.0.1", "@rc-component/notification": "~1.2.0", "@rc-component/pagination": "~1.2.0", "@rc-component/picker": "~1.9.1", "@rc-component/progress": "~1.0.2", "@rc-component/qrcode": "~1.1.1", "@rc-component/rate": "~1.0.1", "@rc-component/resize-observer": "^1.1.2", "@rc-component/segmented": "~1.3.0", "@rc-component/select": "~1.6.15", "@rc-component/slider": "~1.0.1", "@rc-component/steps": "~1.2.2", "@rc-component/switch": "~1.0.3", "@rc-component/table": "~1.9.1", "@rc-component/tabs": "~1.7.0", "@rc-component/textarea": "~1.1.2", "@rc-component/tooltip": "~1.4.0", "@rc-component/tour": "~2.3.0", "@rc-component/tree": "~1.2.4", "@rc-component/tree-select": "~1.8.0", "@rc-component/trigger": "^3.9.0", "@rc-component/upload": "~1.1.0", "@rc-component/util": "^1.10.0", "clsx": "^2.1.1", "dayjs": "^1.11.11", "scroll-into-view-if-needed": "^3.1.0", "throttle-debounce": "^5.0.2" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-8BPz9lpZWQm42PTx7yL4KxWAotVuqINiKcoYRcLtdd5BFmAcAZicVyFTnBJyRDlzGZFZeRW3foGu6jXYFnej6Q=="],
 
     "antd-style": ["antd-style@4.1.0", "", { "dependencies": { "@ant-design/cssinjs": "^2.0.0", "@babel/runtime": "^7.24.1", "@emotion/cache": "^11.11.0", "@emotion/css": "^11.11.2", "@emotion/react": "^11.11.4", "@emotion/serialize": "^1.1.3", "@emotion/utils": "^1.2.1", "use-merge-value": "^1.2.0" }, "peerDependencies": { "antd": ">=6.0.0", "react": ">=18" } }, "sha512-vnPBGg0OVlSz90KRYZhxd89aZiOImTiesF+9MQqN8jsLGZUQTjbP04X9jTdEfsztKUuMbBWg/RmB/wHTakbtMQ=="],
@@ -981,9 +1072,15 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "assign-symbols": ["assign-symbols@1.0.0", "", {}, "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw=="],
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "attr-accept": ["attr-accept@2.2.5", "", {}, "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ=="],
 
@@ -993,17 +1090,27 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.21", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA=="],
+
     "brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
 
+    "caniuse-lite": ["caniuse-lite@1.0.30001790", "", {}, "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw=="],
+
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
 
@@ -1014,6 +1121,8 @@
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "chevrotain": ["chevrotain@12.0.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "12.0.0", "@chevrotain/gast": "12.0.0", "@chevrotain/regexp-to-ast": "12.0.0", "@chevrotain/types": "12.0.0", "@chevrotain/utils": "12.0.0" } }, "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ=="],
 
@@ -1039,6 +1148,8 @@
 
     "colorette": ["colorette@1.4.0", "", {}, "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
@@ -1049,7 +1160,7 @@
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
-    "convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
 
@@ -1062,6 +1173,10 @@
     "css-color-keywords": ["css-color-keywords@1.0.0", "", {}, "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="],
 
     "css-to-react-native": ["css-to-react-native@3.2.0", "", { "dependencies": { "camelize": "^1.0.0", "css-color-keywords": "^1.0.0", "postcss-value-parser": "^4.0.2" } }, "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -1137,9 +1252,13 @@
 
     "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
 
+    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
+
     "dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
@@ -1147,7 +1266,11 @@
 
     "decode-uri-component": ["decode-uri-component@0.4.1", "", {}, "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ=="],
 
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
     "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -1159,7 +1282,13 @@
 
     "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
     "dompurify": ["dompurify@3.4.0", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.343", "", {}, "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg=="],
 
     "emoji-mart": ["emoji-mart@5.6.0", "", {}, "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow=="],
 
@@ -1171,7 +1300,15 @@
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
@@ -1180,6 +1317,8 @@
     "esast-util-from-js": ["esast-util-from-js@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "acorn": "^8.0.0", "esast-util-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw=="],
 
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -1201,6 +1340,8 @@
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
@@ -1208,6 +1349,8 @@
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "file-selector": ["file-selector@0.5.0", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-s8KNnmIDTBoD0p9uJ9uD0XY38SCeBOtj0UMXyQSLg1Ypfrfj8+dAvwsLjYQkQ2GjhVtp2HrnF5cJzMhBjfD8HA=="],
 
@@ -1217,7 +1360,11 @@
 
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
     "for-in": ["for-in@1.0.2", "", {}, "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
 
@@ -1225,15 +1372,23 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-value": ["get-value@2.0.6", "", {}, "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA=="],
 
     "giscus": ["giscus@1.6.0", "", { "dependencies": { "lit": "^3.2.1" } }, "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ=="],
 
     "goober": ["goober@2.1.18", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -1246,6 +1401,10 @@
     "graphology-utils": ["graphology-utils@2.5.2", "", { "peerDependencies": { "graphology-types": ">=0.23.0" } }, "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ=="],
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
@@ -1279,9 +1438,13 @@
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
@@ -1290,6 +1453,8 @@
     "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
 
@@ -1319,6 +1484,8 @@
 
     "is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
 
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "isbot": ["isbot@5.1.39", "", {}, "sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw=="],
 
     "isobject": ["isobject@3.0.1", "", {}, "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="],
@@ -1335,6 +1502,8 @@
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
+    "jsdom": ["jsdom@25.0.1", "", { "dependencies": { "cssstyle": "^4.1.0", "data-urls": "^5.0.0", "decimal.js": "^10.4.3", "form-data": "^4.0.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.5", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.12", "parse5": "^7.1.2", "rrweb-cssom": "^0.7.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.0.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^2.11.2" }, "optionalPeers": ["canvas"] }, "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw=="],
+
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
@@ -1342,6 +1511,8 @@
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json2mq": ["json2mq@0.2.0", "", { "dependencies": { "string-convert": "^0.2.0" } }, "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "katex": ["katex@0.16.45", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA=="],
 
@@ -1397,9 +1568,15 @@
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
     "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
 
     "lucide-react": ["lucide-react@0.469.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -1408,6 +1585,8 @@
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
@@ -1525,6 +1704,12 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
     "minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "mixin-deep": ["mixin-deep@1.3.2", "", { "dependencies": { "for-in": "^1.0.2", "is-extendable": "^1.0.1" } }, "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA=="],
@@ -1537,13 +1722,19 @@
 
     "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
 
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
+
     "numeral": ["numeral@2.0.6", "", {}, "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA=="],
+
+    "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -1579,6 +1770,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -1601,9 +1794,13 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "query-string": ["query-string@9.3.1", "", { "dependencies": { "decode-uri-component": "^0.4.1", "filter-obj": "^5.1.0", "split-on-first": "^3.0.0" } }, "sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw=="],
 
@@ -1665,6 +1862,8 @@
 
     "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
 
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -1690,6 +1889,8 @@
     "recma-parse": ["recma-parse@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "esast-util-from-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ=="],
 
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 
@@ -1747,15 +1948,21 @@
 
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
+    "rrweb-cssom": ["rrweb-cssom@0.7.1", "", {}, "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="],
+
     "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "screenfull": ["screenfull@5.2.0", "", {}, "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="],
 
     "scroll-into-view-if-needed": ["scroll-into-view-if-needed@3.1.0", "", { "dependencies": { "compute-scroll-into-view": "^3.0.2" } }, "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
 
@@ -1769,7 +1976,11 @@
 
     "shiki-stream": ["shiki-stream@0.1.4", "", { "dependencies": { "@shikijs/core": "^3.0.0" }, "peerDependencies": { "react": "^19.0.0", "solid-js": "^1.9.0", "vue": "^3.2.0" }, "optionalPeers": ["react", "solid-js", "vue"] }, "sha512-4pz6JGSDmVTTkPJ/ueixHkFAXY4ySCc+unvCaDZV7hqq/sdJZirRxgIXSuNSKgiFlGTgRR97sdu2R8K55sPsrw=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "sigma": ["sigma@3.0.2", "", { "dependencies": { "events": "^3.3.0", "graphology-utils": "^2.5.2" } }, "sha512-/BUbeOwPGruiBOm0YQQ6ZMcLIZ6tf/W+Jcm7dxZyAX0tK3WP9/sq7/NAWBxPIxVahdGjCJoGwej0Gdrv0DxlQQ=="],
+
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
@@ -1785,9 +1996,17 @@
 
     "split-string": ["split-string@3.1.0", "", { "dependencies": { "extend-shallow": "^3.0.0" } }, "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
     "string-convert": ["string-convert@0.2.1", "", {}, "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
     "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
@@ -1807,6 +2026,8 @@
 
     "swr": ["swr@2.4.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA=="],
 
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
     "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 
     "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
@@ -1821,13 +2042,31 @@
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+
     "to-vfile": ["to-vfile@8.0.0", "", { "dependencies": { "vfile": "^6.0.0" } }, "sha512-IcmH1xB5576MJc9qcfEC/m/nQCFt3fzMHz45sSlgJyTWjRbKW1HAkJpuf3DgE57YzIlZcwcBZA5ENQbBo4aLkg=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
+
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
@@ -1869,6 +2108,8 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
     "uri-js-replace": ["uri-js-replace@1.0.1", "", {}, "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g=="],
 
     "url-join": ["url-join@5.0.0", "", {}, "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="],
@@ -1897,6 +2138,10 @@
 
     "vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
 
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
     "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 
     "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
@@ -1911,7 +2156,27 @@
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
@@ -1927,7 +2192,11 @@
 
     "@antfu/install-pkg/tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
 
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "@emotion/babel-plugin/@emotion/hash": ["@emotion/hash@0.9.2", "", {}, "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="],
+
+    "@emotion/babel-plugin/convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
 
     "@emotion/babel-plugin/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
 
@@ -1981,7 +2250,13 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@testing-library/jest-dom/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
     "cosmiconfig/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
@@ -2009,6 +2284,8 @@
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "rc-menu/@rc-component/trigger": ["@rc-component/trigger@2.3.1", "", { "dependencies": { "@babel/runtime": "^7.23.2", "@rc-component/portal": "^1.1.0", "classnames": "^2.3.2", "rc-motion": "^2.0.0", "rc-resize-observer": "^1.3.1", "rc-util": "^5.44.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-ORENF39PeXTzM+gQEshuk460Z8N4+6DkjpxlpE7Q3gYy1iBpLrx0FOJz3h62ryrJZ/3zCAUIkT1Pb/8hHWpb3A=="],
@@ -2022,6 +2299,12 @@
     "shiki-stream/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
     "split-string/extend-shallow": ["extend-shallow@3.0.2", "", { "dependencies": { "assign-symbols": "^1.0.0", "is-extendable": "^1.0.1" } }, "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q=="],
+
+    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "vite-node/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
+    "vitest/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
     "@pierre/diffs/@shikijs/transformers/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 

--- a/interface/package.json
+++ b/interface/package.json
@@ -34,7 +34,6 @@
 		"@fortawesome/react-fontawesome": "^3.3.0",
 		"@hookform/resolvers": "^5.2.2",
 		"@lobehub/icons": "^5.4.0",
-		"@microsoft/fetch-event-source": "^2.0.1",
 		"@phosphor-icons/react": "^2.1.10",
 		"@react-sigma/core": "^5.0.6",
 		"@spacebot/api-client": "workspace:*",

--- a/interface/package.json
+++ b/interface/package.json
@@ -12,9 +12,13 @@
 		"dev": "vite",
 		"build": "vite build",
 		"build:dev": "vite build --mode development --sourcemap=false",
-		"preview": "vite preview"
+		"preview": "vite preview",
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"dependencies": {
+		"@azure/msal-browser": "^5.0.0",
+		"@azure/msal-react": "^5.0.0",
 		"@codemirror/language": "^6.12.3",
 		"@codemirror/legacy-modes": "^6.5.2",
 		"@codemirror/state": "^6.6.0",
@@ -30,6 +34,7 @@
 		"@fortawesome/react-fontawesome": "^3.3.0",
 		"@hookform/resolvers": "^5.2.2",
 		"@lobehub/icons": "^5.4.0",
+		"@microsoft/fetch-event-source": "^2.0.1",
 		"@phosphor-icons/react": "^2.1.10",
 		"@react-sigma/core": "^5.0.6",
 		"@spacebot/api-client": "workspace:*",
@@ -67,13 +72,19 @@
 	},
 	"devDependencies": {
 		"@tailwindcss/vite": "^4.2.2",
+		"@testing-library/dom": "^10",
+		"@testing-library/jest-dom": "^6",
+		"@testing-library/react": "^16",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
-		"@vitejs/plugin-react": "^6.0.1",
+		"@vitejs/plugin-react": "^4",
+		"@vitest/ui": "^3",
+		"jsdom": "^25",
 		"openapi-typescript": "^7.13.0",
 		"tailwindcss": "^4.2.2",
 		"typescript": "^6.0.2",
-		"vite": "^8.0.8"
+		"vite": "^8.0.8",
+		"vitest": "^3"
 	},
 	"optionalDependencies": {
 		"@tauri-apps/api": "^2.10.1",

--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { RouterProvider } from "@tanstack/react-router";
+import { AuthGate } from "@/auth/AuthGate";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ConnectionScreen } from "@/components/ConnectionScreen";
 import { LiveContextProvider } from "@/hooks/useLiveContext";
@@ -39,12 +40,22 @@ function AppShell() {
 }
 
 export function App() {
+	// Provider layering (outermost → innermost):
+	//   ErrorBoundary      — catches any descendant render/effect throw
+	//   QueryClientProvider — shared react-query state
+	//   AuthGate           — resolves MSAL state BEFORE ServerProvider boots,
+	//                        so the daemon-probe fetch inherits the token
+	//                        provider (Task 6.B.1 authedFetch reads it)
+	//   ServerProvider     — connection-state machine + heartbeat
+	//   AppShell           — ConnectionScreen | LiveContextProvider+router
 	return (
 		<ErrorBoundary>
 			<QueryClientProvider client={queryClient}>
-				<ServerProvider>
-					<AppShell />
-				</ServerProvider>
+				<AuthGate>
+					<ServerProvider>
+						<AppShell />
+					</ServerProvider>
+				</AuthGate>
 				{import.meta.env.DEV && (
 					<ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-right" />
 				)}

--- a/interface/src/auth/AuthGate.tsx
+++ b/interface/src/auth/AuthGate.tsx
@@ -1,0 +1,176 @@
+// Phase 6 Task 6.A.5 — React wrapper that gates the app shell behind
+// Entra sign-in. Exposes a four-state machine:
+//
+//   loading        — pre-init, async bootstrap in-flight
+//   entra_disabled — daemon is in static-token mode; render children directly
+//   unauthenticated — Entra configured but no active account yet
+//   authenticated  — MSAL has an account and token provider is wired
+//
+// Responsibilities:
+//   - handleRedirectPromise for return-from-Entra redirect flows
+//   - setActiveAccount so MsalProvider has a stable account throughout the tree
+//   - setAuthTokenProvider wires a silent-acquisition closure into the
+//     api-client so every outbound call can attach a Bearer token
+//   - SignInPrompt child renders the interactive sign-in button + A-17
+//     "stay signed in on this device" opt-in checkbox
+
+import {
+	InteractionRequiredAuthError,
+	type AccountInfo,
+	type PublicClientApplication,
+} from "@azure/msal-browser";
+import { MsalProvider } from "@azure/msal-react";
+import { setAuthTokenProvider } from "@spacebot/api-client/client";
+import { useEffect, useState, type ReactNode } from "react";
+import { getActiveScopes, getMsalInstance, loadAuthConfig } from "./msalConfig";
+
+const TRUST_DEVICE_KEY = "spacebot.auth.trust_device";
+
+type GateState =
+	| { kind: "loading" }
+	| { kind: "entra_disabled" }
+	| { kind: "unauthenticated"; msal: PublicClientApplication }
+	| { kind: "authenticated"; msal: PublicClientApplication };
+
+export function AuthGate({ children }: { children: ReactNode }) {
+	const [state, setState] = useState<GateState>({ kind: "loading" });
+
+	useEffect(() => {
+		let cancelled = false;
+
+		(async () => {
+			const cfg = await loadAuthConfig();
+			if (cancelled) return;
+			if (!cfg.entra_enabled) {
+				setState({ kind: "entra_disabled" });
+				return;
+			}
+			const msal = await getMsalInstance();
+			if (cancelled) return;
+			if (!msal) {
+				// entra_enabled but bootstrap fields missing → treat as disabled
+				// rather than stranding the user in an unrecoverable loading state.
+				setState({ kind: "entra_disabled" });
+				return;
+			}
+
+			const redirectResult = await msal.handleRedirectPromise();
+			if (cancelled) return;
+			const accounts = msal.getAllAccounts();
+			const active = redirectResult?.account ?? accounts[0] ?? null;
+			if (!active) {
+				setState({ kind: "unauthenticated", msal });
+				return;
+			}
+
+			msal.setActiveAccount(active);
+			setAuthTokenProvider(makeTokenProvider(msal, active));
+			setState({ kind: "authenticated", msal });
+		})().catch((err) => {
+			console.error("[AuthGate] init failed:", err);
+			if (!cancelled) {
+				// Fail open to visible UI rather than spinning forever. The
+				// consequences of mis-gating (a rendered app that the API
+				// layer will 401) are less user-hostile than a stuck spinner.
+				setState({ kind: "entra_disabled" });
+			}
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	if (state.kind === "loading") {
+		return (
+			<div data-testid="auth-gate-loading" role="status" aria-live="polite">
+				Signing in…
+			</div>
+		);
+	}
+	if (state.kind === "entra_disabled") {
+		return <>{children}</>;
+	}
+	if (state.kind === "unauthenticated") {
+		return (
+			<MsalProvider instance={state.msal}>
+				<SignInPrompt msal={state.msal} />
+			</MsalProvider>
+		);
+	}
+	return <MsalProvider instance={state.msal}>{children}</MsalProvider>;
+}
+
+/// Builds the closure that `api-client/client.ts` calls on every request
+/// that needs a Bearer token. Silent acquisition is the happy path; if
+/// MSAL says "user must interact," we kick off a full-page redirect and
+/// return a never-resolving Promise so authedFetch (Task 6.B.1) suspends
+/// gracefully until the redirect completes and the tab reloads.
+function makeTokenProvider(
+	msal: PublicClientApplication,
+	account: AccountInfo,
+): () => Promise<string | null> {
+	return async () => {
+		const scopes = await getActiveScopes();
+		if (scopes.length === 0) return null;
+		try {
+			const result = await msal.acquireTokenSilent({ scopes, account });
+			return result.accessToken;
+		} catch (err) {
+			if (err instanceof InteractionRequiredAuthError) {
+				// Full-page navigation; the returned Promise resolves after
+				// the page is gone. Using `never` ensures authedFetch's retry
+				// loop suspends rather than racing the navigation.
+				void msal.acquireTokenRedirect({ scopes, account });
+				return new Promise<string | null>(() => {
+					/* never resolves; page navigates away */
+				});
+			}
+			throw err;
+		}
+	};
+}
+
+function SignInPrompt({ msal }: { msal: PublicClientApplication }) {
+	// A-17: "Stay signed in on this device" opt-in. Default off; reading
+	// the localStorage key here (not from msalConfig) because the checkbox
+	// state must reflect the value BEFORE the next MSAL init reads it on
+	// reload.
+	const [trust, setTrust] = useState(
+		window.localStorage.getItem(TRUST_DEVICE_KEY) === "true",
+	);
+
+	const onTrustToggle = (checked: boolean) => {
+		setTrust(checked);
+		if (checked) {
+			window.localStorage.setItem(TRUST_DEVICE_KEY, "true");
+		} else {
+			window.localStorage.removeItem(TRUST_DEVICE_KEY);
+		}
+	};
+
+	const onSignIn = async () => {
+		const scopes = await getActiveScopes();
+		await msal.loginRedirect({ scopes });
+	};
+
+	return (
+		<div data-testid="auth-gate-signin" role="status">
+			<button
+				type="button"
+				onClick={onSignIn}
+				aria-label="Sign in with Microsoft Entra ID"
+			>
+				Sign in with Microsoft
+			</button>
+			<label style={{ display: "block", marginTop: "0.75rem" }}>
+				<input
+					type="checkbox"
+					checked={trust}
+					onChange={(e) => onTrustToggle(e.target.checked)}
+				/>
+				Stay signed in on this device (uses encrypted local storage)
+			</label>
+		</div>
+	);
+}

--- a/interface/src/auth/AuthGate.tsx
+++ b/interface/src/auth/AuthGate.tsx
@@ -30,7 +30,8 @@ type GateState =
 	| { kind: "loading" }
 	| { kind: "entra_disabled" }
 	| { kind: "unauthenticated"; msal: PublicClientApplication }
-	| { kind: "authenticated"; msal: PublicClientApplication };
+	| { kind: "authenticated"; msal: PublicClientApplication }
+	| { kind: "error"; message: string };
 
 export function AuthGate({ children }: { children: ReactNode }) {
 	const [state, setState] = useState<GateState>({ kind: "loading" });
@@ -45,14 +46,25 @@ export function AuthGate({ children }: { children: ReactNode }) {
 				setState({ kind: "entra_disabled" });
 				return;
 			}
-			const msal = await getMsalInstance();
+			const result = await getMsalInstance();
 			if (cancelled) return;
-			if (!msal) {
-				// entra_enabled but bootstrap fields missing → treat as disabled
-				// rather than stranding the user in an unrecoverable loading state.
-				setState({ kind: "entra_disabled" });
+			if (!result.ok) {
+				if (result.reason === "disabled") {
+					setState({ kind: "entra_disabled" });
+					return;
+				}
+				// "malformed": /api/auth/config reported entra_enabled: true
+				// but omitted one or more identifiers (client_id, authority).
+				// Surface this to operators instead of fail-open to
+				// entra_disabled, which would mask a real daemon config bug
+				// behind a UI that 401s on every API call.
+				setState({
+					kind: "error",
+					message: `Auth bootstrap failed: daemon reported entra_enabled but missing ${result.missing.join(", ")}. Check /api/auth/config response and the daemon's [api.auth.entra] config block.`,
+				});
 				return;
 			}
+			const msal = result.instance;
 
 			const redirectResult = await msal.handleRedirectPromise();
 			if (cancelled) return;
@@ -69,10 +81,17 @@ export function AuthGate({ children }: { children: ReactNode }) {
 		})().catch((err) => {
 			console.error("[AuthGate] init failed:", err);
 			if (!cancelled) {
-				// Fail open to visible UI rather than spinning forever. The
-				// consequences of mis-gating (a rendered app that the API
-				// layer will 401) are less user-hostile than a stuck spinner.
-				setState({ kind: "entra_disabled" });
+				// Surface the error to operators instead of the legacy
+				// "fail open to entra_disabled" behavior, which silently
+				// masked tenant misconfigurations behind a 401-loop UI.
+				// Keeps the SPA from rendering children that would 401 on
+				// every request; operators see a diagnostic banner.
+				const message =
+					err instanceof Error ? err.message : String(err);
+				setState({
+					kind: "error",
+					message: `Auth bootstrap failed: ${message}. Check the browser console and daemon logs.`,
+				});
 			}
 		});
 
@@ -85,6 +104,29 @@ export function AuthGate({ children }: { children: ReactNode }) {
 		return (
 			<div data-testid="auth-gate-loading" role="status" aria-live="polite">
 				Signing in…
+			</div>
+		);
+	}
+	if (state.kind === "error") {
+		return (
+			<div
+				data-testid="auth-gate-error"
+				role="alert"
+				aria-live="assertive"
+				style={{
+					padding: "1.5rem",
+					margin: "2rem auto",
+					maxWidth: "600px",
+					border: "1px solid var(--color-danger, #dc2626)",
+					borderRadius: "0.5rem",
+					background: "var(--color-danger-bg, #fef2f2)",
+					color: "var(--color-danger-fg, #991b1b)",
+				}}
+			>
+				<h2 style={{ margin: "0 0 0.75rem 0" }}>
+					Sign-in is unavailable
+				</h2>
+				<p style={{ margin: 0 }}>{state.message}</p>
 			</div>
 		);
 	}

--- a/interface/src/auth/__tests__/AuthGate.test.tsx
+++ b/interface/src/auth/__tests__/AuthGate.test.tsx
@@ -15,9 +15,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // mocked implementations during module initialization. `entra_disabled`
 // is the default return to keep tests minimal; individual tests override
 // via `vi.mocked(...)` when they need authenticated/unauthenticated shape.
+// getMsalInstance returns a discriminated `MsalInstanceResult` as of
+// PR #107 review I5 remediation; the default `{ok: false, reason: "disabled"}`
+// matches the `entra_enabled: false` config branch.
 vi.mock("../msalConfig", () => ({
 	loadAuthConfig: vi.fn(async () => ({ entra_enabled: false })),
-	getMsalInstance: vi.fn(async () => null),
+	getMsalInstance: vi.fn(async () => ({ ok: false, reason: "disabled" })),
 	getActiveScopes: vi.fn(async () => []),
 }));
 
@@ -33,11 +36,21 @@ vi.mock("@spacebot/api-client/client", async (importOriginal) => {
 	};
 });
 
+import * as msalConfig from "../msalConfig";
 import { AuthGate } from "../AuthGate";
 
 describe("AuthGate", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// Restore the default `entra_disabled` shape after each test since
+		// individual tests override via `vi.mocked(...).mockResolvedValueOnce`.
+		vi.mocked(msalConfig.loadAuthConfig).mockResolvedValue({
+			entra_enabled: false,
+		});
+		vi.mocked(msalConfig.getMsalInstance).mockResolvedValue({
+			ok: false,
+			reason: "disabled",
+		});
 	});
 
 	it("renders children when entra is disabled", async () => {
@@ -67,5 +80,57 @@ describe("AuthGate", () => {
 		await waitFor(() => {
 			expect(screen.getByText("child-content")).toBeInTheDocument();
 		});
+	});
+
+	/// PR #107 review I4/I5 remediation: when /api/auth/config reports
+	/// `entra_enabled: true` but omits identifiers, AuthGate renders an
+	/// operator-visible error banner instead of fail-open to
+	/// `entra_disabled` (which previously masked daemon config bugs
+	/// behind a 401-loop UI).
+	it("renders an error banner when entra is configured but malformed", async () => {
+		vi.mocked(msalConfig.loadAuthConfig).mockResolvedValueOnce({
+			entra_enabled: true,
+			client_id: undefined,
+			authority: undefined,
+		});
+		vi.mocked(msalConfig.getMsalInstance).mockResolvedValueOnce({
+			ok: false,
+			reason: "malformed",
+			missing: ["client_id", "authority"],
+		});
+		render(
+			<AuthGate>
+				<div>child-content</div>
+			</AuthGate>,
+		);
+		const banner = await screen.findByTestId("auth-gate-error");
+		expect(banner).toBeInTheDocument();
+		expect(banner).toHaveTextContent(/client_id/);
+		expect(banner).toHaveTextContent(/authority/);
+		// Children MUST NOT render when the error state is active — an
+		// app that renders while Entra is broken will 401 on every API
+		// call.
+		expect(screen.queryByText("child-content")).not.toBeInTheDocument();
+	});
+
+	/// PR #107 review I4 remediation: loadAuthConfig failure (e.g., 500
+	/// from /api/auth/config, or a network error) now surfaces as a
+	/// diagnostic banner, not a stuck spinner or a silent fail-open.
+	it("renders an error banner when loadAuthConfig throws", async () => {
+		vi.mocked(msalConfig.loadAuthConfig).mockRejectedValueOnce(
+			new Error("auth-config fetch failed: 500 Internal Server Error"),
+		);
+		// Silence the expected console.error from AuthGate's catch.
+		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		render(
+			<AuthGate>
+				<div>child-content</div>
+			</AuthGate>,
+		);
+		const banner = await screen.findByTestId("auth-gate-error");
+		expect(banner).toBeInTheDocument();
+		expect(banner).toHaveTextContent(/500/);
+		expect(screen.queryByText("child-content")).not.toBeInTheDocument();
+		errSpy.mockRestore();
 	});
 });

--- a/interface/src/auth/__tests__/AuthGate.test.tsx
+++ b/interface/src/auth/__tests__/AuthGate.test.tsx
@@ -1,0 +1,71 @@
+// Phase 6 Task 6.A.5 — AuthGate state machine tests.
+//
+// Covers the two happy-path branches of the gate:
+//   1. entra_disabled → children render directly (static-token deployments)
+//   2. loading → spinner visible before async init resolves
+//
+// The unauthenticated + authenticated branches are exercised by
+// Task 6.C.5's mockMsal-backed integration tests; at this stage we only
+// assert the pre-MSAL states because msalConfig is mocked here.
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock msalConfig before importing AuthGate so the component sees the
+// mocked implementations during module initialization. `entra_disabled`
+// is the default return to keep tests minimal; individual tests override
+// via `vi.mocked(...)` when they need authenticated/unauthenticated shape.
+vi.mock("../msalConfig", () => ({
+	loadAuthConfig: vi.fn(async () => ({ entra_enabled: false })),
+	getMsalInstance: vi.fn(async () => null),
+	getActiveScopes: vi.fn(async () => []),
+}));
+
+// setAuthTokenProvider is called by AuthGate when a user authenticates.
+// Mock it so tests don't mutate module-global state in the real client.
+vi.mock("@spacebot/api-client/client", async (importOriginal) => {
+	const actual = await importOriginal<
+		typeof import("@spacebot/api-client/client")
+	>();
+	return {
+		...actual,
+		setAuthTokenProvider: vi.fn(),
+	};
+});
+
+import { AuthGate } from "../AuthGate";
+
+describe("AuthGate", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders children when entra is disabled", async () => {
+		render(
+			<AuthGate>
+				<div>child-content</div>
+			</AuthGate>,
+		);
+		await waitFor(() => {
+			expect(screen.getByText("child-content")).toBeInTheDocument();
+		});
+	});
+
+	it("shows loading spinner while initializing", async () => {
+		render(
+			<AuthGate>
+				<div>child-content</div>
+			</AuthGate>,
+		);
+		// Before the useEffect async load resolves, the loading state is
+		// in the DOM. queryByTestId (not getByTestId) so the assertion
+		// semantics are "present", not "throws if absent".
+		expect(screen.queryByTestId("auth-gate-loading")).toBeInTheDocument();
+		// waitFor the async state update so useEffect's setState lands
+		// inside the test scope — silences React's `act(...)` warning about
+		// unwrapped state updates during teardown.
+		await waitFor(() => {
+			expect(screen.getByText("child-content")).toBeInTheDocument();
+		});
+	});
+});

--- a/interface/src/auth/__tests__/authTokenProvider.test.ts
+++ b/interface/src/auth/__tests__/authTokenProvider.test.ts
@@ -1,0 +1,78 @@
+// Phase 6 PR #107 review I6 remediation — tests for the
+// `setAuthTokenProvider` / `getAuthToken` primitives in
+// `@spacebot/api-client/client`.
+//
+// The primitives ship as a module-level closure slot fed by AuthGate
+// (Task 6.A.5). Placed here (not in packages/api-client/) to reuse the
+// vitest infrastructure Task 6.A.3 installed in interface/; the tests
+// import via the workspace-symlinked @spacebot/api-client entry point,
+// so they exercise the real module state.
+//
+// Covers four states the behavior can be in:
+//   1. unset → returns null
+//   2. set, provider returns a token → returns the token
+//   3. set, provider returns null → returns null
+//   4. set, provider throws → logs + returns null (not rethrown)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	getAuthToken,
+	setAuthTokenProvider,
+} from "@spacebot/api-client/client";
+
+describe("authTokenProvider primitives", () => {
+	beforeEach(() => {
+		// Reset the module-global slot so each test starts from a known
+		// state. The setter accepts null to clear, matching its documented
+		// contract.
+		setAuthTokenProvider(null);
+	});
+
+	afterEach(() => {
+		setAuthTokenProvider(null);
+	});
+
+	it("returns null when no provider is set", async () => {
+		const token = await getAuthToken();
+		expect(token).toBeNull();
+	});
+
+	it("returns the token the provider yields", async () => {
+		setAuthTokenProvider(async () => "bearer-token-abc");
+		const token = await getAuthToken();
+		expect(token).toBe("bearer-token-abc");
+	});
+
+	it("returns null (not an error) when the provider yields null", async () => {
+		// Scopes-empty + other "no token available" cases intentionally
+		// surface as null. getAuthToken must not coerce null→empty-string
+		// or vice versa.
+		setAuthTokenProvider(async () => null);
+		const token = await getAuthToken();
+		expect(token).toBeNull();
+	});
+
+	it("swallows provider errors and returns null", async () => {
+		// AuthGate's token-provider closure can throw on non-interaction
+		// MSAL errors (interaction errors are handled separately via
+		// acquireTokenRedirect + never-resolving promise). The contract
+		// is: callers see null, not an uncaught rejection.
+		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		setAuthTokenProvider(async () => {
+			throw new Error("msal: silent acquisition failed");
+		});
+		const token = await getAuthToken();
+		expect(token).toBeNull();
+		expect(errSpy).toHaveBeenCalled();
+		errSpy.mockRestore();
+	});
+
+	it("allows subsequent setAuthTokenProvider calls to replace the provider", async () => {
+		setAuthTokenProvider(async () => "first-token");
+		expect(await getAuthToken()).toBe("first-token");
+		setAuthTokenProvider(async () => "second-token");
+		expect(await getAuthToken()).toBe("second-token");
+		setAuthTokenProvider(null);
+		expect(await getAuthToken()).toBeNull();
+	});
+});

--- a/interface/src/auth/msalConfig.ts
+++ b/interface/src/auth/msalConfig.ts
@@ -17,7 +17,7 @@
 //     MSAL types accept the string "memory" but silently fall back to
 //     `sessionStorage` at runtime — do NOT use it.
 //   - A-17: "Trust this device" opt-in flips cache to `localStorage`
-//     (MSAL v4+ AES-GCM-encrypts the cache blob, so this is safe). Default
+//     (MSAL v5 AES-GCM-encrypts the cache blob, so this is safe). Default
 //     (checkbox unchecked) is memoryStorage, which means the user re-auths
 //     on every tab close. Acceptable XSS-mitigation trade-off per
 //     research §12 S-C4.
@@ -34,7 +34,7 @@ const TRUST_DEVICE_KEY = "spacebot.auth.trust_device";
 let cachedConfig: AuthConfigResponse | null = null;
 let cachedInstance: PublicClientApplication | null = null;
 let inflightConfig: Promise<AuthConfigResponse> | null = null;
-let inflightInstance: Promise<PublicClientApplication | null> | null = null;
+let inflightInstance: Promise<MsalInstanceResult> | null = null;
 
 /// Fetches `/api/auth/config` and caches the result for the page lifetime.
 /// Concurrent callers share one in-flight request (prevents thundering
@@ -62,20 +62,39 @@ export async function loadAuthConfig(): Promise<AuthConfigResponse> {
 	}
 }
 
+/// Discriminated result from `getMsalInstance`. Replaces an earlier
+/// `PublicClientApplication | null` return that collapsed two very
+/// different states ("Entra intentionally disabled" and "Entra
+/// configured but malformed") into the same sentinel, masking
+/// server-side config bugs from operators (I5 from the PR #107 review).
+export type MsalInstanceResult =
+	| { ok: true; instance: PublicClientApplication }
+	| { ok: false; reason: "disabled" }
+	| { ok: false; reason: "malformed"; missing: string[] };
+
 /// Returns the singleton `PublicClientApplication`, constructing it on
-/// first call. Returns `null` when Entra is not configured on the daemon
-/// (static-token deployments) — callers must branch accordingly.
+/// first call. Returns a discriminated result so callers can distinguish
+/// "Entra not configured" (fall back to static-token UX) from "Entra
+/// configured but /api/auth/config returned a payload with missing
+/// identifiers" (surface an operator-visible error banner).
 ///
-/// `await instance.initialize()` is mandatory in MSAL v4+ before any other
-/// method call; the caller receives an already-initialized instance.
-export async function getMsalInstance(): Promise<PublicClientApplication | null> {
-	if (cachedInstance) return cachedInstance;
+/// `await instance.initialize()` is mandatory in MSAL v5 before any other
+/// method call (v5 made this stricter than the v4 soft warning); the
+/// caller receives an already-initialized instance.
+export async function getMsalInstance(): Promise<MsalInstanceResult> {
+	if (cachedInstance) return { ok: true, instance: cachedInstance };
 	if (inflightInstance) return inflightInstance;
 
-	inflightInstance = (async () => {
+	inflightInstance = (async (): Promise<MsalInstanceResult> => {
 		const cfg = await loadAuthConfig();
-		if (!cfg.entra_enabled || !cfg.client_id || !cfg.authority) {
-			return null;
+		if (!cfg.entra_enabled) {
+			return { ok: false, reason: "disabled" };
+		}
+		const missing: string[] = [];
+		if (!cfg.client_id) missing.push("client_id");
+		if (!cfg.authority) missing.push("authority");
+		if (missing.length > 0) {
+			return { ok: false, reason: "malformed", missing };
 		}
 
 		// Mock mode for local dev / CI. `mockMsal.ts` ships in Task 6.C.5;
@@ -88,21 +107,26 @@ export async function getMsalInstance(): Promise<PublicClientApplication | null>
 		// Task 6.C.5's API shape up-stack. Error narrowing happens at
 		// runtime in Task 6.C.5's tests.
 		if (import.meta.env.VITE_AUTH_MOCK === "1") {
+			// TODO(6.C.5): remove @ts-expect-error once ./mockMsal exists.
 			// @ts-expect-error Task 6.C.5 creates ./mockMsal; guarded by runtime env flag
 			const mod = await import(/* @vite-ignore */ "./mockMsal");
 			cachedInstance = (await mod.getMockMsalInstance(
 				cfg,
 			)) as unknown as PublicClientApplication;
-			return cachedInstance;
+			return { ok: true, instance: cachedInstance };
 		}
 
 		const trustThisDevice =
 			window.localStorage.getItem(TRUST_DEVICE_KEY) === "true";
 
+		// Safe non-null assertions: the `missing` check above guarantees
+		// both fields are non-null/non-empty. TypeScript's control-flow
+		// narrowing does not span the `missing.push()` pattern, so the
+		// assertion is explicit here.
 		const msalConfig: Configuration = {
 			auth: {
-				clientId: cfg.client_id,
-				authority: cfg.authority,
+				clientId: cfg.client_id as string,
+				authority: cfg.authority as string,
 				// F18 (Task 6.A.6 implementation): use the SPA root as the
 				// redirect URI. The plan's `/auth/callback` assumed a dedicated
 				// route, but the TanStack router does not declare one and MSAL's
@@ -134,7 +158,7 @@ export async function getMsalInstance(): Promise<PublicClientApplication | null>
 		const instance = new PublicClientApplication(msalConfig);
 		await instance.initialize();
 		cachedInstance = instance;
-		return instance;
+		return { ok: true, instance };
 	})();
 
 	try {

--- a/interface/src/auth/msalConfig.ts
+++ b/interface/src/auth/msalConfig.ts
@@ -103,7 +103,15 @@ export async function getMsalInstance(): Promise<PublicClientApplication | null>
 			auth: {
 				clientId: cfg.client_id,
 				authority: cfg.authority,
-				redirectUri: `${window.location.origin}/auth/callback`,
+				// F18 (Task 6.A.6 implementation): use the SPA root as the
+				// redirect URI. The plan's `/auth/callback` assumed a dedicated
+				// route, but the TanStack router does not declare one and MSAL's
+				// handleRedirectPromise runs ABOVE RouterProvider in the tree
+				// anyway — by the time the router mounts the URL fragment is
+				// already consumed. Using `/` avoids a "no route matches"
+				// flash on redirect return. Task 6.A.7 can add a pushState
+				// cleanup to restore deep-links via state.redirectStartPage.
+				redirectUri: `${window.location.origin}/`,
 				postLogoutRedirectUri: `${window.location.origin}/`,
 			},
 			cache: {

--- a/interface/src/auth/msalConfig.ts
+++ b/interface/src/auth/msalConfig.ts
@@ -1,0 +1,159 @@
+// Phase 6 Task 6.A.4 — MSAL.js v5 loader + `PublicClientApplication` factory.
+//
+// Flow at SPA boot:
+//   1. `loadAuthConfig()` fetches `/api/auth/config` (unprotected — no bearer
+//      token required; see src/api/auth_config.rs). Response is cached in a
+//      module-level closure for the tab lifetime.
+//   2. `getMsalInstance()` constructs a `PublicClientApplication` using the
+//      fetched identifiers. Also cached; subsequent calls return the same
+//      instance so every consumer (AuthGate, authedFetch, UserMenu) works
+//      against one MSAL state.
+//   3. If `entra_enabled` is `false` or the bootstrap fields are missing,
+//      `getMsalInstance()` returns `null` so callers can branch to static-
+//      token mode without null-pointer surprises.
+//
+// Amendments applied:
+//   - A-16: `cacheLocation: "memoryStorage"` is the canonical default.
+//     MSAL types accept the string "memory" but silently fall back to
+//     `sessionStorage` at runtime — do NOT use it.
+//   - A-17: "Trust this device" opt-in flips cache to `localStorage`
+//     (MSAL v4+ AES-GCM-encrypts the cache blob, so this is safe). Default
+//     (checkbox unchecked) is memoryStorage, which means the user re-auths
+//     on every tab close. Acceptable XSS-mitigation trade-off per
+//     research §12 S-C4.
+
+import { PublicClientApplication, type Configuration } from "@azure/msal-browser";
+import { getApiBase } from "@spacebot/api-client/client";
+import type { AuthConfigResponse } from "@spacebot/api-client/types";
+
+/// localStorage key read by `getMsalInstance()` to decide between
+/// `memoryStorage` (default) and `localStorage` caching. Written by the
+/// sign-in UI's "stay signed in on this device" checkbox (Task 6.A.6).
+const TRUST_DEVICE_KEY = "spacebot.auth.trust_device";
+
+let cachedConfig: AuthConfigResponse | null = null;
+let cachedInstance: PublicClientApplication | null = null;
+let inflightConfig: Promise<AuthConfigResponse> | null = null;
+let inflightInstance: Promise<PublicClientApplication | null> | null = null;
+
+/// Fetches `/api/auth/config` and caches the result for the page lifetime.
+/// Concurrent callers share one in-flight request (prevents thundering
+/// herd on app boot when multiple components race to know the config).
+export async function loadAuthConfig(): Promise<AuthConfigResponse> {
+	if (cachedConfig) return cachedConfig;
+	if (inflightConfig) return inflightConfig;
+
+	inflightConfig = (async () => {
+		const res = await fetch(`${getApiBase()}/auth/config`);
+		if (!res.ok) {
+			throw new Error(
+				`auth-config fetch failed: ${res.status} ${res.statusText}`,
+			);
+		}
+		const data = (await res.json()) as AuthConfigResponse;
+		cachedConfig = data;
+		return data;
+	})();
+
+	try {
+		return await inflightConfig;
+	} finally {
+		inflightConfig = null;
+	}
+}
+
+/// Returns the singleton `PublicClientApplication`, constructing it on
+/// first call. Returns `null` when Entra is not configured on the daemon
+/// (static-token deployments) — callers must branch accordingly.
+///
+/// `await instance.initialize()` is mandatory in MSAL v4+ before any other
+/// method call; the caller receives an already-initialized instance.
+export async function getMsalInstance(): Promise<PublicClientApplication | null> {
+	if (cachedInstance) return cachedInstance;
+	if (inflightInstance) return inflightInstance;
+
+	inflightInstance = (async () => {
+		const cfg = await loadAuthConfig();
+		if (!cfg.entra_enabled || !cfg.client_id || !cfg.authority) {
+			return null;
+		}
+
+		// Mock mode for local dev / CI. `mockMsal.ts` ships in Task 6.C.5;
+		// this branch only fires when VITE_AUTH_MOCK=1, which is set
+		// explicitly in dev env vars and never in production builds.
+		//
+		// The dynamic-import target is intentionally typed as `any` via
+		// the ts-expect-error pragma: `./mockMsal` does not exist yet, and
+		// writing a fallback .d.ts stub solely to satisfy tsc would leak
+		// Task 6.C.5's API shape up-stack. Error narrowing happens at
+		// runtime in Task 6.C.5's tests.
+		if (import.meta.env.VITE_AUTH_MOCK === "1") {
+			// @ts-expect-error Task 6.C.5 creates ./mockMsal; guarded by runtime env flag
+			const mod = await import(/* @vite-ignore */ "./mockMsal");
+			cachedInstance = (await mod.getMockMsalInstance(
+				cfg,
+			)) as unknown as PublicClientApplication;
+			return cachedInstance;
+		}
+
+		const trustThisDevice =
+			window.localStorage.getItem(TRUST_DEVICE_KEY) === "true";
+
+		const msalConfig: Configuration = {
+			auth: {
+				clientId: cfg.client_id,
+				authority: cfg.authority,
+				redirectUri: `${window.location.origin}/auth/callback`,
+				postLogoutRedirectUri: `${window.location.origin}/`,
+			},
+			cache: {
+				// A-16: canonical string is `memoryStorage`. Do not shorten to
+				// `memory` — that typechecks but degrades to sessionStorage
+				// silently at runtime.
+				cacheLocation: trustThisDevice ? "localStorage" : "memoryStorage",
+				// MSAL v5 dropped `storeAuthStateInCookie` from CacheOptions
+				// (it was a v2/v3 IE-compat legacy path). Nothing to set here.
+			},
+			system: {
+				// MSAL v5 renamed `allowNativeBroker` → `allowPlatformBroker`.
+				// Keep it disabled: WAM/MacBroker adds a UX divergence we
+				// don't want until we've shipped an explicit native-broker
+				// test matrix.
+				allowPlatformBroker: false,
+			},
+		};
+
+		const instance = new PublicClientApplication(msalConfig);
+		await instance.initialize();
+		cachedInstance = instance;
+		return instance;
+	})();
+
+	try {
+		return await inflightInstance;
+	} finally {
+		inflightInstance = null;
+	}
+}
+
+/// Returns the delegated scopes the SPA should request at sign-in (from the
+/// daemon's bootstrap config). Empty array when Entra is disabled or
+/// `scopes` is missing; callers should treat empty-scopes as "skip MSAL
+/// flows" rather than requesting `[]` which MSAL rejects.
+export async function getActiveScopes(): Promise<string[]> {
+	const cfg = await loadAuthConfig();
+	return cfg.scopes ?? [];
+}
+
+/// Test-only reset. Drops cached config + instance + in-flight promises
+/// so a subsequent `loadAuthConfig()` / `getMsalInstance()` re-fetches.
+/// Exported for vitest teardown in Tasks 6.A.5 / 6.C.1.
+///
+/// NOT exported from `interface/src/auth/index.ts` (when created) — this
+/// is deliberately off the happy-path import surface.
+export function __resetMsalCaches(): void {
+	cachedConfig = null;
+	cachedInstance = null;
+	inflightConfig = null;
+	inflightInstance = null;
+}

--- a/interface/src/test/setup.ts
+++ b/interface/src/test/setup.ts
@@ -1,0 +1,5 @@
+// Vitest setup — runs once per test worker before any test file.
+// Registers `@testing-library/jest-dom` matchers onto vitest's `expect`,
+// so assertions like `expect(el).toBeInTheDocument()` resolve.
+
+import "@testing-library/jest-dom/vitest";

--- a/interface/vitest.config.ts
+++ b/interface/vitest.config.ts
@@ -1,0 +1,16 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+// Vitest config for Phase 6 SPA auth tests. Kept minimal: jsdom environment
+// for DOM-backed hooks (useMsal, useMe), globals: true so vitest `expect`
+// resolves without per-file imports, setup file wires
+// `@testing-library/jest-dom` matchers.
+export default defineConfig({
+	plugins: [react()],
+	test: {
+		environment: "jsdom",
+		globals: true,
+		setupFiles: ["./src/test/setup.ts"],
+	},
+});

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -32,6 +32,43 @@ export function getApiBase(): string {
 	return BASE_PATH + "/api";
 }
 
+/**
+ * Auth token provider closure. Phase 6 Task 6.A.5 wires this slot from
+ * `AuthGate.tsx`: on successful MSAL sign-in, AuthGate calls
+ * `setAuthTokenProvider(async () => msal.acquireTokenSilent(...).accessToken)`,
+ * and from that point forward every outbound API call can grab a fresh
+ * Bearer token via `getAuthToken()`.
+ *
+ * The actual `authedFetch()` wrapper + per-call-site migration lands in
+ * Task 6.B.1 (PR B). This module-level slot is introduced in PR A so
+ * AuthGate's wiring has a real consumer and so PR B's rollout is a pure
+ * mechanical edit with no API-surface churn.
+ *
+ * When unset (static-token mode, pre-sign-in, or deployments without
+ * Entra), `getAuthToken()` returns `null` and callers fall back to their
+ * existing header (none, or a server-side-resolved static token).
+ */
+type AuthTokenProvider = () => Promise<string | null>;
+let _authTokenProvider: AuthTokenProvider | null = null;
+
+export function setAuthTokenProvider(provider: AuthTokenProvider | null): void {
+	_authTokenProvider = provider;
+}
+
+export async function getAuthToken(): Promise<string | null> {
+	if (!_authTokenProvider) return null;
+	try {
+		return await _authTokenProvider();
+	} catch (err) {
+		// Log-but-don't-throw: the caller should behave as if no token is
+		// available rather than propagating auth-subsystem errors up into
+		// arbitrary API request code paths. authedFetch (Task 6.B.1) will
+		// layer retry/interactive-fallback on top of this primitive.
+		console.error("[api-client] auth token provider threw:", err);
+		return null;
+	}
+}
+
 import type * as Types from "./types";
 
 // Re-export commonly used types from schema for backward compatibility

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -777,6 +777,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * `GET /api/auth/config` — unprotected endpoint that returns SPA bootstrap
+         *     values. Reaches the handler without an `Authorization` header because
+         *     both auth middlewares include this path in their allowlist (see module
+         *     doc comment).
+         */
+        get: operations["get_auth_config"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/bindings": {
         parameters: {
             query?: never;
@@ -2641,6 +2663,22 @@ export interface components {
             original_filename: string;
             /** Format: int64 */
             size_bytes: number;
+        };
+        /**
+         * @description SPA-safe MSAL bootstrap payload. Never contains secrets — the three
+         *     identifiers below are listed in the Entra tenant's OIDC discovery
+         *     document and the scope string is a public contract.
+         */
+        AuthConfigResponse: {
+            authority?: string | null;
+            client_id?: string | null;
+            /**
+             * @description `true` when the daemon has a resolved `[api.auth.entra]` config. The
+             *     SPA branches on this: `false` means fall back to static-token mode.
+             */
+            entra_enabled: boolean;
+            scopes?: string[] | null;
+            tenant_id?: string | null;
         };
         AuthorizedKeyRequest: {
             public_key: string;
@@ -6632,6 +6670,26 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    get_auth_config: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description MSAL bootstrap config */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthConfigResponse"];
+                };
             };
         };
     };

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -12,6 +12,15 @@ export type InstanceOverviewResponse =
   components["schemas"]["InstanceOverviewResponse"];
 
 // =============================================================================
+// Auth Types (Phase 6)
+// =============================================================================
+
+/// SPA bootstrap payload returned by the unprotected `GET /api/auth/config`.
+/// `entra_enabled: false` signals the daemon is running in static-token mode
+/// and the SPA should skip MSAL bootstrapping entirely.
+export type AuthConfigResponse = components["schemas"]["AuthConfigResponse"];
+
+// =============================================================================
 // Event/SSE Types
 // =============================================================================
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,6 +8,7 @@ mod activity;
 pub mod agents;
 mod attachments;
 mod audit;
+mod auth_config;
 mod bindings;
 mod channels;
 mod config;

--- a/src/api/auth_config.rs
+++ b/src/api/auth_config.rs
@@ -5,7 +5,7 @@
 //! `src/auth/middleware.rs` for the Entra branch and `src/api/server.rs`
 //! for the static-token branch).
 //!
-//! Payload whitelists exactly the three fields MSAL.js needs:
+//! Payload whitelists exactly the four fields MSAL.js needs:
 //!   - `client_id` — the SPA app registration (not the Web API registration)
 //!   - `tenant_id` — used to compute the v2.0 authority URL
 //!   - `authority` — pre-computed `https://login.microsoftonline.com/{tid}/v2.0`
@@ -15,12 +15,13 @@
 //! remaining fields are absent. The SPA reads that as "static-token mode"
 //! and skips MSAL bootstrapping entirely.
 
+use super::state::ApiState;
+
 use axum::Json;
 use axum::extract::State;
 use serde::Serialize;
-use std::sync::Arc;
 
-use super::state::ApiState;
+use std::sync::Arc;
 
 /// SPA-safe MSAL bootstrap payload. Never contains secrets — the three
 /// identifiers below are listed in the Entra tenant's OIDC discovery

--- a/src/api/auth_config.rs
+++ b/src/api/auth_config.rs
@@ -1,0 +1,76 @@
+//! Phase 6 Task 6.A.2 — unprotected `GET /api/auth/config` for SPA bootstrap.
+//!
+//! The browser fetches this before MSAL.js completes sign-in, so no bearer
+//! token is available yet. Two auth middlewares allowlist this path (see
+//! `src/auth/middleware.rs` for the Entra branch and `src/api/server.rs`
+//! for the static-token branch).
+//!
+//! Payload whitelists exactly the three fields MSAL.js needs:
+//!   - `client_id` — the SPA app registration (not the Web API registration)
+//!   - `tenant_id` — used to compute the v2.0 authority URL
+//!   - `authority` — pre-computed `https://login.microsoftonline.com/{tid}/v2.0`
+//!   - `scopes` — the delegated scopes the SPA requests at sign-in
+//!
+//! When Entra is not configured, `entra_enabled: false` is returned and the
+//! remaining fields are absent. The SPA reads that as "static-token mode"
+//! and skips MSAL bootstrapping entirely.
+
+use axum::Json;
+use axum::extract::State;
+use serde::Serialize;
+use std::sync::Arc;
+
+use super::state::ApiState;
+
+/// SPA-safe MSAL bootstrap payload. Never contains secrets — the three
+/// identifiers below are listed in the Entra tenant's OIDC discovery
+/// document and the scope string is a public contract.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct AuthConfigResponse {
+    /// `true` when the daemon has a resolved `[api.auth.entra]` config. The
+    /// SPA branches on this: `false` means fall back to static-token mode.
+    pub entra_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authority: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scopes: Option<Vec<String>>,
+}
+
+/// `GET /api/auth/config` — unprotected endpoint that returns SPA bootstrap
+/// values. Reaches the handler without an `Authorization` header because
+/// both auth middlewares include this path in their allowlist (see module
+/// doc comment).
+#[utoipa::path(
+    get,
+    path = "/auth/config",
+    responses((status = 200, description = "MSAL bootstrap config", body = AuthConfigResponse)),
+    tag = "auth"
+)]
+pub(super) async fn get_auth_config(
+    State(state): State<Arc<ApiState>>,
+) -> Json<AuthConfigResponse> {
+    let Some(cfg) = state.entra_auth_public_config() else {
+        return Json(AuthConfigResponse {
+            entra_enabled: false,
+            client_id: None,
+            tenant_id: None,
+            authority: None,
+            scopes: None,
+        });
+    };
+
+    Json(AuthConfigResponse {
+        entra_enabled: true,
+        client_id: Some(cfg.spa_client_id.clone()),
+        tenant_id: Some(cfg.tenant_id.clone()),
+        authority: Some(format!(
+            "https://login.microsoftonline.com/{}/v2.0",
+            cfg.tenant_id
+        )),
+        scopes: Some(cfg.spa_scopes.clone()),
+    })
+}

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -2,9 +2,9 @@
 
 use super::state::ApiState;
 use super::{
-    activity, agents, attachments, audit, bindings, channels, config, cortex, cron, factory,
-    ingest, links, mcp, memories, messaging, models, notifications, opencode_proxy, portal,
-    projects, providers, secrets, settings, skills, ssh, system, tasks, tools, usage, wiki,
+    activity, agents, attachments, audit, auth_config, bindings, channels, config, cortex, cron,
+    factory, ingest, links, mcp, memories, messaging, models, notifications, opencode_proxy,
+    portal, projects, providers, secrets, settings, skills, ssh, system, tasks, tools, usage, wiki,
     workers,
 };
 
@@ -51,6 +51,10 @@ pub fn api_router() -> OpenApiRouter<Arc<ApiState>> {
     OpenApiRouter::with_openapi(ApiDoc::openapi())
         // System routes
         .routes(routes!(system::health))
+        // Phase 6 Task 6.A.2 — unprotected SPA bootstrap endpoint.
+        // Auth bypass for this path is wired in the middleware allowlists
+        // below (static-token) and in src/auth/middleware.rs (Entra JWT).
+        .routes(routes!(auth_config::get_auth_config))
         .routes(routes!(system::idle))
         .routes(routes!(system::status))
         .routes(routes!(system::storage_status))
@@ -376,7 +380,12 @@ async fn api_auth_middleware(
     };
 
     let path = request.uri().path();
-    if path == "/api/health" || path == "/health" {
+    // Phase 6 Task 6.A.2: `/api/auth/config` is the SPA's bootstrap endpoint.
+    // The browser fetches it before MSAL has a token, so it must bypass the
+    // bearer-token check. Payload is whitelisted to non-secret identifiers
+    // (see src/api/auth_config.rs). Keep this in sync with the companion
+    // bypass in src/auth/middleware.rs.
+    if path == "/api/health" || path == "/health" || path == "/api/auth/config" {
         return next.run(request).await;
     }
 

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -379,13 +379,11 @@ async fn api_auth_middleware(
         return next.run(request).await;
     };
 
-    let path = request.uri().path();
-    // Phase 6 Task 6.A.2: `/api/auth/config` is the SPA's bootstrap endpoint.
-    // The browser fetches it before MSAL has a token, so it must bypass the
-    // bearer-token check. Payload is whitelisted to non-secret identifiers
-    // (see src/api/auth_config.rs). Keep this in sync with the companion
-    // bypass in src/auth/middleware.rs.
-    if path == "/api/health" || path == "/health" || path == "/api/auth/config" {
+    let path = request.uri().path().to_string();
+    // Auth-bypass allowlist is centralized in `crate::auth::bypass` so both
+    // this branch and the Entra JWT branch (src/auth/middleware.rs) consult
+    // a single list. Adding a fourth entry requires editing one place.
+    if crate::auth::bypass::is_auth_bypassed(&path) {
         return next.run(request).await;
     }
 

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -481,6 +481,34 @@ impl ApiState {
     }
 
     /// Test-only constructor mirroring [`Self::new_test_state_with_mock_entra`]
+    /// but additionally installing a populated
+    /// [`crate::auth::EntraAuthConfig`] via [`Self::set_entra_auth_config`].
+    /// Exists so Phase 6 `/api/auth/config` tests can exercise the
+    /// `entra_auth_public_config()` populated path (C1/C2 from the PR #107
+    /// review: the plain `new_test_state_with_mock_entra` leaves
+    /// `entra_config` as `None`, so the handler always branches to the
+    /// "entra_enabled: false" leg and leak-scrub checks pass vacuously).
+    ///
+    /// The config values are test-recognizable sentinels so assertions can
+    /// pin the exact shape the handler projects. `mock_mode: false` because
+    /// production-refusal of mock-mode is enforced at daemon startup, not
+    /// here; individual tests exercising mock-mode-startup-refusal handle
+    /// that separately.
+    #[doc(hidden)]
+    pub async fn new_test_state_with_mock_entra_configured() -> (Arc<Self>, sqlx::SqlitePool) {
+        let (state, pool) = Self::new_test_state_with_mock_entra().await;
+        let cfg = crate::auth::EntraAuthConfig::new_for_test(
+            Arc::from("tenant-11111111-1111-1111-1111-111111111111"),
+            Arc::from("api://web-test"),
+            vec!["api.access".to_string()],
+            Arc::from("spa-22222222-2222-2222-2222-222222222222"),
+            vec![Arc::from("api://web-test/api.access")],
+        );
+        state.set_entra_auth_config(cfg);
+        (state, pool)
+    }
+
+    /// Test-only constructor mirroring [`Self::new_test_state_with_mock_entra`]
     /// but WITHOUT attaching an `instance_pool`. Returns just `Arc<Self>` since
     /// there is no pool to seed. Used to exercise handler no-op fallbacks
     /// when the Phase 2 data model isn't attached (boot window / startup

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1010,6 +1010,25 @@ impl ApiState {
         self.entra_config.store(Arc::new(Some(cfg)));
     }
 
+    /// Returns a SPA-safe projection of the current Entra config, or `None`
+    /// when Entra is not configured (static-token deployment, the brief boot
+    /// window before `set_entra_auth_config` runs, or a mock-backed test
+    /// that doesn't wire a real config). Consumed by the unprotected
+    /// `GET /api/auth/config` handler at SPA boot (Phase 6).
+    ///
+    /// Reads from the companion `entra_config` field rather than the
+    /// `entra_auth` trait object: the `DynJwtValidator` trait exposes only
+    /// `validate_dyn`, and `EntraValidator::cfg` is private. Keeping the
+    /// accessor pointed at `entra_config` also means `MockValidator`-backed
+    /// tests without a real config return `None` correctly.
+    pub fn entra_auth_public_config(&self) -> Option<crate::auth::PublicEntraConfig> {
+        self.entra_config
+            .load()
+            .as_ref()
+            .as_ref()
+            .map(|cfg| cfg.public())
+    }
+
     /// Install the Microsoft Graph client post-construction. Called from
     /// `main.rs` after `set_entra_auth` and after the secrets store has
     /// resolved `web_api_client_secret`. Optional: deployments without

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -5,6 +5,7 @@
 //! persistence. Phase 3: Microsoft Graph client for group resolution and
 //! display-photo fetch. Authorization helpers land in Phase 4.
 
+pub mod bypass;
 pub mod config;
 pub mod context;
 pub mod errors;

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -20,7 +20,7 @@ pub mod roles;
 // library. Precedent: `tests/support/mock_entra.rs` and `ApiState::new_for_tests`.
 pub mod testing;
 
-pub use config::EntraAuthConfig;
+pub use config::{EntraAuthConfig, PublicEntraConfig};
 pub use context::{AuthContext, PrincipalType};
 pub use errors::AuthError;
 pub use jwks::EntraValidator;

--- a/src/auth/bypass.rs
+++ b/src/auth/bypass.rs
@@ -1,0 +1,81 @@
+//! Shared path-allowlist for the auth middleware branches.
+//!
+//! Two middleware implementations (`src/api/server.rs`
+//! `api_auth_middleware` for static-token deployments and
+//! `src/auth/middleware.rs` `entra_auth_middleware` for Entra JWT
+//! deployments) each run BEFORE the router dispatches. Some endpoints
+//! must reach the handler without an `Authorization` header:
+//!
+//!   - `/health` + `/api/health` — the daemon liveness probe is polled
+//!     by container orchestrators that have no bearer token.
+//!   - `/api/auth/config` (Phase 6) — the SPA's MSAL bootstrap fetch
+//!     runs before sign-in completes, so it has no token yet.
+//!
+//! Historically each middleware hand-maintained the allowlist as a
+//! local `if path == "..." || path == "..."` block. That worked for a
+//! single entry (`/health` + its `/api/` variant) but broke down when
+//! Phase 6 added `/api/auth/config`: the literal had to be copied into
+//! two places, and a future contributor adding a third entry to one
+//! branch but forgetting the other would produce a silent security
+//! asymmetry.
+//!
+//! This module centralizes the list in one place. Both middleware
+//! branches call [`is_auth_bypassed`] against the request path.
+
+/// Paths that bypass the auth middleware in both static-token and
+/// Entra-JWT deployments. Kept as a `&[&str]` so the compile-time
+/// sort/uniqueness test below can inspect it without `Vec`-allocating.
+///
+/// When adding a new entry: verify the handler it routes to is genuinely
+/// safe to expose without auth, add a regression test against BOTH
+/// middleware branches (see `tests/api_auth_middleware.rs` and the
+/// `router_level` mod in `tests/entra_jwt_middleware.rs`), and document
+/// the rationale here.
+pub(crate) const AUTH_BYPASS_PATHS: &[&str] = &["/api/auth/config", "/api/health", "/health"];
+
+/// Returns true when the request path bypasses the auth middleware.
+/// Exact-match only; prefix matching is deliberately NOT supported so a
+/// hypothetical `/api/health/leak` handler cannot inherit the bypass.
+#[inline]
+pub(crate) fn is_auth_bypassed(path: &str) -> bool {
+    AUTH_BYPASS_PATHS.contains(&path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Enforces the documented invariant that the allowlist is sorted
+    /// and unique. Adding an entry that breaks the order fails this
+    /// test, which catches the kind of drift an editor's auto-format
+    /// might introduce.
+    #[test]
+    fn allowlist_is_sorted_and_unique() {
+        for window in AUTH_BYPASS_PATHS.windows(2) {
+            assert!(
+                window[0] < window[1],
+                "AUTH_BYPASS_PATHS must be sorted ascending and unique: \
+                 found {:?} before {:?}",
+                window[0],
+                window[1],
+            );
+        }
+    }
+
+    #[test]
+    fn bypass_matches_documented_entries() {
+        assert!(is_auth_bypassed("/health"));
+        assert!(is_auth_bypassed("/api/health"));
+        assert!(is_auth_bypassed("/api/auth/config"));
+    }
+
+    #[test]
+    fn bypass_is_exact_match_only() {
+        // Prefix-matching would be a latent security hole.
+        assert!(!is_auth_bypassed("/api/auth/config/leak"));
+        assert!(!is_auth_bypassed("/api/health/status"));
+        assert!(!is_auth_bypassed("/healthcheck"));
+        assert!(!is_auth_bypassed(""));
+        assert!(!is_auth_bypassed("/"));
+    }
+}

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -5,7 +5,28 @@
 //! `TomlEntraAuthConfig`. `load.rs` resolves `secret:…` / `env:…`
 //! references and constructs this struct.
 
+use serde::Serialize;
 use std::sync::Arc;
+
+/// SPA-safe projection of [`EntraAuthConfig`]. Returned by `/api/auth/config`
+/// at SPA boot so MSAL.js can construct a `PublicClientApplication` without
+/// hard-coding tenant/client identifiers at build time.
+///
+/// Every field here is explicitly **non-secret**: tenant IDs and the SPA
+/// client ID are listed in Entra's public OIDC discovery document, and
+/// scopes are canonical strings. The Web API client ID
+/// (`EntraAuthConfig::audience`), any client secrets, and Graph
+/// credentials are deliberately NOT projected — they live on the daemon.
+///
+/// `String` (not `Arc<str>`) because the struct is constructed once per
+/// request and serialized immediately; the `Arc` sharing benefit vanishes
+/// at the `to_string()` call.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+pub struct PublicEntraConfig {
+    pub tenant_id: String,
+    pub spa_client_id: String,
+    pub spa_scopes: Vec<String>,
+}
 
 /// Resolved Entra auth config.
 #[derive(Debug, Clone)]
@@ -70,6 +91,18 @@ impl EntraAuthConfig {
             "https://login.microsoftonline.com/{}/discovery/v2.0/keys",
             self.tenant_id
         )
+    }
+
+    /// Project to a SPA-safe view. Used by `GET /api/auth/config` (Phase 6).
+    /// The projection drops every field the browser must not see: Web API
+    /// client ID (`audience`), allowed scopes, cache TTLs, mock-mode flag,
+    /// and test-only overrides.
+    pub fn public(&self) -> PublicEntraConfig {
+        PublicEntraConfig {
+            tenant_id: self.tenant_id.to_string(),
+            spa_client_id: self.spa_client_id.to_string(),
+            spa_scopes: self.spa_scopes.iter().map(|s| s.to_string()).collect(),
+        }
     }
 
     /// Integration-test constructor. Always-compiled (`#[doc(hidden)]`) so

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -6,6 +6,7 @@
 //! references and constructs this struct.
 
 use serde::Serialize;
+
 use std::sync::Arc;
 
 /// SPA-safe projection of [`EntraAuthConfig`]. Returned by `/api/auth/config`

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -22,11 +22,11 @@ pub async fn entra_auth_middleware(
     mut request: Request,
     next: Next,
 ) -> Response {
-    // Health + SPA-bootstrap bypass, matching the static-token middleware
-    // allowlist at src/api/server.rs. `/api/auth/config` is reachable before
-    // sign-in so the browser can discover Entra identifiers (Phase 6 Task 6.A.2).
     let path = request.uri().path().to_string();
-    if path == "/api/health" || path == "/health" || path == "/api/auth/config" {
+    // Auth-bypass allowlist shared with the static-token branch
+    // (src/api/server.rs `api_auth_middleware`). See `crate::auth::bypass`
+    // for the full list and the invariant (sorted, unique, exact-match only).
+    if crate::auth::bypass::is_auth_bypassed(&path) {
         return next.run(request).await;
     }
 

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -22,9 +22,11 @@ pub async fn entra_auth_middleware(
     mut request: Request,
     next: Next,
 ) -> Response {
-    // Health bypass, matching the static-token middleware.
+    // Health + SPA-bootstrap bypass, matching the static-token middleware
+    // allowlist at src/api/server.rs. `/api/auth/config` is reachable before
+    // sign-in so the browser can discover Entra identifiers (Phase 6 Task 6.A.2).
     let path = request.uri().path().to_string();
-    if path == "/api/health" || path == "/health" {
+    if path == "/api/health" || path == "/health" || path == "/api/auth/config" {
         return next.run(request).await;
     }
 

--- a/tests/api_auth_config.rs
+++ b/tests/api_auth_config.rs
@@ -1,36 +1,51 @@
-//! Phase 6 Task 6.A.1 — TDD red phase for `GET /api/auth/config`.
+//! Phase 6 Task 6.A.1 — `GET /api/auth/config` contract tests.
 //!
-//! `/api/auth/config` is unprotected (the SPA fetches it before MSAL completes
-//! login, so no bearer token is available yet). These tests assert:
+//! Asserts:
 //!   1. the endpoint is reachable without an `Authorization` header,
-//!   2. the response body never contains secret-adjacent substrings,
-//!   3. when Entra is not configured, the response reports `entra_enabled: false`
-//!      and omits client_id / tenant_id / authority / scopes.
-//!
-//! Until Task 6.A.2 lands the handler + the middleware allowlist edit, these
-//! tests will fail at runtime (404 for the unprotected assertion, or 401 for
-//! the "bypass" assertion). That's the intentional red-phase state.
+//!   2. when Entra IS configured, the response body never contains
+//!      secret-adjacent substrings (C1 remediation: previously this ran
+//!      against a state with no populated `EntraAuthConfig`, so the check
+//!      was vacuously true against an empty payload),
+//!   3. when Entra IS configured, the response body contains exactly the
+//!      four non-secret identifiers the SPA needs and none of the other
+//!      `EntraAuthConfig` fields (C2 populated-path coverage),
+//!   4. when Entra is NOT configured, the response reports
+//!      `entra_enabled: false` and omits the identifier fields.
 
-// F1/F2/F3 corrections (2026-04-22 pre-code audit):
-//  - Test helper is `build_test_router_entra` (NOT `build_test_router_with_auth`)
-//    re-exported at `spacebot::api::test_support` (definition at
-//    `src/api/server.rs:663`, re-export at `src/api.rs:45`).
-//  - `new_test_state_with_mock_entra` is an associated fn on `ApiState`
-//    (src/api/state.rs:455), not a free function in `spacebot::api::state`.
-//  - `new_for_tests(None::<String>)` makes the `Option<String>` type explicit
-//    (signature at src/api/state.rs:432).
+// F1/F2/F3 corrections (2026-04-22 pre-code audit): helpers are
+// `build_test_router_entra` (re-exported at `spacebot::api::test_support`),
+// `ApiState::new_test_state_with_mock_entra[_configured]` (associated
+// functions on `ApiState`, not free functions in `spacebot::api::state`),
+// and `new_for_tests(None::<String>)` makes the `Option<String>` type
+// explicit. Numeric line citations removed per the PR #107 review (I7):
+// symbol names are stable, line numbers drift.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt as _;
+use serde::Deserialize;
 use spacebot::api::ApiState;
 use spacebot::api::test_support::build_test_router_entra;
 use tower::ServiceExt as _;
 
-#[tokio::test]
-async fn config_endpoint_is_unprotected() {
-    let (state, _pool) = ApiState::new_test_state_with_mock_entra().await;
-    let app = build_test_router_entra(state);
+/// Mirror of the handler response shape so tests can assert on parsed
+/// fields rather than substring-matching JSON text. Decoupled from the
+/// handler's `AuthConfigResponse` (which is `pub(super)`) so integration
+/// tests in `tests/*.rs` compile without widening that visibility.
+#[derive(Deserialize)]
+struct ParsedConfig {
+    entra_enabled: bool,
+    #[serde(default)]
+    client_id: Option<String>,
+    #[serde(default)]
+    tenant_id: Option<String>,
+    #[serde(default)]
+    authority: Option<String>,
+    #[serde(default)]
+    scopes: Option<Vec<String>>,
+}
+
+async fn get_config(app: axum::Router) -> (StatusCode, String, ParsedConfig) {
     let res = app
         .oneshot(
             Request::builder()
@@ -40,60 +55,123 @@ async fn config_endpoint_is_unprotected() {
         )
         .await
         .unwrap();
-    assert_eq!(
-        res.status(),
-        StatusCode::OK,
-        "config endpoint must be reachable without bearer token"
-    );
+    let status = res.status();
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+    let parsed: ParsedConfig =
+        serde_json::from_str(&body).expect("handler response must parse as AuthConfigResponse");
+    (status, body, parsed)
 }
 
 #[tokio::test]
-async fn config_endpoint_never_leaks_secrets() {
-    let (state, _pool) = ApiState::new_test_state_with_mock_entra().await;
+async fn config_endpoint_is_unprotected() {
+    let (state, _pool) = ApiState::new_test_state_with_mock_entra_configured().await;
     let app = build_test_router_entra(state);
-    let res = app
-        .oneshot(
-            Request::builder()
-                .uri("/api/auth/config")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(res.status(), StatusCode::OK);
-    let body = res.into_body().collect().await.unwrap().to_bytes();
-    let body_str = String::from_utf8(body.to_vec()).unwrap();
-    // Forbidden substrings. A regression here means we're leaking a secret
-    // into a publicly accessible endpoint.
-    for forbidden in ["client_secret", "graph_client_secret", "auth_token"] {
+    let (status, _, parsed) = get_config(app).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "config endpoint must be reachable without bearer token"
+    );
+    assert!(
+        parsed.entra_enabled,
+        "populated fixture must report entra_enabled=true"
+    );
+}
+
+/// C1 remediation: runs against a state with a POPULATED `EntraAuthConfig`
+/// so the leak-scrub assertion has substance. Previously the test used
+/// `new_test_state_with_mock_entra` (no `entra_config` attached) and the
+/// response was `{"entra_enabled":false}` — the forbidden-substring
+/// check passed against an empty payload.
+#[tokio::test]
+async fn config_endpoint_never_leaks_secrets() {
+    let (state, _pool) = ApiState::new_test_state_with_mock_entra_configured().await;
+    let app = build_test_router_entra(state);
+    let (status, body, _) = get_config(app).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Secret-adjacent key names that must NEVER appear in the response.
+    // A regression that widened `PublicEntraConfig::public()` to include
+    // `audience`, `allowed_scopes`, `mock_mode`, or a future secret field
+    // would surface here.
+    for forbidden in [
+        "client_secret",
+        "graph_client_secret",
+        "auth_token",
+        "audience",
+        "allowed_scopes",
+        "mock_mode",
+        "jwks_url_override",
+        "issuer_override",
+    ] {
         assert!(
-            !body_str.contains(forbidden),
-            "secret-adjacent key `{forbidden}` appeared in public config: {body_str}"
+            !body.contains(forbidden),
+            "secret-adjacent key `{forbidden}` appeared in public config: {body}"
         );
     }
+}
+
+/// C2 remediation: explicit populated-path assertion. Pins the exact
+/// shape the handler projects from a populated `EntraAuthConfig`.
+#[tokio::test]
+async fn config_endpoint_projects_populated_config_fields() {
+    let (state, _pool) = ApiState::new_test_state_with_mock_entra_configured().await;
+    let app = build_test_router_entra(state);
+    let (status, _body, parsed) = get_config(app).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(parsed.entra_enabled);
+    assert_eq!(
+        parsed.client_id.as_deref(),
+        Some("spa-22222222-2222-2222-2222-222222222222"),
+        "client_id must mirror EntraAuthConfig::spa_client_id"
+    );
+    assert_eq!(
+        parsed.tenant_id.as_deref(),
+        Some("tenant-11111111-1111-1111-1111-111111111111"),
+        "tenant_id must mirror EntraAuthConfig::tenant_id"
+    );
+    assert_eq!(
+        parsed.authority.as_deref(),
+        Some(
+            "https://login.microsoftonline.com/tenant-11111111-1111-1111-1111-111111111111/v2.0"
+        ),
+        "authority must be the v2.0 login URL computed from tenant_id"
+    );
+    assert_eq!(
+        parsed.scopes.as_deref(),
+        Some(&["api://web-test/api.access".to_string()][..]),
+        "scopes must mirror EntraAuthConfig::spa_scopes verbatim"
+    );
 }
 
 #[tokio::test]
 async fn config_returns_entra_disabled_when_unconfigured() {
     // Build a state WITHOUT Entra. `new_for_tests(None::<String>)` produces a
-    // minimal state for middleware-integration tests; the `::<String>` turbofish
-    // makes the `Option<String>` type explicit so inference does not complain.
+    // minimal state for middleware-integration tests; `None::<String>` is
+    // explicit so the Option type is inferable without ambiguity.
     let state = std::sync::Arc::new(ApiState::new_for_tests(None::<String>));
     let app = build_test_router_entra(state);
-    let res = app
-        .oneshot(
-            Request::builder()
-                .uri("/api/auth/config")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(res.status(), StatusCode::OK);
-    let body = res.into_body().collect().await.unwrap().to_bytes();
-    let body_str = String::from_utf8(body.to_vec()).unwrap();
+    let (status, _body, parsed) = get_config(app).await;
+    assert_eq!(status, StatusCode::OK);
     assert!(
-        body_str.contains("\"entra_enabled\":false"),
-        "unconfigured Entra must report entra_enabled=false, got: {body_str}"
+        !parsed.entra_enabled,
+        "unconfigured Entra must report entra_enabled=false"
+    );
+    assert!(
+        parsed.client_id.is_none(),
+        "client_id must be absent when entra_enabled=false"
+    );
+    assert!(
+        parsed.tenant_id.is_none(),
+        "tenant_id must be absent when entra_enabled=false"
+    );
+    assert!(
+        parsed.authority.is_none(),
+        "authority must be absent when entra_enabled=false"
+    );
+    assert!(
+        parsed.scopes.is_none(),
+        "scopes must be absent when entra_enabled=false"
     );
 }

--- a/tests/api_auth_config.rs
+++ b/tests/api_auth_config.rs
@@ -133,9 +133,7 @@ async fn config_endpoint_projects_populated_config_fields() {
     );
     assert_eq!(
         parsed.authority.as_deref(),
-        Some(
-            "https://login.microsoftonline.com/tenant-11111111-1111-1111-1111-111111111111/v2.0"
-        ),
+        Some("https://login.microsoftonline.com/tenant-11111111-1111-1111-1111-111111111111/v2.0"),
         "authority must be the v2.0 login URL computed from tenant_id"
     );
     assert_eq!(

--- a/tests/api_auth_config.rs
+++ b/tests/api_auth_config.rs
@@ -1,0 +1,99 @@
+//! Phase 6 Task 6.A.1 — TDD red phase for `GET /api/auth/config`.
+//!
+//! `/api/auth/config` is unprotected (the SPA fetches it before MSAL completes
+//! login, so no bearer token is available yet). These tests assert:
+//!   1. the endpoint is reachable without an `Authorization` header,
+//!   2. the response body never contains secret-adjacent substrings,
+//!   3. when Entra is not configured, the response reports `entra_enabled: false`
+//!      and omits client_id / tenant_id / authority / scopes.
+//!
+//! Until Task 6.A.2 lands the handler + the middleware allowlist edit, these
+//! tests will fail at runtime (404 for the unprotected assertion, or 401 for
+//! the "bypass" assertion). That's the intentional red-phase state.
+
+// F1/F2/F3 corrections (2026-04-22 pre-code audit):
+//  - Test helper is `build_test_router_entra` (NOT `build_test_router_with_auth`)
+//    re-exported at `spacebot::api::test_support` (definition at
+//    `src/api/server.rs:663`, re-export at `src/api.rs:45`).
+//  - `new_test_state_with_mock_entra` is an associated fn on `ApiState`
+//    (src/api/state.rs:455), not a free function in `spacebot::api::state`.
+//  - `new_for_tests(None::<String>)` makes the `Option<String>` type explicit
+//    (signature at src/api/state.rs:432).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt as _;
+use spacebot::api::ApiState;
+use spacebot::api::test_support::build_test_router_entra;
+use tower::ServiceExt as _;
+
+#[tokio::test]
+async fn config_endpoint_is_unprotected() {
+    let (state, _pool) = ApiState::new_test_state_with_mock_entra().await;
+    let app = build_test_router_entra(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/config")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "config endpoint must be reachable without bearer token"
+    );
+}
+
+#[tokio::test]
+async fn config_endpoint_never_leaks_secrets() {
+    let (state, _pool) = ApiState::new_test_state_with_mock_entra().await;
+    let app = build_test_router_entra(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/config")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8(body.to_vec()).unwrap();
+    // Forbidden substrings. A regression here means we're leaking a secret
+    // into a publicly accessible endpoint.
+    for forbidden in ["client_secret", "graph_client_secret", "auth_token"] {
+        assert!(
+            !body_str.contains(forbidden),
+            "secret-adjacent key `{forbidden}` appeared in public config: {body_str}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn config_returns_entra_disabled_when_unconfigured() {
+    // Build a state WITHOUT Entra. `new_for_tests(None::<String>)` produces a
+    // minimal state for middleware-integration tests; the `::<String>` turbofish
+    // makes the `Option<String>` type explicit so inference does not complain.
+    let state = std::sync::Arc::new(ApiState::new_for_tests(None::<String>));
+    let app = build_test_router_entra(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/config")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8(body.to_vec()).unwrap();
+    assert!(
+        body_str.contains("\"entra_enabled\":false"),
+        "unconfigured Entra must report entra_enabled=false, got: {body_str}"
+    );
+}

--- a/tests/api_auth_middleware.rs
+++ b/tests/api_auth_middleware.rs
@@ -92,6 +92,31 @@ async fn health_bypasses_auth_even_without_token() {
     assert_eq!(res.status(), StatusCode::OK);
 }
 
+/// Phase 6 Task 6.A.1b — the SPA bootstrap endpoint must bypass the
+/// bearer-token check. The allowlist is a single line at
+/// `src/api/server.rs` (companion at `src/auth/middleware.rs`) and a
+/// future refactor could silently drop it; this assertion exists so the
+/// regression would fail CI rather than shipping.
+#[tokio::test]
+async fn auth_config_bypasses_token_check() {
+    let state = Arc::new(ApiState::new_for_tests(Some("super-secret-token".into())));
+    let app = build_test_router(state);
+    let res = app
+        .oneshot(req_with_auth("/api/auth/config", None))
+        .await
+        .unwrap();
+    // No Authorization header present; the handler must still be reached.
+    // Content-wise the response is `entra_enabled: false` for a test state
+    // without Entra wired, so 200 is the expected status. The critical
+    // assertion is "not 401".
+    assert_ne!(
+        res.status(),
+        StatusCode::UNAUTHORIZED,
+        "/api/auth/config must bypass the bearer-token check"
+    );
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
 #[tokio::test]
 async fn pass_through_when_no_token_configured() {
     let state = Arc::new(ApiState::new_for_tests(None));

--- a/tests/entra_jwt_middleware.rs
+++ b/tests/entra_jwt_middleware.rs
@@ -274,6 +274,32 @@ mod router_level {
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
     }
 
+    /// Phase 6 C3 remediation: lock the Entra-JWT middleware allowlist
+    /// entry for `/api/auth/config`. Mirrors
+    /// `auth_config_bypasses_token_check` in `tests/api_auth_middleware.rs`
+    /// (which covers the static-token branch). The allowlist is a single
+    /// path literal hand-maintained across the two middleware branches —
+    /// a future refactor that drops it from one branch would only be
+    /// caught if both branches have a regression test.
+    #[tokio::test]
+    async fn auth_config_bypasses_entra_jwt_check() {
+        let tenant = MockTenant::start().await;
+        let app = router_for(&tenant).await;
+        let res = app
+            .oneshot(req_with_auth("/api/auth/config", None))
+            .await
+            .unwrap();
+        // No Authorization header and no valid JWT — must still reach the
+        // handler. Critical assertion is "not 401"; the 200 follow-up
+        // tightens against regressions that surface as 500/404.
+        assert_ne!(
+            res.status(),
+            StatusCode::UNAUTHORIZED,
+            "/api/auth/config must bypass the Entra JWT check"
+        );
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
     #[tokio::test]
     async fn middleware_rejects_non_bearer_scheme() {
         let tenant = MockTenant::start().await;


### PR DESCRIPTION
First of three PRs implementing Phase 6 of the Entra ID rollout (SPA integration). This PR lands the unprotected bootstrap endpoint, the MSAL.js v5 client integration, and the React gate component that sits above the app shell. PR B will add `authedFetch` + migrate the 88 existing fetch call sites; PR C will swap the SSE consumers to `@microsoft/fetch-event-source`.

## Summary

- **Backend** — New unprotected `GET /api/auth/config` endpoint returns the SPA's non-secret MSAL bootstrap identifiers (tenant_id, spa_client_id, authority, scopes). Both auth middleware branches allowlist the path so the browser can reach it before sign-in. New `PublicEntraConfig` projection drops every secret-adjacent field before serialization.
- **Frontend** — `msalConfig.ts` loads the config once, constructs a singleton `PublicClientApplication`, applies A-16 `memoryStorage` default + A-17 `localStorage` opt-in. `AuthGate.tsx` runs a four-state machine (loading / entra_disabled / unauthenticated / authenticated) above the app shell, handles redirect return, and wires `setAuthTokenProvider` into `@spacebot/api-client` so PR B's `authedFetch` has a real token source.
- **Operator docs** — New `/docs/entra-auth` fumadocs page covers app-registration schema, TOML config (all 10 fields), SPA bootstrap flow, cache-location behavior, mock mode, and 5 troubleshooting scenarios.

## Commits

| Commit | Task | Scope |
|---|---|---|
| `d0daf57` | 6.A.1/2 | Backend handler + middleware allowlist + 3 integration tests + 1 regression test |
| `e17ec72` | 6.A.3 | `bun add` MSAL.js v5 + vitest/testing-library (first test infra in \`interface/\`) |
| `7870fdf` | 6.A.4 | `msalConfig.ts` loader + `PublicClientApplication` factory |
| `985009d` | 6.A.5 | `AuthGate.tsx` + `setAuthTokenProvider` stub in api-client + 2 vitest tests |
| `c950de3` | 6.A.6 | Wire `<AuthGate>` into App root; F18 redirect-URI fix |
| `210c445` | 6.A.7 | `/docs/entra-auth` operator guide |

## Pre-code audit remediations folded in

Pre-code audit on 2026-04-22 flagged 7 Critical + 7 Important/Minor findings against the original plan. Plus 2 more (F17/F18) discovered at implementation time. All remediated inline with file:line citations:

| ID | Class | Fix |
|---|---|---|
| F1 | Symbol drift | `build_test_router_with_auth` → `build_test_router_entra` (src/api/server.rs:663) |
| F2 | Module path | `state::new_test_state` → `ApiState::new_test_state` (associated fn) |
| F3 | Type inference | `new_for_tests(None::<String>)` explicit annotation |
| F4 | Field accessor | `state.instance_db().await` doesn't exist; use ArcSwap::load chain |
| F5 | Duplicate migration | Phase 3 already shipped `display_photo_b64` + `photo_updated_at`; no new migration in PR A |
| F6 | utoipa prefix | `path = "/auth/config"` (api_router nests under /api at assembly) |
| F7 | Accessor pattern | Read `entra_config: ArcSwap<Option<EntraAuthConfig>>` (validator trait has no config()) |
| F8 | Stale criterion | `/api/me/groups` → single `/api/me` per A-18 |
| F9 | Column name | `display_photo_fetched_at` → `photo_updated_at` (matches Phase 3 schema) |
| F11 | Missing step | Explicit `pub mod auth_config;` in `src/api.rs` |
| F12 | Missing mkdir | `interface/src/auth/` scaffold step added |
| F13 | Malformed shell | Parenthetical removed from `git add` command |
| F14 | Count drift | Verified 88 fetch sites / 2,825 lines (not ~100 / 2,789) |
| F16 | Routing pattern | Middleware path-allowlist, matching `/api/health` precedent |
| F17 | MSAL v4→v5 API drift | Dropped `storeAuthStateInCookie`, renamed `allowNativeBroker` → `allowPlatformBroker` |
| F18 | Redirect URI | `/auth/callback` has no router route; redirect to `/` instead |

## Security / correctness

- **Unprotected endpoint payload** — three fields only (tenant_id, client_id, authority, scopes). Regression test `config_endpoint_never_leaks_secrets` asserts the body contains none of `client_secret`, `graph_client_secret`, `auth_token`.
- **Middleware allowlist** — single-line extension in both branches, matching the existing `/api/health` pattern. New `auth_config_bypasses_token_check` regression test in `tests/api_auth_middleware.rs` locks the bypass against future refactors.
- **MSAL cache** — A-16 defaults to `memoryStorage` (tokens evaporate on tab close). A-17 `localStorage` opt-in persists across sessions but relies on MSAL v5's automatic AES-GCM encryption.
- **Token provider error path** — `getAuthToken()` catches, logs, and returns `null` rather than propagating. `authedFetch` (PR B) will layer retry + interactive fallback on top of this primitive.

## Testing

- **New Rust tests** — 3 in `tests/api_auth_config.rs` (unprotected / no leaks / entra_disabled shape) + 1 in `tests/api_auth_middleware.rs` (allowlist regression)
- **New TypeScript tests** — 2 in `interface/src/auth/__tests__/AuthGate.test.tsx` (first vitest tests in the codebase; establishes the test infrastructure PR B + PR C will reuse)
- **Unit tests unchanged** — 898/898 pass; no regressions from the auth module additions
- **Integration tests unchanged** — 29/29 in `entra_jwt_middleware.rs`, 12/12 in `api_auth_middleware.rs` (11 pre-existing + 1 new)

## Gate evidence

- `just gate-pr`: green (fmt, clippy -Dwarnings, workspace-protocol, vite-dedupe, ADR-anchors, nextest unit, integration compile, check-typegen)
- `bunx tsc --noEmit` from `interface/`: zero errors
- `bun run build` from `interface/`: 3.38s
- `bun run build` from `docs/`: 129 pages; `/docs/entra-auth` rendered

## Test plan

- [ ] CI green
- [ ] Manual smoke on a preview deployment:
  - [ ] With Entra disabled: UI loads, no MSAL network activity, `/api/auth/config` returns `{"entra_enabled":false}`
  - [ ] With Entra enabled + mock_mode: SPA shows sign-in prompt, VITE_AUTH_MOCK=1 skips the real redirect, `authedFetch` attaches Bearer after "sign-in"
  - [ ] With Entra enabled + real tenant: end-to-end sign-in + API call succeeds; `/api/me` (exists on main from Phase 3) returns the authenticated principal
- [ ] `/docs/entra-auth` renders correctly in the live docs site

## Out of scope (deferred to PR B / PR C)

- `authedFetch` wrapper and the 88-call-site migration in `packages/api-client/src/client.ts` (PR B)
- `@microsoft/fetch-event-source` polyfill for SSE consumers (PR C)
- Post-redirect URL cleanup via `history.replaceState` + `state.redirectStartPage` preservation (Task 6.A.7 note)
- `/api/me` handler consolidation per A-18 (Task 6.C.6 per current plan; will revisit if scope shifts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)