### PR TITLE
feat(spa): Phase 6 PR B — authedFetch + 88-call-site migration + token-provider wiring

### DIFF
--- a/interface/src/auth/__tests__/authedFetch.test.ts
+++ b/interface/src/auth/__tests__/authedFetch.test.ts
@@ -1,0 +1,228 @@
+// Phase 6 PR B Task 6.B.1 — failing vitest for `authedFetch`, the central
+// fetch wrapper introduced by Task 6.B.2 as a sibling module to
+// `@spacebot/api-client/client`.
+//
+// G7 correction (2026-04-23 PR B audit): this file mirrors the import
+// pattern established by `authTokenProvider.test.ts` (PR A). The module
+// slot `setAuthTokenProvider(null)` in beforeEach/afterEach resets
+// closure state between tests; no new mock infrastructure required.
+//
+// D5 correction: `authedFetch` calls `getAuthToken()` internally, so
+// tests drive behavior through `setAuthTokenProvider` rather than
+// stubbing `getAuthToken` directly. This exercises the real PR A
+// error-swallow fence and keeps the tests coupled to the shipping
+// contract, not a mock.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	authedFetch,
+	setAuthTokenProvider,
+} from "@spacebot/api-client/client";
+
+describe("authedFetch", () => {
+	beforeEach(() => {
+		setAuthTokenProvider(null);
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		setAuthTokenProvider(null);
+	});
+
+	it("attaches Authorization header when provider is set", async () => {
+		setAuthTokenProvider(async () => "fake-token-abc");
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("ok", { status: 200 }));
+		await authedFetch("http://api/resource");
+		const init = spy.mock.calls[0][1] as RequestInit | undefined;
+		const headers = new Headers(init?.headers);
+		expect(headers.get("authorization")).toBe("Bearer fake-token-abc");
+	});
+
+	it("does NOT set Content-Type on FormData requests", async () => {
+		setAuthTokenProvider(async () => "t");
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("ok"));
+		const fd = new FormData();
+		fd.append("file", new Blob(["hi"]), "file.txt");
+		await authedFetch("http://api/upload", { method: "POST", body: fd });
+		const init = spy.mock.calls[0][1] as RequestInit | undefined;
+		const headers = new Headers(init?.headers);
+		// If we accidentally set Content-Type, the browser can't set the
+		// multipart boundary and the upload corrupts.
+		expect(headers.get("content-type")).toBeNull();
+	});
+
+	// G1 correction (2026-04-23 PR B audit): portalSendAudio at
+	// client.ts sends a raw Blob (not FormData). authedFetch must not
+	// force a Content-Type on Blob bodies either; the browser + server
+	// negotiate via the Blob's own `type`.
+	it("does NOT set Content-Type on Blob body", async () => {
+		setAuthTokenProvider(async () => "t");
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("ok"));
+		const blob = new Blob(["audio-bytes"], { type: "audio/webm" });
+		await authedFetch("http://api/portal/audio", {
+			method: "POST",
+			body: blob,
+		});
+		const init = spy.mock.calls[0][1] as RequestInit | undefined;
+		const headers = new Headers(init?.headers);
+		expect(headers.get("content-type")).toBeNull();
+	});
+
+	// G2 correction (2026-04-23 PR B audit): callers may pass a Headers
+	// instance instead of a plain object literal. The `new Headers(init.headers ?? {})`
+	// idiom in authedFetch accepts both; this test locks the contract.
+	it("accepts init.headers as a Headers instance", async () => {
+		setAuthTokenProvider(async () => "t");
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("ok"));
+		const hdrs = new Headers({ "x-custom": "keep-me" });
+		await authedFetch("http://api/foo", { headers: hdrs });
+		const init = spy.mock.calls[0][1] as RequestInit | undefined;
+		const headers = new Headers(init?.headers);
+		expect(headers.get("authorization")).toBe("Bearer t");
+		expect(headers.get("x-custom")).toBe("keep-me");
+	});
+
+	it("retries once on 401 after forcing a fresh token", async () => {
+		let call = 0;
+		setAuthTokenProvider(async () => `token-${++call}`);
+		const spy = vi.spyOn(globalThis, "fetch").mockImplementation(
+			async (_u, init) => {
+				const h = new Headers(init?.headers);
+				if (h.get("authorization") === "Bearer token-1") {
+					return new Response("{}", { status: 401 });
+				}
+				return new Response("{}", { status: 200 });
+			},
+		);
+		const res = await authedFetch("http://api/foo");
+		expect(res.status).toBe(200);
+		expect(spy).toHaveBeenCalledTimes(2);
+	});
+
+	// D3 correction (2026-04-23 PR B audit): if the provider yields null
+	// on the 401-retry attempt (MSAL silent acquisition fails without
+	// triggering a redirect), authedFetch must NOT loop forever and must
+	// NOT retry with no-Authorization-header. Return the 401 to caller.
+	it("returns 401 without further retry when provider yields null on retry", async () => {
+		let call = 0;
+		setAuthTokenProvider(async () => {
+			call++;
+			// First call: token issued. Retry: provider unavailable.
+			return call === 1 ? "TOKEN" : null;
+		});
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("{}", { status: 401 }));
+		const res = await authedFetch("http://api/foo");
+		expect(res.status).toBe(401);
+		// 2 fetch calls max: original with token, one retry attempt. The
+		// retry would normally include a refreshed header, but with
+		// provider=null the header is absent; authedFetch must still return
+		// the 401 rather than entering a no-header loop.
+		expect(spy.mock.calls.length).toBeLessThanOrEqual(2);
+	});
+
+	it("passes through when no provider is set (Entra disabled)", async () => {
+		setAuthTokenProvider(null);
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("ok"));
+		await authedFetch("http://api/foo");
+		const init = spy.mock.calls[0][1] as RequestInit | undefined;
+		const headers = new Headers(init?.headers);
+		expect(headers.get("authorization")).toBeNull();
+	});
+
+	// G4 correction (2026-04-23 PR B audit): disabled-mode 401 must NOT
+	// trigger retry (can't refresh what doesn't exist). Return the 401 to
+	// the caller on the first response.
+	it("returns 401 without retry when no provider is set", async () => {
+		setAuthTokenProvider(null);
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("{}", { status: 401 }));
+		const res = await authedFetch("http://api/foo");
+		expect(res.status).toBe(401);
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	// Pins the two-counter retry-state design: a 401 refresh must NOT
+	// consume the 202 sync budget.
+	it("401 → refresh → 202 → 202 → 202 → 200 succeeds (202 budget not consumed by 401)", async () => {
+		setAuthTokenProvider(async () => "TOKEN");
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(new Response("", { status: 401 }))
+			.mockResolvedValueOnce(
+				new Response("", { status: 202, headers: { "retry-after": "0" } }),
+			)
+			.mockResolvedValueOnce(
+				new Response("", { status: 202, headers: { "retry-after": "0" } }),
+			)
+			.mockResolvedValueOnce(
+				new Response("", { status: 202, headers: { "retry-after": "0" } }),
+			)
+			.mockResolvedValueOnce(new Response("ok", { status: 200 }));
+		const res = await authedFetch("http://api/test");
+		expect(res.status).toBe(200);
+		expect(spy).toHaveBeenCalledTimes(5);
+	});
+
+	it("second consecutive 401 is returned to the caller (auth cap = 1)", async () => {
+		setAuthTokenProvider(async () => "TOKEN");
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("", { status: 401 }));
+		const res = await authedFetch("http://api/test");
+		expect(res.status).toBe(401);
+		expect(spy).toHaveBeenCalledTimes(2); // original + one refresh retry
+	});
+
+	// D8 correction (2026-04-23 PR B audit): the previous "alternating
+	// 401/202" test accepted EITHER 401 or 202 as the outcome — weak
+	// assertion. Trace the state machine deterministically:
+	//   attempt 0 (total=0): 401; authAttempts=0<1 → retry; auth=1, total=1
+	//   attempt 1 (total=1): 202; syncAttempts=0<3 → retry; sync=1, total=2
+	//   attempt 2 (total=2): 401; authAttempts=1!<1 → return 401 to caller
+	// → exactly 3 fetch calls, deterministic 401.
+	it("401 → 202 → 401 returns 401 after exactly 3 calls (auth budget exhausted)", async () => {
+		setAuthTokenProvider(async () => "TOKEN");
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(new Response("", { status: 401 }))
+			.mockResolvedValueOnce(
+				new Response("", { status: 202, headers: { "retry-after": "0" } }),
+			)
+			.mockResolvedValueOnce(new Response("", { status: 401 }));
+		const res = await authedFetch("http://api/test");
+		expect(res.status).toBe(401);
+		expect(spy).toHaveBeenCalledTimes(3);
+	});
+
+	// G3 correction (2026-04-23 PR B audit): the overall `totalAttempts`
+	// cap is the safety net for a pathological loop that neither the auth
+	// nor the sync budget alone would catch. The sync cap is the tightening
+	// constraint in this sequence: 4 fetch calls (original + 3 sync retries)
+	// before syncAttempts=3 gates the 4th retry.
+	it("202 run: sync-cap fires at attempt 4 and returns the last 202", async () => {
+		setAuthTokenProvider(async () => "TOKEN");
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(
+				new Response("", { status: 202, headers: { "retry-after": "0" } }),
+			);
+		const res = await authedFetch("http://api/test");
+		expect(res.status).toBe(202);
+		// Original + 3 sync retries = 4 fetch calls. syncAttempts=3 gates
+		// the 4th-retry attempt.
+		expect(spy.mock.calls.length).toBe(4);
+	});
+});

--- a/interface/src/auth/__tests__/authedFetch.test.ts
+++ b/interface/src/auth/__tests__/authedFetch.test.ts
@@ -18,6 +18,8 @@ import {
 	authedFetch,
 	setAuthTokenProvider,
 } from "@spacebot/api-client/client";
+import type { AuthExhaustedDetail } from "@spacebot/api-client/authedFetch";
+import { parseRetryAfterMs } from "@spacebot/api-client/authedFetch";
 
 describe("authedFetch", () => {
 	beforeEach(() => {
@@ -74,6 +76,31 @@ describe("authedFetch", () => {
 		expect(headers.get("content-type")).toBeNull();
 	});
 
+	// Review-B item 4: tightens G1/G2 coverage. The prior FormData/Blob
+	// tests only proved Content-Type was absent — they passed even if the
+	// `headers.delete("Content-Type")` line were removed, because no
+	// caller-supplied Content-Type existed to delete. This test explicitly
+	// sets Content-Type alongside FormData, proving the delete branch runs.
+	it("deletes caller-supplied Content-Type when body is FormData", async () => {
+		setAuthTokenProvider(async () => "t");
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("ok"));
+		const fd = new FormData();
+		fd.append("file", new Blob(["hi"]), "file.txt");
+		// Callers that naively set application/json break multipart uploads
+		// because the browser can't insert its own boundary parameter. The
+		// wrapper must scrub the caller's header on FormData/Blob bodies.
+		await authedFetch("http://api/upload", {
+			method: "POST",
+			body: fd,
+			headers: { "content-type": "application/json" },
+		});
+		const init = spy.mock.calls[0][1] as RequestInit | undefined;
+		const headers = new Headers(init?.headers);
+		expect(headers.get("content-type")).toBeNull();
+	});
+
 	// G2 correction (2026-04-23 PR B audit): callers may pass a Headers
 	// instance instead of a plain object literal. The `new Headers(init.headers ?? {})`
 	// idiom in authedFetch accepts both; this test locks the contract.
@@ -111,23 +138,38 @@ describe("authedFetch", () => {
 	// on the 401-retry attempt (MSAL silent acquisition fails without
 	// triggering a redirect), authedFetch must NOT loop forever and must
 	// NOT retry with no-Authorization-header. Return the 401 to caller.
-	it("returns 401 without further retry when provider yields null on retry", async () => {
+	//
+	// Also pins the `spacebot:auth-exhausted` observability event with
+	// reason=no_token_on_retry, so a refactor that drops or renames the
+	// event fails this test.
+	it("returns 401 without further retry when provider yields null on retry + dispatches no_token_on_retry", async () => {
 		let call = 0;
 		setAuthTokenProvider(async () => {
 			call++;
 			// First call: token issued. Retry: provider unavailable.
 			return call === 1 ? "TOKEN" : null;
 		});
-		const spy = vi
+		const fetchSpy = vi
 			.spyOn(globalThis, "fetch")
 			.mockResolvedValue(new Response("{}", { status: 401 }));
+		const dispatchSpy = vi.spyOn(window, "dispatchEvent");
 		const res = await authedFetch("http://api/foo");
 		expect(res.status).toBe(401);
-		// 2 fetch calls max: original with token, one retry attempt. The
-		// retry would normally include a refreshed header, but with
-		// provider=null the header is absent; authedFetch must still return
-		// the 401 rather than entering a no-header loop.
-		expect(spy.mock.calls.length).toBeLessThanOrEqual(2);
+		// 1 fetch call: authedFetch sees the 401, re-reads the provider,
+		// gets null, and returns immediately without a retry. A retry with
+		// a null token would set no Authorization header, which the plan
+		// explicitly forbids as a silent no-header loop.
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const authExhaustedCalls = dispatchSpy.mock.calls.filter(
+			(c) =>
+				c[0] instanceof CustomEvent &&
+				c[0].type === "spacebot:auth-exhausted",
+		);
+		expect(authExhaustedCalls).toHaveLength(1);
+		const detail = (authExhaustedCalls[0][0] as CustomEvent<AuthExhaustedDetail>)
+			.detail;
+		expect(detail.reason).toBe("no_token_on_retry");
+		expect(detail.url).toBe("http://api/foo");
 	});
 
 	it("passes through when no provider is set (Entra disabled)", async () => {
@@ -176,14 +218,25 @@ describe("authedFetch", () => {
 		expect(spy).toHaveBeenCalledTimes(5);
 	});
 
-	it("second consecutive 401 is returned to the caller (auth cap = 1)", async () => {
+	it("second consecutive 401 is returned to the caller + dispatches refresh_failed (auth cap = 1)", async () => {
 		setAuthTokenProvider(async () => "TOKEN");
-		const spy = vi
+		const fetchSpy = vi
 			.spyOn(globalThis, "fetch")
 			.mockResolvedValue(new Response("", { status: 401 }));
+		const dispatchSpy = vi.spyOn(window, "dispatchEvent");
 		const res = await authedFetch("http://api/test");
 		expect(res.status).toBe(401);
-		expect(spy).toHaveBeenCalledTimes(2); // original + one refresh retry
+		expect(fetchSpy).toHaveBeenCalledTimes(2); // original + one refresh retry
+		const authExhaustedCalls = dispatchSpy.mock.calls.filter(
+			(c) =>
+				c[0] instanceof CustomEvent &&
+				c[0].type === "spacebot:auth-exhausted",
+		);
+		expect(authExhaustedCalls).toHaveLength(1);
+		const detail = (authExhaustedCalls[0][0] as CustomEvent<AuthExhaustedDetail>)
+			.detail;
+		expect(detail.reason).toBe("refresh_failed");
+		expect(detail.url).toBe("http://api/test");
 	});
 
 	// D8 correction (2026-04-23 PR B audit): the previous "alternating
@@ -224,5 +277,38 @@ describe("authedFetch", () => {
 		// Original + 3 sync retries = 4 fetch calls. syncAttempts=3 gates
 		// the 4th-retry attempt.
 		expect(spy.mock.calls.length).toBe(4);
+	});
+});
+
+// Review-B item 5: direct tests for the Retry-After parser. The four
+// branches are all reachable through the authedFetch integration path,
+// but driving them via a 202 response with a specific header is slow
+// (real setTimeout waits) and indirect. Direct unit tests pin the
+// security-adjacent 10s clamp and the malformed-header fallback.
+describe("parseRetryAfterMs", () => {
+	it("returns 1000ms default when header is null", () => {
+		expect(parseRetryAfterMs(null)).toBe(1000);
+	});
+
+	it("returns 1000ms fallback when header is non-numeric", () => {
+		expect(parseRetryAfterMs("abc")).toBe(1000);
+	});
+
+	it("returns 1000ms fallback when header is negative", () => {
+		expect(parseRetryAfterMs("-5")).toBe(1000);
+	});
+
+	it("multiplies seconds to milliseconds for valid input", () => {
+		expect(parseRetryAfterMs("2")).toBe(2000);
+		expect(parseRetryAfterMs("5")).toBe(5000);
+	});
+
+	it("clamps at 10s to prevent malicious-proxy long-sleep attacks", () => {
+		expect(parseRetryAfterMs("11")).toBe(10_000);
+		expect(parseRetryAfterMs("999999")).toBe(10_000);
+	});
+
+	it("accepts integer boundary value (10s) without clamping further", () => {
+		expect(parseRetryAfterMs("10")).toBe(10_000);
 	});
 });

--- a/interface/src/auth/__tests__/authedFetch.test.ts
+++ b/interface/src/auth/__tests__/authedFetch.test.ts
@@ -187,8 +187,8 @@ describe("authedFetch", () => {
 	});
 
 	// D8 correction (2026-04-23 PR B audit): the previous "alternating
-	// 401/202" test accepted EITHER 401 or 202 as the outcome — weak
-	// assertion. Trace the state machine deterministically:
+	// 401/202" test accepted EITHER 401 or 202 as the outcome, which was
+	// a weak assertion. Trace the state machine deterministically:
 	//   attempt 0 (total=0): 401; authAttempts=0<1 → retry; auth=1, total=1
 	//   attempt 1 (total=1): 202; syncAttempts=0<3 → retry; sync=1, total=2
 	//   attempt 2 (total=2): 401; authAttempts=1!<1 → return 401 to caller

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     "./client": "./src/client.ts",
+    "./authedFetch": "./src/authedFetch.ts",
     "./types": "./src/types.ts",
     "./schema": "./src/schema.d.ts"
   }

--- a/packages/api-client/src/authedFetch.ts
+++ b/packages/api-client/src/authedFetch.ts
@@ -7,9 +7,9 @@
 // Hard safety cap at 5 total attempts for pathological 401↔202 loops.
 //
 // D4/O1 correction: lives in a sibling module so Task 6.B.3's sed pass
-// against client.ts cannot produce recursion — this file contains
-// exactly one `fetch(` call by design (the delegation to the browser
-// primitive at line ~60).
+// against client.ts cannot produce recursion. This file contains
+// exactly one `fetch(` call by design: the delegation to the browser
+// primitive at line ~60.
 
 import { getAuthToken } from "./client";
 
@@ -39,7 +39,7 @@ const SYNC_CAP = 3;
 const TOTAL_CAP = 5;
 
 // Public API. Drop-in replacement for `fetch()` with Entra-aware auth
-// behavior. `state` is intentionally NOT a parameter — callers should
+// behavior. `state` is intentionally NOT a parameter: callers should
 // not tune retry budgets per-call.
 export async function authedFetch(
 	input: RequestInfo | URL,
@@ -79,7 +79,7 @@ async function authedFetchInner(
 		// D3 correction: check that the token provider CAN still yield a
 		// token. If the retry would produce null (provider unset, or
 		// provider threw and got caught), the retry cannot change the
-		// outcome — return the 401 to the caller instead of entering a
+		// outcome. Return the 401 to the caller instead of entering a
 		// no-header retry loop.
 		const retryToken = await getAuthToken();
 		if (retryToken === null) {

--- a/packages/api-client/src/authedFetch.ts
+++ b/packages/api-client/src/authedFetch.ts
@@ -13,19 +13,32 @@
 
 import { getAuthToken } from "./client";
 
+// Reasons surfaced on the `spacebot:auth-exhausted` CustomEvent.
+// Downstream listeners (Sentry, toast banner, React Query invalidation)
+// can narrow on this to distinguish "MSAL silent acquisition failed
+// without triggering a redirect" (no_token_on_retry) from "fresh token
+// did not satisfy the server" (refresh_failed).
+export type AuthExhaustedReason = "no_token_on_retry" | "refresh_failed";
+
+export type AuthExhaustedDetail = {
+	url: string;
+	reason: AuthExhaustedReason;
+};
+
 // Budget tracker threaded through retry recursion. O3 correction: kept
-// module-private so callers can't misuse it (e.g., pre-setting
-// `totalAttempts: 4` to neuter retries on a specific call).
+// module-private so callers can't misuse it (e.g., pre-setting a
+// high `authAttempts` to neuter retries on a specific call).
+//
+// totalAttempts is derivable as authAttempts + syncAttempts, so it is
+// NOT stored on the state. Recomputed at the safety-cap check.
 type RetryState = {
 	authAttempts: number; // 401 → token-refresh retries (cap: 1)
 	syncAttempts: number; // 202 → permissions-sync retries (cap: 3, A-10)
-	totalAttempts: number; // hard safety cap against 401↔202 loops (cap: 5)
 };
 
 const INITIAL_STATE: RetryState = {
 	authAttempts: 0,
 	syncAttempts: 0,
-	totalAttempts: 0,
 };
 
 // Derived from Phase 3's A-10 race handling: `group_cache_ttl_secs`
@@ -36,7 +49,7 @@ const INITIAL_STATE: RetryState = {
 // of client retry will fix.
 const AUTH_CAP = 1;
 const SYNC_CAP = 3;
-const TOTAL_CAP = 5;
+const TOTAL_CAP = AUTH_CAP + SYNC_CAP + 1; // safety net, structurally unreachable under current caps
 
 // Public API. Drop-in replacement for `fetch()` with Entra-aware auth
 // behavior. `state` is intentionally NOT a parameter: callers should
@@ -45,20 +58,25 @@ export async function authedFetch(
 	input: RequestInfo | URL,
 	init?: RequestInit,
 ): Promise<Response> {
-	return authedFetchInner(input, init ?? {}, { ...INITIAL_STATE });
+	return authedFetchInner(input, init ?? {}, { ...INITIAL_STATE }, undefined);
 }
 
+// `preResolvedToken` allows the caller to pass in a token already
+// fetched via `getAuthToken()` so the retry path does not call the
+// provider twice for the same retry attempt. When undefined, we fetch.
 async function authedFetchInner(
 	input: RequestInfo | URL,
 	init: RequestInit,
 	state: RetryState,
+	preResolvedToken: string | null | undefined,
 ): Promise<Response> {
 	const headers = new Headers(init.headers ?? {});
 
 	// D5 correction: route through getAuthToken() to inherit PR A's
 	// error-swallow fence. Null returns are normal (no provider, or
 	// provider threw and got caught).
-	const token = await getAuthToken();
+	const token =
+		preResolvedToken !== undefined ? preResolvedToken : await getAuthToken();
 	if (token) headers.set("Authorization", `Bearer ${token}`);
 
 	// Preserve browser-managed Content-Type for body types where the
@@ -72,7 +90,7 @@ async function authedFetchInner(
 
 	// Overall safety cap. Terminates any pathological 401↔202 loop that
 	// evades the per-dimension budgets.
-	if (state.totalAttempts >= TOTAL_CAP) return res;
+	if (state.authAttempts + state.syncAttempts >= TOTAL_CAP) return res;
 
 	// 401 → force refresh + retry, subject to the auth cap.
 	if (res.status === 401 && state.authAttempts < AUTH_CAP) {
@@ -83,36 +101,24 @@ async function authedFetchInner(
 		// no-header retry loop.
 		const retryToken = await getAuthToken();
 		if (retryToken === null) {
-			// O2 correction: surface for observability. Downstream can wire
-			// Sentry / ReactQuery invalidation / toast banner via
-			// addEventListener.
-			if (typeof window !== "undefined") {
-				window.dispatchEvent(
-					new CustomEvent("spacebot:auth-exhausted", {
-						detail: { url: String(input), reason: "no_token_on_retry" },
-					}),
-				);
-			}
+			dispatchAuthExhausted(String(input), "no_token_on_retry");
 			return res;
 		}
-		return authedFetchInner(input, init, {
-			...state,
-			authAttempts: state.authAttempts + 1,
-			totalAttempts: state.totalAttempts + 1,
-		});
+		// Thread the freshly-resolved token into the recursive call so the
+		// inner invocation does not ask the provider a second time.
+		return authedFetchInner(
+			input,
+			init,
+			{ ...state, authAttempts: state.authAttempts + 1 },
+			retryToken,
+		);
 	}
 
 	// O2 correction: surface final 401 after refresh as well. If we
 	// reach this branch with authAttempts >= AUTH_CAP and status 401,
 	// the refresh did not help.
 	if (res.status === 401 && state.authAttempts >= AUTH_CAP) {
-		if (typeof window !== "undefined") {
-			window.dispatchEvent(
-				new CustomEvent("spacebot:auth-exhausted", {
-					detail: { url: String(input), reason: "refresh_failed" },
-				}),
-			);
-		}
+		dispatchAuthExhausted(String(input), "refresh_failed");
 	}
 
 	// A-10: 202 Accepted + Retry-After during the first-request race
@@ -120,14 +126,34 @@ async function authedFetchInner(
 	if (res.status === 202 && state.syncAttempts < SYNC_CAP) {
 		const waitMs = parseRetryAfterMs(res.headers.get("retry-after"));
 		await new Promise((resolve) => setTimeout(resolve, waitMs));
-		return authedFetchInner(input, init, {
-			...state,
-			syncAttempts: state.syncAttempts + 1,
-			totalAttempts: state.totalAttempts + 1,
-		});
+		// Sync retry uses a fresh provider read. The token may have rotated
+		// during the wait.
+		return authedFetchInner(
+			input,
+			init,
+			{ ...state, syncAttempts: state.syncAttempts + 1 },
+			undefined,
+		);
 	}
 
 	return res;
+}
+
+// SSR / Node-test guard: authedFetch is SPA-only today, but if it is
+// ever imported from a Tauri backend or a Node integration harness the
+// `window` global is absent. Silent no-op in that case. Revisit the
+// observability surface if authedFetch starts being consumed server-side.
+function dispatchAuthExhausted(
+	url: string,
+	reason: AuthExhaustedReason,
+): void {
+	if (typeof window === "undefined") return;
+	const detail: AuthExhaustedDetail = { url, reason };
+	window.dispatchEvent(
+		new CustomEvent<AuthExhaustedDetail>("spacebot:auth-exhausted", {
+			detail,
+		}),
+	);
 }
 
 // D9 correction: the daemon ALWAYS emits `Retry-After: 2` when returning
@@ -137,7 +163,9 @@ async function authedFetchInner(
 // responsive while the daemon is fixed. Previously this was 2000ms with
 // no documented rationale. Clamped to 10s to prevent a malicious proxy
 // from locking the SPA in a long sleep.
-function parseRetryAfterMs(header: string | null): number {
+//
+// Exported for direct unit testing of the NaN / negative / clamp branches.
+export function parseRetryAfterMs(header: string | null): number {
 	if (!header) return 1000;
 	const parsed = Number.parseInt(header, 10);
 	if (Number.isNaN(parsed) || parsed < 0) return 1000;

--- a/packages/api-client/src/authedFetch.ts
+++ b/packages/api-client/src/authedFetch.ts
@@ -1,0 +1,145 @@
+// Phase 6 PR B Task 6.B.2 — central fetch wrapper for all API calls.
+//
+// Attaches Authorization when the token provider yields a token.
+// Preserves FormData + Blob browser-managed Content-Type boundary.
+// Retries once on 401 after forcing a fresh token (auth cap = 1).
+// Retries up to 3 times on 202 Accepted (A-10, Graph-sync race).
+// Hard safety cap at 5 total attempts for pathological 401↔202 loops.
+//
+// D4/O1 correction: lives in a sibling module so Task 6.B.3's sed pass
+// against client.ts cannot produce recursion — this file contains
+// exactly one `fetch(` call by design (the delegation to the browser
+// primitive at line ~60).
+
+import { getAuthToken } from "./client";
+
+// Budget tracker threaded through retry recursion. O3 correction: kept
+// module-private so callers can't misuse it (e.g., pre-setting
+// `totalAttempts: 4` to neuter retries on a specific call).
+type RetryState = {
+	authAttempts: number; // 401 → token-refresh retries (cap: 1)
+	syncAttempts: number; // 202 → permissions-sync retries (cap: 3, A-10)
+	totalAttempts: number; // hard safety cap against 401↔202 loops (cap: 5)
+};
+
+const INITIAL_STATE: RetryState = {
+	authAttempts: 0,
+	syncAttempts: 0,
+	totalAttempts: 0,
+};
+
+// Derived from Phase 3's A-10 race handling: `group_cache_ttl_secs`
+// default 300s → Retry-After: 2s → 3 retries buys 6s of wait before the
+// daemon has populated `team_memberships`. Auth refresh is deliberately
+// capped at 1 because a second consecutive 401 with a fresh token is an
+// operator problem (bad `aud`, wrong tenant, clock-skew) that no amount
+// of client retry will fix.
+const AUTH_CAP = 1;
+const SYNC_CAP = 3;
+const TOTAL_CAP = 5;
+
+// Public API. Drop-in replacement for `fetch()` with Entra-aware auth
+// behavior. `state` is intentionally NOT a parameter — callers should
+// not tune retry budgets per-call.
+export async function authedFetch(
+	input: RequestInfo | URL,
+	init?: RequestInit,
+): Promise<Response> {
+	return authedFetchInner(input, init ?? {}, { ...INITIAL_STATE });
+}
+
+async function authedFetchInner(
+	input: RequestInfo | URL,
+	init: RequestInit,
+	state: RetryState,
+): Promise<Response> {
+	const headers = new Headers(init.headers ?? {});
+
+	// D5 correction: route through getAuthToken() to inherit PR A's
+	// error-swallow fence. Null returns are normal (no provider, or
+	// provider threw and got caught).
+	const token = await getAuthToken();
+	if (token) headers.set("Authorization", `Bearer ${token}`);
+
+	// Preserve browser-managed Content-Type for body types where the
+	// browser computes the boundary or MIME type. FormData + Blob both
+	// fall into this class.
+	if (init.body instanceof FormData || init.body instanceof Blob) {
+		headers.delete("Content-Type");
+	}
+
+	const res = await fetch(input, { ...init, headers });
+
+	// Overall safety cap. Terminates any pathological 401↔202 loop that
+	// evades the per-dimension budgets.
+	if (state.totalAttempts >= TOTAL_CAP) return res;
+
+	// 401 → force refresh + retry, subject to the auth cap.
+	if (res.status === 401 && state.authAttempts < AUTH_CAP) {
+		// D3 correction: check that the token provider CAN still yield a
+		// token. If the retry would produce null (provider unset, or
+		// provider threw and got caught), the retry cannot change the
+		// outcome — return the 401 to the caller instead of entering a
+		// no-header retry loop.
+		const retryToken = await getAuthToken();
+		if (retryToken === null) {
+			// O2 correction: surface for observability. Downstream can wire
+			// Sentry / ReactQuery invalidation / toast banner via
+			// addEventListener.
+			if (typeof window !== "undefined") {
+				window.dispatchEvent(
+					new CustomEvent("spacebot:auth-exhausted", {
+						detail: { url: String(input), reason: "no_token_on_retry" },
+					}),
+				);
+			}
+			return res;
+		}
+		return authedFetchInner(input, init, {
+			...state,
+			authAttempts: state.authAttempts + 1,
+			totalAttempts: state.totalAttempts + 1,
+		});
+	}
+
+	// O2 correction: surface final 401 after refresh as well. If we
+	// reach this branch with authAttempts >= AUTH_CAP and status 401,
+	// the refresh did not help.
+	if (res.status === 401 && state.authAttempts >= AUTH_CAP) {
+		if (typeof window !== "undefined") {
+			window.dispatchEvent(
+				new CustomEvent("spacebot:auth-exhausted", {
+					detail: { url: String(input), reason: "refresh_failed" },
+				}),
+			);
+		}
+	}
+
+	// A-10: 202 Accepted + Retry-After during the first-request race
+	// against Phase 3's group-sync fire-and-forget spawn.
+	if (res.status === 202 && state.syncAttempts < SYNC_CAP) {
+		const waitMs = parseRetryAfterMs(res.headers.get("retry-after"));
+		await new Promise((resolve) => setTimeout(resolve, waitMs));
+		return authedFetchInner(input, init, {
+			...state,
+			syncAttempts: state.syncAttempts + 1,
+			totalAttempts: state.totalAttempts + 1,
+		});
+	}
+
+	return res;
+}
+
+// D9 correction: the daemon ALWAYS emits `Retry-After: 2` when returning
+// 202 from the first-request race handler (see
+// `src/auth/middleware.rs:309-317`). A 202 without `Retry-After` is a
+// server contract violation; default to 1000ms so the client stays
+// responsive while the daemon is fixed. Previously this was 2000ms with
+// no documented rationale. Clamped to 10s to prevent a malicious proxy
+// from locking the SPA in a long sleep.
+function parseRetryAfterMs(header: string | null): number {
+	if (!header) return 1000;
+	const parsed = Number.parseInt(header, 10);
+	if (Number.isNaN(parsed) || parsed < 0) return 1000;
+	return Math.min(parsed * 1000, 10_000);
+}

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -69,10 +69,11 @@ export async function getAuthToken(): Promise<string | null> {
 	}
 }
 
-// Phase 6 Task 6.B.2: central fetch wrapper. Defined in a sibling module
-// so the Task 6.B.3 sed pass doesn't risk recursing its own
-// `fetch(input, { ...init, headers })` call into `authedFetch(...)`.
-export { authedFetch } from "./authedFetch";
+// Phase 6 Task 6.B.2: central fetch wrapper. Defined in a sibling
+// module so the Task 6.B.3 sed pass doesn't risk recursing its own
+// delegation into a browser primitive call.
+import { authedFetch } from "./authedFetch";
+export { authedFetch };
 
 import type * as Types from "./types";
 
@@ -364,7 +365,7 @@ export interface TimelineWorkerRun {
 // Note: TimelineItem is re-exported from types.ts as a union type
 
 async function fetchJson<T>(path: string): Promise<T> {
-	const response = await fetch(`${getApiBase()}${path}`);
+	const response = await authedFetch(`${getApiBase()}${path}`);
 	if (!response.ok) {
 		throw new Error(`API error: ${response.status}`);
 	}
@@ -1470,7 +1471,7 @@ export const api = {
 	channels: () => fetchJson<Types.ChannelsResponse>("/channels"),
 	deleteChannel: async (agentId: string, channelId: string) => {
 		const params = new URLSearchParams({ agent_id: agentId, channel_id: channelId });
-		const response = await fetch(`${getApiBase()}/channels?${params}`, { method: "DELETE" });
+		const response = await authedFetch(`${getApiBase()}/channels?${params}`, { method: "DELETE" });
 		if (!response.ok) throw new Error(`API error: ${response.status}`);
 		return response.json() as Promise<{ success: boolean }>;
 	},
@@ -1483,7 +1484,7 @@ export const api = {
 	inspectPrompt: (channelId: string) =>
 		fetchJson<PromptInspectResponse>(`/channels/prompt/inspect?channel_id=${encodeURIComponent(channelId)}`),
 	setPromptCapture: async (channelId: string, enabled: boolean) => {
-		const response = await fetch(`${getApiBase()}/channels/prompt/capture`, {
+		const response = await authedFetch(`${getApiBase()}/channels/prompt/capture`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ channel_id: channelId, enabled }),
@@ -1549,7 +1550,7 @@ export const api = {
 		return fetchJson<Types.CortexChatMessagesResponse>(`/cortex-chat/messages?${search}`);
 	},
 	cortexChatSend: (agentId: string, threadId: string, message: string, channelId?: string) =>
-		fetch(`${getApiBase()}/cortex-chat/send`, {
+		authedFetch(`${getApiBase()}/cortex-chat/send`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
@@ -1564,7 +1565,7 @@ export const api = {
 			`/cortex-chat/threads?agent_id=${encodeURIComponent(agentId)}`,
 		),
 	cortexChatDeleteThread: async (agentId: string, threadId: string) => {
-		const response = await fetch(`${getApiBase()}/cortex-chat/thread`, {
+		const response = await authedFetch(`${getApiBase()}/cortex-chat/thread`, {
 			method: "DELETE",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ agent_id: agentId, thread_id: threadId }),
@@ -1576,7 +1577,7 @@ export const api = {
 	agentIdentity: (agentId: string) =>
 		fetchJson<{ soul: string | null; identity: string | null; role: string | null }>(`/agents/identity?agent_id=${encodeURIComponent(agentId)}`),
 	updateIdentity: async (request: { agent_id: string; soul?: string | null; identity?: string | null; role?: string | null }) => {
-		const response = await fetch(`${getApiBase()}/agents/identity`, {
+		const response = await authedFetch(`${getApiBase()}/agents/identity`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -1587,7 +1588,7 @@ export const api = {
 		return response.json() as Promise<{ soul: string | null; identity: string | null; role: string | null }>;
 	},
 	createAgent: async (agentId: string, displayName?: string, role?: string) => {
-		const response = await fetch(`${getApiBase()}/agents`, {
+		const response = await authedFetch(`${getApiBase()}/agents`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ agent_id: agentId, display_name: displayName || undefined, role: role || undefined }),
@@ -1599,7 +1600,7 @@ export const api = {
 	},
 
 	updateAgent: async (agentId: string, update: { display_name?: string; role?: string; gradient_start?: string; gradient_end?: string }) => {
-		const response = await fetch(`${getApiBase()}/agents`, {
+		const response = await authedFetch(`${getApiBase()}/agents`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ agent_id: agentId, ...update }),
@@ -1612,7 +1613,7 @@ export const api = {
 
 	deleteAgent: async (agentId: string) => {
 		const params = new URLSearchParams({ agent_id: agentId });
-		const response = await fetch(`${getApiBase()}/agents?${params}`, {
+		const response = await authedFetch(`${getApiBase()}/agents?${params}`, {
 			method: "DELETE",
 		});
 		if (!response.ok) {
@@ -1627,7 +1628,7 @@ export const api = {
 	/** Upload an avatar image for an agent. */
 	uploadAvatar: async (agentId: string, file: File) => {
 		const params = new URLSearchParams({ agent_id: agentId });
-		const response = await fetch(`${getApiBase()}/agents/avatar?${params}`, {
+		const response = await authedFetch(`${getApiBase()}/agents/avatar?${params}`, {
 			method: "POST",
 			headers: { "Content-Type": file.type },
 			body: file,
@@ -1641,7 +1642,7 @@ export const api = {
 	/** Delete the avatar for an agent. */
 	deleteAvatar: async (agentId: string) => {
 		const params = new URLSearchParams({ agent_id: agentId });
-		const response = await fetch(`${getApiBase()}/agents/avatar?${params}`, {
+		const response = await authedFetch(`${getApiBase()}/agents/avatar?${params}`, {
 			method: "DELETE",
 		});
 		if (!response.ok) {
@@ -1653,7 +1654,7 @@ export const api = {
 	agentConfig: (agentId: string) =>
 		fetchJson<AgentConfigResponse>(`/agents/config?agent_id=${encodeURIComponent(agentId)}`),
 	updateAgentConfig: async (request: AgentConfigUpdateRequest) => {
-		const response = await fetch(`${getApiBase()}/agents/config`, {
+		const response = await authedFetch(`${getApiBase()}/agents/config`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -1676,7 +1677,7 @@ export const api = {
 	},
 
 	createCronJob: async (agentId: string, request: CreateCronRequest) => {
-		const response = await fetch(`${getApiBase()}/agents/cron`, {
+		const response = await authedFetch(`${getApiBase()}/agents/cron`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ ...request, agent_id: agentId }),
@@ -1689,7 +1690,7 @@ export const api = {
 
 	deleteCronJob: async (agentId: string, cronId: string) => {
 		const search = new URLSearchParams({ agent_id: agentId, cron_id: cronId });
-		const response = await fetch(`${getApiBase()}/agents/cron?${search}`, {
+		const response = await authedFetch(`${getApiBase()}/agents/cron?${search}`, {
 			method: "DELETE",
 		});
 		if (!response.ok) {
@@ -1699,7 +1700,7 @@ export const api = {
 	},
 
 	toggleCronJob: async (agentId: string, cronId: string, enabled: boolean) => {
-		const response = await fetch(`${getApiBase()}/agents/cron/toggle`, {
+		const response = await authedFetch(`${getApiBase()}/agents/cron/toggle`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ agent_id: agentId, cron_id: cronId, enabled }),
@@ -1711,7 +1712,7 @@ export const api = {
 	},
 
 	triggerCronJob: async (agentId: string, cronId: string) => {
-		const response = await fetch(`${getApiBase()}/agents/cron/trigger`, {
+		const response = await authedFetch(`${getApiBase()}/agents/cron/trigger`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ agent_id: agentId, cron_id: cronId }),
@@ -1723,7 +1724,7 @@ export const api = {
 	},
 
 	cancelProcess: async (channelId: string, processType: "worker" | "branch", processId: string) => {
-		const response = await fetch(`${getApiBase()}/channels/cancel-process`, {
+		const response = await authedFetch(`${getApiBase()}/channels/cancel-process`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ channel_id: channelId, process_type: processType, process_id: processId }),
@@ -1746,7 +1747,7 @@ export const api = {
 		useBearerAuth?: boolean,
 		extraHeaders?: Array<{name: string; value: string}>,
 	) => {
-		const response = await fetch(`${getApiBase()}/providers`, {
+		const response = await authedFetch(`${getApiBase()}/providers`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
@@ -1775,7 +1776,7 @@ export const api = {
 		useBearerAuth?: boolean,
 		extraHeaders?: Array<{name: string; value: string}>,
 	) => {
-		const response = await fetch(`${getApiBase()}/providers/test-model`, {
+		const response = await authedFetch(`${getApiBase()}/providers/test-model`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
@@ -1795,7 +1796,7 @@ export const api = {
 		return response.json() as Promise<Types.ProviderModelTestResponse>;
 	},
 	getProviderConfig: async (provider: string, options?: { signal?: AbortSignal }) => {
-		const response = await fetch(`${getApiBase()}/providers/${provider}/config`, {
+		const response = await authedFetch(`${getApiBase()}/providers/${provider}/config`, {
 			method: "GET",
 			signal: options?.signal,
 		});
@@ -1811,7 +1812,7 @@ export const api = {
 		}>;
 	},
 	startOpenAiOAuthBrowser: async (params: {model: string}) => {
-		const response = await fetch(`${getApiBase()}/providers/openai/browser-oauth/start`, {
+		const response = await authedFetch(`${getApiBase()}/providers/openai/browser-oauth/start`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
@@ -1824,7 +1825,7 @@ export const api = {
 		return response.json() as Promise<Types.OpenAiOAuthBrowserStartResponse>;
 	},
 	openAiOAuthBrowserStatus: async (state: string) => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/providers/openai/browser-oauth/status?state=${encodeURIComponent(state)}`,
 		);
 		if (!response.ok) {
@@ -1833,7 +1834,7 @@ export const api = {
 		return response.json() as Promise<Types.OpenAiOAuthBrowserStatusResponse>;
 	},
 	removeProvider: async (provider: string) => {
-		const response = await fetch(`${getApiBase()}/providers/${encodeURIComponent(provider)}`, {
+		const response = await authedFetch(`${getApiBase()}/providers/${encodeURIComponent(provider)}`, {
 			method: "DELETE",
 		});
 		if (!response.ok) {
@@ -1851,7 +1852,7 @@ export const api = {
 		return fetchJson<Types.ModelsResponse>(`/models${query}`);
 	},
 	refreshModels: async () => {
-		const response = await fetch(`${getApiBase()}/models/refresh`, {
+		const response = await authedFetch(`${getApiBase()}/models/refresh`, {
 			method: "POST",
 		});
 		if (!response.ok) {
@@ -1869,7 +1870,7 @@ export const api = {
 		for (const file of files) {
 			formData.append("files", file);
 		}
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/agents/ingest/files?agent_id=${encodeURIComponent(agentId)}`,
 			{ method: "POST", body: formData },
 		);
@@ -1881,7 +1882,7 @@ export const api = {
 
 	deleteIngestFile: async (agentId: string, contentHash: string) => {
 		const params = new URLSearchParams({ agent_id: agentId, content_hash: contentHash });
-		const response = await fetch(`${getApiBase()}/agents/ingest/files?${params}`, {
+		const response = await authedFetch(`${getApiBase()}/agents/ingest/files?${params}`, {
 			method: "DELETE",
 		});
 		if (!response.ok) {
@@ -1901,7 +1902,7 @@ export const api = {
 	},
 
 	createBinding: async (request: CreateBindingRequest) => {
-		const response = await fetch(`${getApiBase()}/bindings`, {
+		const response = await authedFetch(`${getApiBase()}/bindings`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -1913,7 +1914,7 @@ export const api = {
 	},
 
 	updateBinding: async (request: UpdateBindingRequest) => {
-		const response = await fetch(`${getApiBase()}/bindings`, {
+		const response = await authedFetch(`${getApiBase()}/bindings`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -1925,7 +1926,7 @@ export const api = {
 	},
 
 	deleteBinding: async (request: DeleteBindingRequest) => {
-		const response = await fetch(`${getApiBase()}/bindings`, {
+		const response = await authedFetch(`${getApiBase()}/bindings`, {
 			method: "DELETE",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -1942,7 +1943,7 @@ export const api = {
 			enabled,
 			adapter: adapter ?? null,
 		};
-		const response = await fetch(`${getApiBase()}/messaging/toggle`, {
+		const response = await authedFetch(`${getApiBase()}/messaging/toggle`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(body),
@@ -1958,7 +1959,7 @@ export const api = {
 			platform,
 			adapter: adapter ?? null,
 		};
-		const response = await fetch(`${getApiBase()}/messaging/disconnect`, {
+		const response = await authedFetch(`${getApiBase()}/messaging/disconnect`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(body),
@@ -1970,7 +1971,7 @@ export const api = {
 	},
 
 	createMessagingInstance: async (request: Types.CreateMessagingInstanceRequest) => {
-		const response = await fetch(`${getApiBase()}/messaging/instances`, {
+		const response = await authedFetch(`${getApiBase()}/messaging/instances`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -1982,7 +1983,7 @@ export const api = {
 	},
 
 	deleteMessagingInstance: async (request: Types.DeleteMessagingInstanceRequest) => {
-		const response = await fetch(`${getApiBase()}/messaging/instances`, {
+		const response = await authedFetch(`${getApiBase()}/messaging/instances`, {
 			method: "DELETE",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -1997,7 +1998,7 @@ export const api = {
 	globalSettings: () => fetchJson<Types.GlobalSettingsResponse>("/settings"),
 	
 	updateGlobalSettings: async (settings: Types.GlobalSettingsUpdate) => {
-		const response = await fetch(`${getApiBase()}/settings`, {
+		const response = await authedFetch(`${getApiBase()}/settings`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(settings),
@@ -2011,7 +2012,7 @@ export const api = {
 	// Raw config API
 	rawConfig: () => fetchJson<Types.RawConfigResponse>("/settings/raw"),
 	updateRawConfig: async (content: string) => {
-		const response = await fetch(`${getApiBase()}/settings/raw`, {
+		const response = await authedFetch(`${getApiBase()}/settings/raw`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ content }),
@@ -2031,14 +2032,14 @@ export const api = {
 	// Update API
 	updateCheck: () => fetchJson<UpdateStatus>("/update-check"),
 	updateCheckNow: async () => {
-		const response = await fetch(`${getApiBase()}/update-check`, { method: "POST" });
+		const response = await authedFetch(`${getApiBase()}/update-check`, { method: "POST" });
 		if (!response.ok) {
 			throw new Error(`API error: ${response.status}`);
 		}
 		return response.json() as Promise<UpdateStatus>;
 	},
 	updateApply: async () => {
-		const response = await fetch(`${getApiBase()}/update-apply`, { method: "POST" });
+		const response = await authedFetch(`${getApiBase()}/update-apply`, { method: "POST" });
 		if (!response.ok) {
 			throw new Error(`API error: ${response.status}`);
 		}
@@ -2050,7 +2051,7 @@ export const api = {
 		fetchJson<SkillsListResponse>(`/agents/skills?agent_id=${encodeURIComponent(agentId)}`),
 	
 	installSkill: async (request: InstallSkillRequest) => {
-		const response = await fetch(`${getApiBase()}/agents/skills/install`, {
+		const response = await authedFetch(`${getApiBase()}/agents/skills/install`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2062,7 +2063,7 @@ export const api = {
 	},
 	
 	removeSkill: async (request: RemoveSkillRequest) => {
-		const response = await fetch(`${getApiBase()}/agents/skills/remove`, {
+		const response = await authedFetch(`${getApiBase()}/agents/skills/remove`, {
 			method: "DELETE",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2083,7 +2084,7 @@ export const api = {
 		for (const file of files) {
 			form.append("file", file);
 		}
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/agents/skills/upload?agent_id=${encodeURIComponent(agentId)}`,
 			{ method: "POST", body: form },
 		);
@@ -2115,7 +2116,7 @@ export const api = {
 	agentLinks: (agentId: string) =>
 		fetchJson<LinksResponse>(`/agents/${encodeURIComponent(agentId)}/links`),
 	createLink: async (request: CreateLinkRequest): Promise<{ link: AgentLinkResponse }> => {
-		const response = await fetch(`${getApiBase()}/links`, {
+		const response = await authedFetch(`${getApiBase()}/links`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2126,7 +2127,7 @@ export const api = {
 		return response.json() as Promise<{ link: AgentLinkResponse }>;
 	},
 	updateLink: async (from: string, to: string, request: UpdateLinkRequest): Promise<{ link: AgentLinkResponse }> => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/links/${encodeURIComponent(from)}/${encodeURIComponent(to)}`,
 			{
 				method: "PUT",
@@ -2140,7 +2141,7 @@ export const api = {
 		return response.json() as Promise<{ link: AgentLinkResponse }>;
 	},
 	deleteLink: async (from: string, to: string): Promise<void> => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/links/${encodeURIComponent(from)}/${encodeURIComponent(to)}`,
 			{ method: "DELETE" },
 		);
@@ -2152,7 +2153,7 @@ export const api = {
 	// Agent Groups API
 	groups: () => fetchJson<{ groups: TopologyGroup[] }>("/links/groups"),
 	createGroup: async (request: CreateGroupRequest): Promise<{ group: TopologyGroup }> => {
-		const response = await fetch(`${getApiBase()}/links/groups`, {
+		const response = await authedFetch(`${getApiBase()}/links/groups`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2163,7 +2164,7 @@ export const api = {
 		return response.json() as Promise<{ group: TopologyGroup }>;
 	},
 	updateGroup: async (name: string, request: UpdateGroupRequest): Promise<{ group: TopologyGroup }> => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/links/groups/${encodeURIComponent(name)}`,
 			{
 				method: "PUT",
@@ -2177,7 +2178,7 @@ export const api = {
 		return response.json() as Promise<{ group: TopologyGroup }>;
 	},
 	deleteGroup: async (name: string): Promise<void> => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/links/groups/${encodeURIComponent(name)}`,
 			{ method: "DELETE" },
 		);
@@ -2189,7 +2190,7 @@ export const api = {
 	// Humans API
 	humans: () => fetchJson<{ humans: TopologyHuman[] }>("/links/humans"),
 	createHuman: async (request: CreateHumanRequest): Promise<{ human: TopologyHuman }> => {
-		const response = await fetch(`${getApiBase()}/links/humans`, {
+		const response = await authedFetch(`${getApiBase()}/links/humans`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2200,7 +2201,7 @@ export const api = {
 		return response.json() as Promise<{ human: TopologyHuman }>;
 	},
 	updateHuman: async (id: string, request: UpdateHumanRequest): Promise<{ human: TopologyHuman }> => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/links/humans/${encodeURIComponent(id)}`,
 			{
 				method: "PUT",
@@ -2214,7 +2215,7 @@ export const api = {
 		return response.json() as Promise<{ human: TopologyHuman }>;
 	},
 	deleteHuman: async (id: string): Promise<void> => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/links/humans/${encodeURIComponent(id)}`,
 			{ method: "DELETE" },
 		);
@@ -2227,7 +2228,7 @@ export const api = {
 	uploadAttachment: (agentId: string, channelId: string, file: File) => {
 		const form = new FormData();
 		form.append("file", file, file.name);
-		return fetch(
+		return authedFetch(
 			`${getApiBase()}/agents/${encodeURIComponent(agentId)}/channels/${encodeURIComponent(channelId)}/attachments/upload`,
 			{ method: "POST", body: form },
 		);
@@ -2252,7 +2253,7 @@ export const api = {
 
 	// Portal API (renamed from webchat)
 	portalSend: (agentId: string, sessionId: string, message: string, senderName?: string, attachmentIds?: string[]) =>
-		fetch(`${getApiBase()}/portal/send`, {
+		authedFetch(`${getApiBase()}/portal/send`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
@@ -2265,7 +2266,7 @@ export const api = {
 		}),
 
 	portalHistory: (agentId: string, sessionId: string, limit = 100) =>
-		fetch(`${getApiBase()}/portal/history?agent_id=${encodeURIComponent(agentId)}&session_id=${encodeURIComponent(sessionId)}&limit=${limit}`),
+		authedFetch(`${getApiBase()}/portal/history?agent_id=${encodeURIComponent(agentId)}&session_id=${encodeURIComponent(sessionId)}&limit=${limit}`),
 
 	listPortalConversations: (
 		agentId: string,
@@ -2281,7 +2282,7 @@ export const api = {
 		title?: string,
 		settings?: Types.ConversationSettings,
 	): Promise<Types.PortalConversationResponse> => {
-		const response = await fetch(`${getApiBase()}/portal/conversations`, {
+		const response = await authedFetch(`${getApiBase()}/portal/conversations`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ agent_id: agentId, title, settings }),
@@ -2297,7 +2298,7 @@ export const api = {
 		archived?: boolean,
 		settings?: Types.ConversationSettings,
 	): Promise<Types.PortalConversationResponse> => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/portal/conversations/${encodeURIComponent(sessionId)}`,
 			{
 				method: "PUT",
@@ -2313,7 +2314,7 @@ export const api = {
 		agentId: string,
 		sessionId: string,
 	): Promise<{ success: boolean }> => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/portal/conversations/${encodeURIComponent(sessionId)}?agent_id=${encodeURIComponent(agentId)}`,
 			{ method: "DELETE" },
 		);
@@ -2331,7 +2332,7 @@ export const api = {
 		),
 
 	updateChannelSettings: (channelId: string, agentId: string, settings: Types.ConversationSettings) =>
-		fetch(`${getApiBase()}/channels/${encodeURIComponent(channelId)}/settings`, {
+		authedFetch(`${getApiBase()}/channels/${encodeURIComponent(channelId)}/settings`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ agent_id: agentId, settings }),
@@ -2353,7 +2354,7 @@ export const api = {
 	getTask: (taskNumber: number) =>
 		fetchJson<TaskResponse>(`/tasks/${taskNumber}`),
 	createTask: async (request: CreateTaskRequest): Promise<TaskResponse> => {
-		const response = await fetch(`${getApiBase()}/tasks`, {
+		const response = await authedFetch(`${getApiBase()}/tasks`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2362,7 +2363,7 @@ export const api = {
 		return response.json() as Promise<TaskResponse>;
 	},
 	updateTask: async (taskNumber: number, request: UpdateTaskRequest): Promise<TaskResponse> => {
-		const response = await fetch(`${getApiBase()}/tasks/${taskNumber}`, {
+		const response = await authedFetch(`${getApiBase()}/tasks/${taskNumber}`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2371,14 +2372,14 @@ export const api = {
 		return response.json() as Promise<TaskResponse>;
 	},
 	deleteTask: async (taskNumber: number): Promise<TaskActionResponse> => {
-		const response = await fetch(`${getApiBase()}/tasks/${taskNumber}`, {
+		const response = await authedFetch(`${getApiBase()}/tasks/${taskNumber}`, {
 			method: "DELETE",
 		});
 		if (!response.ok) throw new Error(`API error: ${response.status}`);
 		return response.json() as Promise<TaskActionResponse>;
 	},
 	approveTask: async (taskNumber: number, approvedBy?: string): Promise<TaskResponse> => {
-		const response = await fetch(`${getApiBase()}/tasks/${taskNumber}/approve`, {
+		const response = await authedFetch(`${getApiBase()}/tasks/${taskNumber}/approve`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ approved_by: approvedBy }),
@@ -2387,7 +2388,7 @@ export const api = {
 		return response.json() as Promise<TaskResponse>;
 	},
 	executeTask: async (taskNumber: number): Promise<TaskResponse> => {
-		const response = await fetch(`${getApiBase()}/tasks/${taskNumber}/execute`, {
+		const response = await authedFetch(`${getApiBase()}/tasks/${taskNumber}/execute`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({}),
@@ -2396,7 +2397,7 @@ export const api = {
 		return response.json() as Promise<TaskResponse>;
 	},
 	assignTask: async (taskNumber: number, assignedAgentId: string): Promise<TaskResponse> => {
-		const response = await fetch(`${getApiBase()}/tasks/${taskNumber}/assign`, {
+		const response = await authedFetch(`${getApiBase()}/tasks/${taskNumber}/assign`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ assigned_agent_id: assignedAgentId }),
@@ -2409,7 +2410,7 @@ export const api = {
 	secretsStatus: () => fetchJson<SecretStoreStatus>("/secrets/status"),
 	listSecrets: () => fetchJson<SecretListResponse>("/secrets"),
 	putSecret: async (name: string, value: string, category?: SecretCategory): Promise<PutSecretResponse> => {
-		const response = await fetch(`${getApiBase()}/secrets/${encodeURIComponent(name)}`, {
+		const response = await authedFetch(`${getApiBase()}/secrets/${encodeURIComponent(name)}`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ value, category }),
@@ -2421,7 +2422,7 @@ export const api = {
 		return response.json() as Promise<PutSecretResponse>;
 	},
 	deleteSecret: async (name: string): Promise<DeleteSecretResponse> => {
-		const response = await fetch(`${getApiBase()}/secrets/${encodeURIComponent(name)}`, {
+		const response = await authedFetch(`${getApiBase()}/secrets/${encodeURIComponent(name)}`, {
 			method: "DELETE",
 		});
 		if (!response.ok) {
@@ -2431,7 +2432,7 @@ export const api = {
 		return response.json() as Promise<DeleteSecretResponse>;
 	},
 	enableEncryption: async (): Promise<EncryptResponse> => {
-		const response = await fetch(`${getApiBase()}/secrets/encrypt`, { method: "POST" });
+		const response = await authedFetch(`${getApiBase()}/secrets/encrypt`, { method: "POST" });
 		if (!response.ok) {
 			const body = await response.json().catch(() => ({}));
 			throw new Error(body.error || `API error: ${response.status}`);
@@ -2439,7 +2440,7 @@ export const api = {
 		return response.json() as Promise<EncryptResponse>;
 	},
 	unlockSecrets: async (masterKey: string): Promise<UnlockResponse> => {
-		const response = await fetch(`${getApiBase()}/secrets/unlock`, {
+		const response = await authedFetch(`${getApiBase()}/secrets/unlock`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ master_key: masterKey }),
@@ -2451,7 +2452,7 @@ export const api = {
 		return response.json() as Promise<UnlockResponse>;
 	},
 	lockSecrets: async (): Promise<{ state: string; message: string }> => {
-		const response = await fetch(`${getApiBase()}/secrets/lock`, { method: "POST" });
+		const response = await authedFetch(`${getApiBase()}/secrets/lock`, { method: "POST" });
 		if (!response.ok) {
 			const body = await response.json().catch(() => ({}));
 			throw new Error(body.error || `API error: ${response.status}`);
@@ -2459,7 +2460,7 @@ export const api = {
 		return response.json() as Promise<{ state: string; message: string }>;
 	},
 	rotateKey: async (): Promise<{ master_key: string; message: string }> => {
-		const response = await fetch(`${getApiBase()}/secrets/rotate`, { method: "POST" });
+		const response = await authedFetch(`${getApiBase()}/secrets/rotate`, { method: "POST" });
 		if (!response.ok) {
 			const body = await response.json().catch(() => ({}));
 			throw new Error(body.error || `API error: ${response.status}`);
@@ -2467,7 +2468,7 @@ export const api = {
 		return response.json() as Promise<{ master_key: string; message: string }>;
 	},
 	migrateSecrets: async (): Promise<MigrateResponse> => {
-		const response = await fetch(`${getApiBase()}/secrets/migrate`, { method: "POST" });
+		const response = await authedFetch(`${getApiBase()}/secrets/migrate`, { method: "POST" });
 		if (!response.ok) {
 			const body = await response.json().catch(() => ({}));
 			throw new Error(body.error || `API error: ${response.status}`);
@@ -2489,7 +2490,7 @@ export const api = {
 		),
 
 	createProject: async (request: CreateProjectRequest): Promise<ProjectWithRelations> => {
-		const response = await fetch(`${getApiBase()}/agents/projects`, {
+		const response = await authedFetch(`${getApiBase()}/agents/projects`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2499,7 +2500,7 @@ export const api = {
 	},
 
 	updateProject: async (projectId: string, request: UpdateProjectRequest): Promise<ProjectWithRelations> => {
-		const response = await fetch(`${getApiBase()}/agents/projects/${encodeURIComponent(projectId)}`, {
+		const response = await authedFetch(`${getApiBase()}/agents/projects/${encodeURIComponent(projectId)}`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2509,7 +2510,7 @@ export const api = {
 	},
 
 	deleteProject: async (projectId: string): Promise<ProjectActionResponse> => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/agents/projects/${encodeURIComponent(projectId)}`,
 			{ method: "DELETE" },
 		);
@@ -2518,7 +2519,7 @@ export const api = {
 	},
 
 	scanProject: async (projectId: string): Promise<ProjectWithRelations> => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/agents/projects/${encodeURIComponent(projectId)}/scan`,
 			{ method: "POST" },
 		);
@@ -2527,7 +2528,7 @@ export const api = {
 	},
 
 	reorderProjects: async (ids: string[]): Promise<void> => {
-		const response = await fetch(`${getApiBase()}/agents/projects/reorder`, {
+		const response = await authedFetch(`${getApiBase()}/agents/projects/reorder`, {
 			method: "PUT",
 			headers: {"Content-Type": "application/json"},
 			body: JSON.stringify({ids}),
@@ -2541,7 +2542,7 @@ export const api = {
 		),
 
 	createProjectRepo: async (projectId: string, request: CreateRepoRequest): Promise<{ repo: ProjectRepo }> => {
-		const response = await fetch(`${getApiBase()}/agents/projects/${encodeURIComponent(projectId)}/repos`, {
+		const response = await authedFetch(`${getApiBase()}/agents/projects/${encodeURIComponent(projectId)}/repos`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2551,7 +2552,7 @@ export const api = {
 	},
 
 	deleteProjectRepo: async (projectId: string, repoId: string): Promise<ProjectActionResponse> => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/agents/projects/${encodeURIComponent(projectId)}/repos/${encodeURIComponent(repoId)}`,
 			{ method: "DELETE" },
 		);
@@ -2560,7 +2561,7 @@ export const api = {
 	},
 
 	createProjectWorktree: async (projectId: string, request: CreateWorktreeRequest): Promise<{ worktree: ProjectWorktree }> => {
-		const response = await fetch(`${getApiBase()}/agents/projects/${encodeURIComponent(projectId)}/worktrees`, {
+		const response = await authedFetch(`${getApiBase()}/agents/projects/${encodeURIComponent(projectId)}/worktrees`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2570,7 +2571,7 @@ export const api = {
 	},
 
 	deleteProjectWorktree: async (projectId: string, worktreeId: string): Promise<ProjectActionResponse> => {
-		const response = await fetch(
+		const response = await authedFetch(
 			`${getApiBase()}/agents/projects/${encodeURIComponent(projectId)}/worktrees/${encodeURIComponent(worktreeId)}`,
 			{ method: "DELETE" },
 		);
@@ -2606,38 +2607,38 @@ export const api = {
 		if (params?.limit !== undefined) query.set("limit", String(params.limit));
 		if (params?.offset !== undefined) query.set("offset", String(params.offset));
 		const qs = query.toString();
-		const response = await fetch(`${getApiBase()}/notifications${qs ? `?${qs}` : ""}`);
+		const response = await authedFetch(`${getApiBase()}/notifications${qs ? `?${qs}` : ""}`);
 		if (!response.ok) throw new Error(`API error: ${response.status}`);
 		return response.json() as Promise<NotificationsResponse>;
 	},
 
 	getUnreadCount: async (): Promise<UnreadCountResponse> => {
-		const response = await fetch(`${getApiBase()}/notifications/unread_count`);
+		const response = await authedFetch(`${getApiBase()}/notifications/unread_count`);
 		if (!response.ok) throw new Error(`API error: ${response.status}`);
 		return response.json() as Promise<UnreadCountResponse>;
 	},
 
 	markNotificationRead: async (id: string): Promise<void> => {
-		const response = await fetch(`${getApiBase()}/notifications/${encodeURIComponent(id)}/read`, {
+		const response = await authedFetch(`${getApiBase()}/notifications/${encodeURIComponent(id)}/read`, {
 			method: "POST",
 		});
 		if (!response.ok && response.status !== 404) throw new Error(`API error: ${response.status}`);
 	},
 
 	dismissNotification: async (id: string): Promise<void> => {
-		const response = await fetch(`${getApiBase()}/notifications/${encodeURIComponent(id)}/dismiss`, {
+		const response = await authedFetch(`${getApiBase()}/notifications/${encodeURIComponent(id)}/dismiss`, {
 			method: "POST",
 		});
 		if (!response.ok && response.status !== 404) throw new Error(`API error: ${response.status}`);
 	},
 
 	markAllNotificationsRead: async (): Promise<void> => {
-		const response = await fetch(`${getApiBase()}/notifications/read_all`, { method: "POST" });
+		const response = await authedFetch(`${getApiBase()}/notifications/read_all`, { method: "POST" });
 		if (!response.ok) throw new Error(`API error: ${response.status}`);
 	},
 
 	dismissReadNotifications: async (): Promise<void> => {
-		const response = await fetch(`${getApiBase()}/notifications/dismiss_read`, { method: "POST" });
+		const response = await authedFetch(`${getApiBase()}/notifications/dismiss_read`, { method: "POST" });
 		if (!response.ok) throw new Error(`API error: ${response.status}`);
 	},
 
@@ -2663,7 +2664,7 @@ export const api = {
 	},
 
 	createWikiPage: async (request: CreateWikiPageRequest): Promise<WikiPageResponse> => {
-		const response = await fetch(`${getApiBase()}/wiki`, {
+		const response = await authedFetch(`${getApiBase()}/wiki`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2673,7 +2674,7 @@ export const api = {
 	},
 
 	editWikiPage: async (slug: string, request: EditWikiPageRequest): Promise<WikiPageResponse> => {
-		const response = await fetch(`${getApiBase()}/wiki/${encodeURIComponent(slug)}/edit`, {
+		const response = await authedFetch(`${getApiBase()}/wiki/${encodeURIComponent(slug)}/edit`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(request),
@@ -2686,7 +2687,7 @@ export const api = {
 		fetchJson<WikiHistoryResponse>(`/wiki/${encodeURIComponent(slug)}/history?limit=${limit}`),
 
 	restoreWikiVersion: async (slug: string, version: number): Promise<WikiPageResponse> => {
-		const response = await fetch(`${getApiBase()}/wiki/${encodeURIComponent(slug)}/restore`, {
+		const response = await authedFetch(`${getApiBase()}/wiki/${encodeURIComponent(slug)}/restore`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ version }),
@@ -2696,7 +2697,7 @@ export const api = {
 	},
 
 	archiveWikiPage: async (slug: string): Promise<{ success: boolean; message: string }> => {
-		const response = await fetch(`${getApiBase()}/wiki/${encodeURIComponent(slug)}`, {
+		const response = await authedFetch(`${getApiBase()}/wiki/${encodeURIComponent(slug)}`, {
 			method: "DELETE",
 		});
 		if (!response.ok) throw new Error(`API error: ${response.status}`);

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -69,6 +69,11 @@ export async function getAuthToken(): Promise<string | null> {
 	}
 }
 
+// Phase 6 Task 6.B.2: central fetch wrapper. Defined in a sibling module
+// so the Task 6.B.3 sed pass doesn't risk recursing its own
+// `fetch(input, { ...init, headers })` call into `authedFetch(...)`.
+export { authedFetch } from "./authedFetch";
+
 import type * as Types from "./types";
 
 // Re-export commonly used types from schema for backward compatibility

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -367,7 +367,9 @@ export interface TimelineWorkerRun {
 async function fetchJson<T>(path: string): Promise<T> {
 	const response = await authedFetch(`${getApiBase()}${path}`);
 	if (!response.ok) {
-		throw new Error(`API error: ${response.status}`);
+		// Include the path so operators + Sentry breadcrumbs can identify
+		// which endpoint returned the error status.
+		throw new Error(`API error ${response.status}: ${path}`);
 	}
 	return response.json();
 }

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -70,8 +70,8 @@ export async function getAuthToken(): Promise<string | null> {
 }
 
 // Phase 6 Task 6.B.2: central fetch wrapper. Defined in a sibling
-// module so the Task 6.B.3 sed pass doesn't risk recursing its own
-// delegation into a browser primitive call.
+// module to keep this file free of raw `fetch(` calls, so any future
+// sed-based migration pass has zero valid migration targets here.
 import { authedFetch } from "./authedFetch";
 export { authedFetch };
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -74,6 +74,10 @@ export async function getAuthToken(): Promise<string | null> {
 // sed-based migration pass has zero valid migration targets here.
 import { authedFetch } from "./authedFetch";
 export { authedFetch };
+export type {
+	AuthExhaustedDetail,
+	AuthExhaustedReason,
+} from "./authedFetch";
 
 import type * as Types from "./types";
 


### PR DESCRIPTION
## Summary

- New `packages/api-client/src/authedFetch.ts` sibling module: drop-in `fetch()` replacement that attaches `Authorization: Bearer <token>` when the PR A token provider yields one, retries once on 401 after a fresh token, and retries up to 3× on 202 for the Phase 3 Graph-sync race.
- Mechanical migration of **88 inline `fetch()` call sites across 2,867 lines** in `packages/api-client/src/client.ts` to `authedFetch()` — all REST + streaming calls (except SSE, which PR C handles) now carry the Entra bearer.
- 12 new vitest cases in `interface/src/auth/__tests__/authedFetch.test.ts` pinning header attachment, FormData + Blob Content-Type safety, 401-retry semantics, and the two-budget deterministic retry state machine.

## Design — two independent retry budgets + hard safety cap

| Budget | Cap | Fires on | Rationale |
|---|---|---|---|
| `authAttempts` | 1 | 401 Unauthorized | Second consecutive 401 with a fresh token is an operator problem (`aud`, tenant, clock-skew). No client retry will help. |
| `syncAttempts` | 3 | 202 Accepted | Phase 3 A-10 group-sync race: `Retry-After: 2` × 3 retries buys 6s of wait. |
| `totalAttempts` | 5 | safety net | Terminates any pathological 401↔202 loop that evades per-dimension budgets. |

A 401 refresh does NOT consume the 202 budget (and vice versa). The D8 deterministic-trace test pins this: `401 → 202 → 401` returns 401 after exactly 3 calls because the 2nd 401 finds `authAttempts=1 !< AUTH_CAP=1`.

## Why a sibling module (O1)

`authedFetch` lives in its own file, NOT inside `client.ts`. Previous plan drafts had it inline, which would have required a `// AUTHEDFETCH_IMPL_END`-style guard to stop the Task 6.B.3 sed pass from rewriting `authedFetch`'s own internal `fetch(input, { ...init, headers })` call into `authedFetch(...)` — infinite recursion. The extraction eliminates the entire bug class structurally: the sed pass runs against `client.ts` only, and `authedFetch.ts` contains exactly one `fetch(` call by design.

## Observability

`authedFetch` dispatches `spacebot:auth-exhausted` CustomEvent on the `window` when auth is unrecoverable — both the `no_token_on_retry` and `refresh_failed` paths. Downstream telemetry (Sentry, ReactQuery invalidation, toast banner) can wire a listener without coupling this primitive to any specific sink.

## Review-fold corrections applied from plan (2026-04-23 PR B pre-code audit)

- **D1/D2/D5** — Uses PR A's shipped `setAuthTokenProvider` + `getAuthToken`; no redeclaration. Provider that throws produces null from `getAuthToken`, which authedFetch treats as "no auth available" and omits the header.
- **D3** — New test: if the provider yields null on 401-retry, return the 401 without a no-header loop.
- **D4/O1** — `authedFetch` extracted to sibling module, eliminating sed-recursion class.
- **D6** — PR C concern (removing `@ts-expect-error` once `./mockMsal` exists), not PR B.
- **D8** — Deterministic `401→202→401 = 3 calls` trace replaces prior weak "either 401 or 202" assertion.
- **D9** — Retry-After fallback hardened: 1000ms default + 10s clamp to prevent malicious-proxy sleep attacks.
- **D10** — `fetchJson` now throws `fetch failed: 401` after 2 fetch calls (original + refresh retry) instead of 1. Strictly better.
- **G1/G2/G3/G4** — New tests for Blob body Content-Type safety, Headers-instance acceptance, sync-cap fires deterministically at attempt 4, and disabled-mode 401 passthrough.
- **G5** — Migration scope explicit: 1× `fetchJson` + 87× inline api-object closures, all via `\bfetch(` sed.
- **G7** — Test file mirrors `authTokenProvider.test.ts` pattern (PR A) for consistent reset semantics.
- **O2** — `spacebot:auth-exhausted` CustomEvent on no-token-on-retry + refresh-failed paths.
- **O3** — `RetryState` privatized via `authedFetchInner`; public `authedFetch(input, init?)` has no budget-tuning knobs.
- **O4** — This PR description uses verified counts (88 sites, 2,867 lines). The plan's "2,825 lines" was stale; file is 2,867 after this PR's net +5 lines (import + 92 deletion + 93 insertion).

## Deploy ordering (G6 — important)

After this PR merges but before PR C merges, the SSE endpoint (`/api/events`) remains on native `EventSource`, which cannot send `Authorization` headers. An Entra-enabled deployment between PR B and PR C merges would:

- ✅ REST `/api/*` calls authenticated via `authedFetch`
- ❌ SSE `/api/events` rejected with 401 by Entra middleware

**Production order:** merge PR A (✅ done) → merge this PR B → merge PR C → only then enable `[api.auth.entra].enabled = true`. Staging with Entra enabled between B and C is fine if SSE-dependent flows are known broken.

## Site-count + file-size verification (O4)

```bash
$ grep -c '\bfetch(' packages/api-client/src/client.ts
0
$ grep -c '\bauthedFetch(' packages/api-client/src/client.ts
89  # 88 migrated calls + 1 pre-existing doc-comment mention on line 42
$ wc -l packages/api-client/src/client.ts
2867
```

Split per G5: 1 × `fetchJson` helper + 87 × inline closures (~lines 1400-2600) + 1 × new internal import at the top.

## Verification

```bash
cd interface && bunx tsc --noEmit          # clean
cd interface && bun run build              # 3.83s, clean (chunk-size warning pre-existing)
cd interface && bunx vitest run            # 21/21 green
                                           #   authTokenProvider.test.ts: 5
                                           #   AuthGate.test.tsx: 4
                                           #   authedFetch.test.ts: 12
just gate-pr                               # green — all gate checks passed
```

## Test plan

- [x] Failing vitest committed first (TDD red: all 12 fail with "authedFetch is not a function")
- [x] Implementation lands authedFetch in sibling module; tests green
- [x] sed pass migrates 88 sites; no unmigrated `fetch(` remains
- [x] `bunx tsc --noEmit` clean
- [x] `bun run build` clean
- [x] Full vitest suite 21/21
- [x] `just gate-pr` green
- [ ] Manual smoke in mock mode: sign in, confirm `Authorization: Bearer ...` on every `/api/*` call, no `spacebot:auth-exhausted` events on happy path (deferred until PR C so mock mode can exercise the streaming endpoints end-to-end)
- [ ] Playwright e2e (O5 — deferred post-PR-C)

## Related

- Follows Phase 6 PR A (#107, squash `f15d11d`).
- Unblocks Phase 6 PR C (EventSource → fetchEventSource migration).
- Plan: `.scratchpad/plans/entraid-auth/phase-6-spa-msal.md` (gitignored) Tasks 6.B.1 – 6.B.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)