### PR TITLE
feat(spa): Phase 6 PR C — SSE polyfill + /api/me + user menu + mock mode

### DIFF
--- a/docs/content/docs/(configuration)/entra-auth.mdx
+++ b/docs/content/docs/(configuration)/entra-auth.mdx
@@ -189,6 +189,104 @@ Rare after Phase 6 (the error banner above should cover most cases), but possibl
 
 The Entra middleware branch didn't install. Most likely `[api.auth.entra].enabled` is false or the config failed TOML resolution at startup. Re-check logs for the validator startup line. See [`docs/design-docs/entra-audit-log.md`](https://github.com/jrmatherly/spacebot/blob/main/docs/design-docs/entra-audit-log.md) for the full audit-event shape.
 
+## Server-sent events under Entra
+
+Phase 6 PR C swapped the SPA's native `EventSource` for [`@microsoft/fetch-event-source`](https://github.com/Azure/fetch-event-source) so the stream can carry `Authorization: Bearer <token>`. Native `EventSource` cannot attach custom headers, so under Entra the `/api/events` stream would otherwise arrive unauthenticated and return 401.
+
+The transport change is invisible to the existing `useEventSource` hook contract. The hook still accepts `handlers: Record<string, EventHandler>` + `enabled` + `onReconnect` and returns `{ connectionState }`. Downstream consumers like `useLiveContext` and the `ConnectionBanner` component work without modification. SSE now inherits the same auth behavior as every REST call:
+
+- Authorization header attached when a token provider is set
+- 401 retries once with a forced refresh token
+- `spacebot:auth-exhausted` CustomEvent dispatched on unrecoverable auth
+
+### Deploy-ordering note
+
+An Entra-enabled deployment between PR B merge and PR C merge would have REST calls authenticated but SSE rejected with 401. Production rollout order:
+
+1. Merge PR A (runtime config + AuthGate). Done.
+2. Merge PR B (authedFetch + 88-site migration). Done.
+3. Merge PR C (SSE polyfill + /api/me + mock mode). This PR.
+4. Only then enable `[api.auth.entra].enabled = true` in production config.
+
+Do NOT enable Entra between PR B and PR C merges. A staging deployment with Entra enabled between those two merges is fine as long as SSE-dependent flows are known broken.
+
+## Sign-out and the user menu
+
+The header shows the signed-in principal's display name plus a sign-out control rendered by `UserMenu.tsx`. Sign-out calls `msal.logoutRedirect({ account, postLogoutRedirectUri: window.location.origin })`, which returns the browser to the SPA root; MSAL clears its in-memory cache (plus `localStorage` when the A-17 "Stay signed in on this device" opt-in is active).
+
+When Entra is disabled, the `MsalProvider` is absent and `useMsal` returns an empty accounts array. `UserMenu` gracefully returns `null` in that case so the header region stays empty in static-token deployments.
+
+## `/api/me` — consolidated principal endpoint (A-18, A-19)
+
+The SPA reads identity, roles, groups, and photo/initials from a single `GET /api/me` call. The frontend `useMe()` hook in `interface/src/auth/useMe.ts` returns the full shape:
+
+```json
+{
+  "principal_key": "tenant-1:alice",
+  "tid": "tenant-1",
+  "oid": "alice",
+  "principal_type": "user",
+  "display_name": "Alice Example",
+  "display_email": "alice@example.com",
+  "display_photo_data_url": "data:image/jpeg;base64,…",
+  "initials": null,
+  "roles": ["SpacebotUser"],
+  "groups": ["engineering", "platform"],
+  "groups_overage": false
+}
+```
+
+- **`display_photo_data_url`** is populated from the 7-day TTL cache of Microsoft Graph `GET /me/photo/$value`. When the account has no photo (HTTP 404 from Graph), the cache row stays in the photo-absent state and the TTL prevents re-fetching on every subsequent request.
+- **`initials`** is computed from the first letters of the display name (up to 3 chars) and populated only when `display_photo_data_url` is null. The SPA never has to branch on both absent.
+- **`groups_overage: true`** indicates the principal belongs to more than the 200-group SPA-6 payload limit; the daemon resolved the full list via Graph.
+
+`useRole("SpacebotAdmin")` reads from the same hook so there is one source of truth for the principal's roles.
+
+## Local development — VITE_AUTH_MOCK
+
+Setting `VITE_AUTH_MOCK=1` in `interface/.env.development.local` activates a mock MSAL instance that mints JSON-base64url tokens compatible with the daemon's `MockValidator` (Phase 4 PR 1). No real Entra tenant is required. Three env vars shape the mock principal:
+
+```
+VITE_AUTH_MOCK=1
+VITE_MOCK_TID=tenant-mock
+VITE_MOCK_OID=alice
+VITE_MOCK_ROLES=SpacebotUser,SpacebotAdmin
+```
+
+On the daemon side, set `[api.auth.entra].mock_mode = true` in `config.toml` to accept the mock tokens. Both halves must be configured for the local flow to work end-to-end. The mock tokens carry `principal_type: "user"` and the roles you specify; `groups` defaults to an empty array.
+
+## Additional troubleshooting (PR C surfaces)
+
+### SSE streams silently stopped updating after sign-in
+
+Verify `@microsoft/fetch-event-source` is installed in `interface/`:
+
+```bash
+grep '"@microsoft/fetch-event-source"' interface/package.json
+```
+
+If missing, the hook still uses native `EventSource` and the 401 path is not wired. Reinstall with `cd interface && bun install`.
+
+### `/api/me` returns 401 but `/api/auth/config` works
+
+This is the expected signal that Entra validation rejected the access token. The access token's `aud` claim must equal the daemon's `[api.auth.entra].audience`. Decode the token at [jwt.ms](https://jwt.ms) and compare.
+
+### `/api/me` returns data but `display_photo_data_url` is always null
+
+Either the Graph photo sync hasn't run (check daemon logs for `sync_user_photo_for_principal`), or the user has no photo set (Graph returned 404, which is normal for many accounts). Inspect the row directly:
+
+```sql
+SELECT display_photo_b64, photo_updated_at
+FROM users
+WHERE principal_key = 'tenant-1:alice';
+```
+
+If `photo_updated_at` is recent but `display_photo_b64` is NULL, the 404-is-normal path ran; the TTL prevents re-fetching for 7 days.
+
+### User menu shows `undefined` / no name
+
+The access token has no `name` claim or the account was read before `handleRedirectPromise` resolved. Refresh the page. If the name stays missing, inspect the users row; the Graph sync populates `display_name` from the ID token's `name` claim, not the access token.
+
 ## Related
 
 - [`entra-app-registrations.md`](https://github.com/jrmatherly/spacebot/blob/main/docs/design-docs/entra-app-registrations.md) — app registration schema, redirect URIs, API permissions, role claims

--- a/docs/content/docs/(configuration)/entra-auth.mdx
+++ b/docs/content/docs/(configuration)/entra-auth.mdx
@@ -83,7 +83,7 @@ The static `auth_token` path at `[api]` level stays available as a fallback. Exa
 Delegated `User.Read` is required for two features:
 
 - **Group overage resolution.** Entra truncates the `groups` claim at 150 entries. Users in more groups receive a `hasgroups: true` flag; the daemon must call Graph's `/me/getMemberObjects` to materialize the full list.
-- **Display photo caching** (A-19). The SPA renders a user photo or initials fallback; the daemon caches the base64 in `users.display_photo_b64` with a weekly TTL.
+- **Display photo caching** (A-19). The SPA renders a user photo or initials fallback; the daemon caches the base64 in `users.display_photo_b64` with a 7-day TTL.
 
 See the Graph API permissions section of [`entra-app-registrations.md`](https://github.com/jrmatherly/spacebot/blob/main/docs/design-docs/entra-app-registrations.md) for the exact OBO permission grant. Without Graph, everything still works but overage users see 403s on team resources until their group membership drops below 150, and user avatars fall back to initials.
 

--- a/interface/bun.lock
+++ b/interface/bun.lock
@@ -22,6 +22,7 @@
         "@fortawesome/react-fontawesome": "^3.3.0",
         "@hookform/resolvers": "^5.2.2",
         "@lobehub/icons": "^5.4.0",
+        "@microsoft/fetch-event-source": "^2.0.1",
         "@phosphor-icons/react": "^2.1.10",
         "@react-sigma/core": "^5.0.6",
         "@spacebot/api-client": "workspace:*",
@@ -498,6 +499,8 @@
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
+
+    "@microsoft/fetch-event-source": ["@microsoft/fetch-event-source@2.0.1", "", {}, "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/interface/package.json
+++ b/interface/package.json
@@ -34,6 +34,7 @@
 		"@fortawesome/react-fontawesome": "^3.3.0",
 		"@hookform/resolvers": "^5.2.2",
 		"@lobehub/icons": "^5.4.0",
+		"@microsoft/fetch-event-source": "^2.0.1",
 		"@phosphor-icons/react": "^2.1.10",
 		"@react-sigma/core": "^5.0.6",
 		"@spacebot/api-client": "workspace:*",

--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from "@tanstack/react-router";
 import { AuthGate } from "@/auth/AuthGate";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ConnectionScreen } from "@/components/ConnectionScreen";
+import { UserMenu } from "@/components/UserMenu";
 import { LiveContextProvider } from "@/hooks/useLiveContext";
 import { ServerProvider, useServer } from "@/hooks/useServer";
 import { router } from "@/router";
@@ -34,6 +35,15 @@ function AppShell() {
 
 	return (
 		<LiveContextProvider onBootstrapped={onBootstrapped}>
+			<header
+				style={{
+					display: "flex",
+					justifyContent: "flex-end",
+					borderBottom: "1px solid var(--color-border, #e5e7eb)",
+				}}
+			>
+				<UserMenu />
+			</header>
 			<RouterProvider router={router} />
 		</LiveContextProvider>
 	);

--- a/interface/src/auth/AuthGate.tsx
+++ b/interface/src/auth/AuthGate.tsx
@@ -39,11 +39,14 @@ type GateState =
 export function AuthGate({ children }: { children: ReactNode }) {
 	const [state, setState] = useState<GateState>({ kind: "loading" });
 
-	// D21 correction (2026-04-23 PR C audit): authedFetch dispatches
-	// spacebot:auth-exhausted on 401 refresh-exhaustion (PR B). SSE via
-	// fetchEventSource(fetch: authedFetch) inherits the same dispatch.
-	// A single window-level listener covers both REST and SSE. Phase 7
-	// replaces this console.warn with a toast banner + Re-sign in CTA.
+	// authedFetch dispatches `spacebot:auth-exhausted` on 401
+	// refresh-exhaustion. SSE via fetchEventSource(fetch: authedFetch)
+	// inherits the same dispatch. A single window-level listener
+	// covers both REST and SSE.
+	//
+	// TODO: replace console.warn with a toast banner + "Re-sign in"
+	// CTA wired to acquireTokenRedirect. Trigger: when the
+	// notifications surface lands (tracked as a Phase 7 scope item).
 	useEffect(() => {
 		const handler = (event: Event) => {
 			const detail = (event as CustomEvent<AuthExhaustedDetail>).detail;

--- a/interface/src/auth/AuthGate.tsx
+++ b/interface/src/auth/AuthGate.tsx
@@ -20,7 +20,10 @@ import {
 	type PublicClientApplication,
 } from "@azure/msal-browser";
 import { MsalProvider } from "@azure/msal-react";
-import { setAuthTokenProvider } from "@spacebot/api-client/client";
+import {
+	setAuthTokenProvider,
+	type AuthExhaustedDetail,
+} from "@spacebot/api-client/client";
 import { useEffect, useState, type ReactNode } from "react";
 import { getActiveScopes, getMsalInstance, loadAuthConfig } from "./msalConfig";
 
@@ -35,6 +38,23 @@ type GateState =
 
 export function AuthGate({ children }: { children: ReactNode }) {
 	const [state, setState] = useState<GateState>({ kind: "loading" });
+
+	// D21 correction (2026-04-23 PR C audit): authedFetch dispatches
+	// spacebot:auth-exhausted on 401 refresh-exhaustion (PR B). SSE via
+	// fetchEventSource(fetch: authedFetch) inherits the same dispatch.
+	// A single window-level listener covers both REST and SSE. Phase 7
+	// replaces this console.warn with a toast banner + Re-sign in CTA.
+	useEffect(() => {
+		const handler = (event: Event) => {
+			const detail = (event as CustomEvent<AuthExhaustedDetail>).detail;
+			console.warn(
+				`[authedFetch] session expired at ${detail.url} (${detail.reason})`,
+			);
+		};
+		window.addEventListener("spacebot:auth-exhausted", handler);
+		return () =>
+			window.removeEventListener("spacebot:auth-exhausted", handler);
+	}, []);
 
 	useEffect(() => {
 		let cancelled = false;

--- a/interface/src/auth/__tests__/AuthGate.test.tsx
+++ b/interface/src/auth/__tests__/AuthGate.test.tsx
@@ -1,12 +1,9 @@
-// Phase 6 Task 6.A.5 — AuthGate state machine tests.
+// AuthGate state machine tests.
 //
-// Covers the two happy-path branches of the gate:
-//   1. entra_disabled → children render directly (static-token deployments)
-//   2. loading → spinner visible before async init resolves
-//
-// The unauthenticated + authenticated branches are exercised by
-// Task 6.C.5's mockMsal-backed integration tests; at this stage we only
-// assert the pre-MSAL states because msalConfig is mocked here.
+// Covers the gate's branches that are reachable without a real MSAL
+// tenant: entra_disabled, loading, and the malformed + fetch-failure
+// error states. The unauthenticated + authenticated branches are
+// exercised by the mockMsal-backed integration tests.
 
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -82,11 +79,10 @@ describe("AuthGate", () => {
 		});
 	});
 
-	/// PR #107 review I4/I5 remediation: when /api/auth/config reports
-	/// `entra_enabled: true` but omits identifiers, AuthGate renders an
-	/// operator-visible error banner instead of fail-open to
-	/// `entra_disabled` (which previously masked daemon config bugs
-	/// behind a 401-loop UI).
+	/// When /api/auth/config reports `entra_enabled: true` but omits
+	/// identifiers, AuthGate renders an operator-visible error banner
+	/// instead of falling open to `entra_disabled` (which previously
+	/// masked daemon config bugs behind a 401-loop UI).
 	it("renders an error banner when entra is configured but malformed", async () => {
 		vi.mocked(msalConfig.loadAuthConfig).mockResolvedValueOnce({
 			entra_enabled: true,
@@ -113,9 +109,9 @@ describe("AuthGate", () => {
 		expect(screen.queryByText("child-content")).not.toBeInTheDocument();
 	});
 
-	/// PR #107 review I4 remediation: loadAuthConfig failure (e.g., 500
-	/// from /api/auth/config, or a network error) now surfaces as a
-	/// diagnostic banner, not a stuck spinner or a silent fail-open.
+	/// loadAuthConfig failure (e.g., 500 from /api/auth/config, or a
+	/// network error) surfaces as a diagnostic banner, not a stuck
+	/// spinner or a silent fail-open.
 	it("renders an error banner when loadAuthConfig throws", async () => {
 		vi.mocked(msalConfig.loadAuthConfig).mockRejectedValueOnce(
 			new Error("auth-config fetch failed: 500 Internal Server Error"),
@@ -132,5 +128,72 @@ describe("AuthGate", () => {
 		expect(banner).toHaveTextContent(/500/);
 		expect(screen.queryByText("child-content")).not.toBeInTheDocument();
 		errSpy.mockRestore();
+	});
+
+	// Phase 6 PR C: authedFetch (PR B) dispatches spacebot:auth-exhausted
+	// on 401 refresh-exhaustion. SSE via fetchEventSource inherits the
+	// same dispatch. AuthGate's global listener surfaces both to
+	// console.warn. Phase 7 upgrades to a toast banner; until then, this
+	// test pins the plumbing so a refactor that removes the listener is
+	// caught immediately.
+	it("logs a warn when spacebot:auth-exhausted fires on the window", async () => {
+		const warnSpy = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => {});
+		render(
+			<AuthGate>
+				<div>child-content</div>
+			</AuthGate>,
+		);
+		// Wait for AuthGate to finish async init and attach the listener.
+		await waitFor(() => {
+			expect(screen.getByText("child-content")).toBeInTheDocument();
+		});
+
+		window.dispatchEvent(
+			new CustomEvent("spacebot:auth-exhausted", {
+				detail: {
+					url: "http://api/some-endpoint",
+					reason: "refresh_failed",
+				},
+			}),
+		);
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("http://api/some-endpoint"),
+		);
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("refresh_failed"),
+		);
+		warnSpy.mockRestore();
+	});
+
+	// Unmount must remove the listener or future dispatches log to
+	// nowhere while still consuming test resources. Catches a regression
+	// where the useEffect returns the wrong cleanup (e.g., returns the
+	// handler itself instead of a remove-call).
+	it("removes the spacebot:auth-exhausted listener on unmount", async () => {
+		const warnSpy = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => {});
+		const { unmount } = render(
+			<AuthGate>
+				<div>child-content</div>
+			</AuthGate>,
+		);
+		await waitFor(() => {
+			expect(screen.getByText("child-content")).toBeInTheDocument();
+		});
+		unmount();
+		warnSpy.mockClear();
+
+		window.dispatchEvent(
+			new CustomEvent("spacebot:auth-exhausted", {
+				detail: { url: "http://api/after-unmount", reason: "refresh_failed" },
+			}),
+		);
+
+		expect(warnSpy).not.toHaveBeenCalled();
+		warnSpy.mockRestore();
 	});
 });

--- a/interface/src/auth/__tests__/mockMsal.test.ts
+++ b/interface/src/auth/__tests__/mockMsal.test.ts
@@ -1,0 +1,79 @@
+// Unit tests for the mockMsal base64url encoding contract with the
+// daemon's MockValidator (src/auth/testing.rs). The daemon parses the
+// token body after base64url-decoding, so any deviation from the
+// url-safe alphabet (plus stripping `=`) makes every VITE_AUTH_MOCK=1
+// CI run fail authentication with no obvious signal.
+
+import { describe, it, expect } from "vitest";
+import { base64UrlEncode } from "../mockMsal";
+
+describe("base64UrlEncode", () => {
+	it("returns empty string for empty input", () => {
+		expect(base64UrlEncode(new Uint8Array(0))).toBe("");
+	});
+
+	it("produces a round-trippable encoding for JSON payloads", () => {
+		const payload = JSON.stringify({ principal_type: "user", oid: "alice" });
+		const bytes = new TextEncoder().encode(payload);
+		const encoded = base64UrlEncode(bytes);
+		// Decode via atob after reversing the url-safe transform.
+		const padded = encoded.replace(/-/g, "+").replace(/_/g, "/");
+		const missing = (4 - (padded.length % 4)) % 4;
+		const binary = atob(padded + "=".repeat(missing));
+		const decoded = new Uint8Array(
+			Array.from(binary).map((c) => c.charCodeAt(0)),
+		);
+		const roundTripped = new TextDecoder().decode(decoded);
+		expect(roundTripped).toBe(payload);
+	});
+
+	it("replaces + with -", () => {
+		// Payload chosen so the standard base64 encoding contains +.
+		const bytes = new Uint8Array([0xfb, 0xff, 0xbf]);
+		const encoded = base64UrlEncode(bytes);
+		expect(encoded).not.toContain("+");
+		// Sanity: the standard encoding WOULD contain +, proving we
+		// exercised the replace path.
+		const standard = btoa(
+			String.fromCharCode(...Array.from(bytes)),
+		);
+		expect(standard).toContain("+");
+	});
+
+	it("replaces / with _", () => {
+		// Payload chosen so the standard base64 encoding contains /.
+		const bytes = new Uint8Array([0xff, 0xff, 0xff]);
+		const encoded = base64UrlEncode(bytes);
+		expect(encoded).not.toContain("/");
+		const standard = btoa(
+			String.fromCharCode(...Array.from(bytes)),
+		);
+		expect(standard).toContain("/");
+	});
+
+	it("strips trailing = padding", () => {
+		// 1-byte input produces "zz==" in standard base64 (2 pad chars).
+		const bytes = new Uint8Array([0xcf]);
+		const encoded = base64UrlEncode(bytes);
+		expect(encoded).not.toContain("=");
+		expect(encoded).toBe(
+			btoa(String.fromCharCode(0xcf)).replace(/=+$/, ""),
+		);
+	});
+
+	it("handles bytes ≥ 0x80 correctly (non-ASCII bytes from TextEncoder)", () => {
+		// UTF-8 encoding of "é" is 0xc3 0xa9. Both bytes are ≥ 0x80;
+		// String.fromCharCode must be used, not String.fromCodePoint.
+		const bytes = new TextEncoder().encode("é");
+		expect(Array.from(bytes)).toEqual([0xc3, 0xa9]);
+		const encoded = base64UrlEncode(bytes);
+		// Decode and confirm the round-trip preserves the high bytes.
+		const padded = encoded.replace(/-/g, "+").replace(/_/g, "/");
+		const missing = (4 - (padded.length % 4)) % 4;
+		const binary = atob(padded + "=".repeat(missing));
+		const decoded = new Uint8Array(
+			Array.from(binary).map((c) => c.charCodeAt(0)),
+		);
+		expect(Array.from(decoded)).toEqual([0xc3, 0xa9]);
+	});
+});

--- a/interface/src/auth/__tests__/useMe.test.tsx
+++ b/interface/src/auth/__tests__/useMe.test.tsx
@@ -1,10 +1,12 @@
-// Phase 6 PR C Task 6.C.6 Step 6 — vitest for useMe / useRole hooks.
+// Vitest for useMe / useRole hooks.
 //
-// Covers the two observable behaviors:
+// Covers the observable behaviors:
 //   1. Happy path: /api/me returns 200 with a populated MeResponse
 //      shape; useMe's data matches; useRole(role) returns boolean.
 //   2. Failure path: /api/me returns 401; useMe's error surfaces with
-//      the D17 `API error <status>: <path>` message.
+//      the `API error <status>: <path>` message convention.
+//   3. Malformed payload: /api/me returns 200 with non-JSON body;
+//      useMe's error message identifies the parse failure.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -62,7 +64,7 @@ describe("useMe", () => {
 		expect(result.current.data?.roles).toContain("SpacebotAdmin");
 	});
 
-	it("surfaces API error <status>: /me on 401 (D17 pattern)", async () => {
+	it("surfaces API error <status>: /me on 401", async () => {
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response("", { status: 401 }),
 		);
@@ -71,6 +73,25 @@ describe("useMe", () => {
 		await waitFor(() => expect(result.current.isError).toBe(true));
 		expect((result.current.error as Error).message).toBe(
 			"API error 401: /me",
+		);
+	});
+
+	it("distinguishes malformed JSON from network failure", async () => {
+		// Daemon returns 200 but the body is non-JSON (e.g., accidentally
+		// serving HTML from a misconfigured proxy). Without the explicit
+		// JSON-parse catch, React Query would surface the SyntaxError
+		// with the same shape as a network rejection.
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("<html>not json</html>", {
+				status: 200,
+				headers: { "content-type": "text/html" },
+			}),
+		);
+
+		const { result } = renderHook(() => useMe(), { wrapper });
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect((result.current.error as Error).message).toBe(
+			"API error: malformed JSON from /me",
 		);
 	});
 });
@@ -132,14 +153,20 @@ describe("useRole", () => {
 			),
 		);
 
-		const { result } = renderHook(() => useRole("SpacebotAdmin"), {
-			wrapper,
-		});
-		// Wait long enough for the query to resolve; roles won't contain
-		// SpacebotAdmin, so the hook returns false even after data lands.
-		// We wait for data to be present via the default react-query
-		// pattern; since result.current is boolean, check stability.
-		await new Promise((r) => setTimeout(r, 50));
-		expect(result.current).toBe(false);
+		const { result, rerender } = renderHook(
+			() => {
+				const me = useMe();
+				const role = useRole("SpacebotAdmin");
+				return { me, role };
+			},
+			{ wrapper },
+		);
+		// Wait for the underlying query to resolve, then assert the role
+		// check returns false. Previous fixed-timeout approach was flaky.
+		await waitFor(() =>
+			expect(result.current.me.isSuccess).toBe(true),
+		);
+		rerender();
+		expect(result.current.role).toBe(false);
 	});
 });

--- a/interface/src/auth/__tests__/useMe.test.tsx
+++ b/interface/src/auth/__tests__/useMe.test.tsx
@@ -1,0 +1,145 @@
+// Phase 6 PR C Task 6.C.6 Step 6 — vitest for useMe / useRole hooks.
+//
+// Covers the two observable behaviors:
+//   1. Happy path: /api/me returns 200 with a populated MeResponse
+//      shape; useMe's data matches; useRole(role) returns boolean.
+//   2. Failure path: /api/me returns 401; useMe's error surfaces with
+//      the D17 `API error <status>: <path>` message.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import React from "react";
+import { setAuthTokenProvider } from "@spacebot/api-client/client";
+import { useMe, useRole } from "../useMe";
+
+function wrapper({ children }: { children: ReactNode }) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return React.createElement(
+		QueryClientProvider,
+		{ client },
+		children,
+	);
+}
+
+describe("useMe", () => {
+	beforeEach(() => {
+		setAuthTokenProvider(async () => "mock-token");
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		setAuthTokenProvider(null);
+	});
+
+	it("returns MeResponse shape from /api/me on 200", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					principal_key: "tenant-1:alice",
+					tid: "tenant-1",
+					oid: "alice",
+					principal_type: "user",
+					display_name: "Alice Example",
+					display_email: "alice@example.com",
+					display_photo_data_url: null,
+					initials: "AE",
+					roles: ["SpacebotUser", "SpacebotAdmin"],
+					groups: ["engineering"],
+					groups_overage: false,
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const { result } = renderHook(() => useMe(), { wrapper });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data?.principal_key).toBe("tenant-1:alice");
+		expect(result.current.data?.initials).toBe("AE");
+		expect(result.current.data?.roles).toContain("SpacebotAdmin");
+	});
+
+	it("surfaces API error <status>: /me on 401 (D17 pattern)", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("", { status: 401 }),
+		);
+
+		const { result } = renderHook(() => useMe(), { wrapper });
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect((result.current.error as Error).message).toBe(
+			"API error 401: /me",
+		);
+	});
+});
+
+describe("useRole", () => {
+	beforeEach(() => {
+		setAuthTokenProvider(async () => "mock-token");
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		setAuthTokenProvider(null);
+	});
+
+	it("returns true when /api/me roles contain the queried role", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					principal_key: "tenant-1:alice",
+					tid: "tenant-1",
+					oid: "alice",
+					principal_type: "user",
+					display_name: null,
+					display_email: null,
+					display_photo_data_url: null,
+					initials: "?",
+					roles: ["SpacebotAdmin"],
+					groups: [],
+					groups_overage: false,
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const { result } = renderHook(() => useRole("SpacebotAdmin"), {
+			wrapper,
+		});
+		// useRole returns false before data arrives; re-read after fetch.
+		await waitFor(() => expect(result.current).toBe(true));
+	});
+
+	it("returns false when /api/me roles do not contain the role", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					principal_key: "tenant-1:alice",
+					tid: "tenant-1",
+					oid: "alice",
+					principal_type: "user",
+					display_name: null,
+					display_email: null,
+					display_photo_data_url: null,
+					initials: "?",
+					roles: ["SpacebotUser"],
+					groups: [],
+					groups_overage: false,
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const { result } = renderHook(() => useRole("SpacebotAdmin"), {
+			wrapper,
+		});
+		// Wait long enough for the query to resolve; roles won't contain
+		// SpacebotAdmin, so the hook returns false even after data lands.
+		// We wait for data to be present via the default react-query
+		// pattern; since result.current is boolean, check stability.
+		await new Promise((r) => setTimeout(r, 50));
+		expect(result.current).toBe(false);
+	});
+});

--- a/interface/src/auth/mockMsal.ts
+++ b/interface/src/auth/mockMsal.ts
@@ -1,0 +1,86 @@
+// Phase 6 PR C Task 6.C.5 — mock PublicClientApplication for local dev / CI.
+//
+// Activated by VITE_AUTH_MOCK=1. Mints a base64url JSON token
+// compatible with the daemon's MockValidator (src/auth/testing.rs,
+// Phase 4 PR 1). Claims pulled from Vite env vars so CI can set
+// different roles without recompiling:
+//
+//   VITE_MOCK_TID=tenant-1
+//   VITE_MOCK_OID=alice
+//   VITE_MOCK_ROLES=SpacebotUser,SpacebotAdmin
+//
+// D16 correction (2026-04-23 PR C audit): AuthConfigResponse is
+// imported from @spacebot/api-client/types (the canonical schema
+// path), NOT from ./msalConfig (which imports it internally but does
+// not re-export).
+
+import type { AuthConfigResponse } from "@spacebot/api-client/types";
+
+interface MockAccount {
+	tid: string;
+	oid: string;
+	name: string;
+	username: string;
+	roles: string[];
+}
+
+/**
+ * Returns a PublicClientApplication-shaped stub. Callers in
+ * msalConfig.ts cast to PublicClientApplication after await; this
+ * function intentionally returns a structural duck-type rather than
+ * a real MSAL instance so local dev does not need an Entra tenant.
+ */
+export async function getMockMsalInstance(_cfg: AuthConfigResponse) {
+	const tid = (import.meta.env.VITE_MOCK_TID as string | undefined) ?? "tenant-mock";
+	const oid = (import.meta.env.VITE_MOCK_OID as string | undefined) ?? "alice";
+	const rolesRaw =
+		(import.meta.env.VITE_MOCK_ROLES as string | undefined) ?? "SpacebotUser";
+	const roles = rolesRaw.split(",").map((s) => s.trim()).filter(Boolean);
+
+	const account: MockAccount = {
+		tid,
+		oid,
+		name: `Mock ${oid}`,
+		username: `${oid}@example.com`,
+		roles,
+	};
+
+	// Produce a JSON-base64url token compatible with the daemon's
+	// MockValidator. No signature — MockValidator parses the body
+	// directly after base64url-decoding.
+	const mintToken = (): string => {
+		const mintable = {
+			principal_type: "user",
+			tid,
+			oid,
+			roles,
+			groups: [] as string[],
+			display_email: account.username,
+			display_name: account.name,
+		};
+		const json = new TextEncoder().encode(JSON.stringify(mintable));
+		// btoa over a plain char string (String.fromCharCode on the
+		// bytes), then URL-safe transform: + → -, / → _, strip =.
+		let binary = "";
+		for (const byte of json) {
+			binary += String.fromCharCode(byte);
+		}
+		return btoa(binary)
+			.replace(/\+/g, "-")
+			.replace(/\//g, "_")
+			.replace(/=+$/, "");
+	};
+
+	return {
+		initialize: async () => {},
+		handleRedirectPromise: async () => null,
+		getAllAccounts: () => [account],
+		setActiveAccount: (_a: unknown) => {},
+		acquireTokenSilent: async () => ({ accessToken: mintToken() }),
+		acquireTokenRedirect: async () => {},
+		loginRedirect: async () => {},
+		logoutRedirect: async () => {
+			window.location.href = "/";
+		},
+	};
+}

--- a/interface/src/auth/mockMsal.ts
+++ b/interface/src/auth/mockMsal.ts
@@ -1,19 +1,18 @@
-// Phase 6 PR C Task 6.C.5 — mock PublicClientApplication for local dev / CI.
+// Mock PublicClientApplication for local dev / CI (VITE_AUTH_MOCK=1).
 //
-// Activated by VITE_AUTH_MOCK=1. Mints a base64url JSON token
-// compatible with the daemon's MockValidator (src/auth/testing.rs,
-// Phase 4 PR 1). Claims pulled from Vite env vars so CI can set
-// different roles without recompiling:
+// Mints a base64url-encoded JSON token compatible with the daemon's
+// MockValidator in `src/auth/testing.rs`. Claims come from Vite env
+// vars so CI can set different roles without recompiling:
 //
 //   VITE_MOCK_TID=tenant-1
 //   VITE_MOCK_OID=alice
 //   VITE_MOCK_ROLES=SpacebotUser,SpacebotAdmin
 //
-// D16 correction (2026-04-23 PR C audit): AuthConfigResponse is
-// imported from @spacebot/api-client/types (the canonical schema
-// path), NOT from ./msalConfig (which imports it internally but does
-// not re-export).
+// `AuthConfigResponse` imports from `@spacebot/api-client/types` (the
+// canonical schema path); `msalConfig.ts` imports the same name
+// internally but does not re-export it.
 
+import type { AccountInfo } from "@azure/msal-browser";
 import type { AuthConfigResponse } from "@spacebot/api-client/types";
 
 interface MockAccount {
@@ -24,18 +23,35 @@ interface MockAccount {
 	roles: string[];
 }
 
+// URL-safe base64 alphabet. Exported for direct unit testing of the
+// encoding contract with the daemon's MockValidator.
+export function base64UrlEncode(bytes: Uint8Array): string {
+	let binary = "";
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	return btoa(binary)
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/, "");
+}
+
 /**
  * Returns a PublicClientApplication-shaped stub. Callers in
- * msalConfig.ts cast to PublicClientApplication after await; this
- * function intentionally returns a structural duck-type rather than
- * a real MSAL instance so local dev does not need an Entra tenant.
+ * msalConfig.ts cast to PublicClientApplication after await; the
+ * function returns a structural duck-type rather than a real MSAL
+ * instance so local dev does not need an Entra tenant.
  */
 export async function getMockMsalInstance(_cfg: AuthConfigResponse) {
-	const tid = (import.meta.env.VITE_MOCK_TID as string | undefined) ?? "tenant-mock";
+	const tid =
+		(import.meta.env.VITE_MOCK_TID as string | undefined) ?? "tenant-mock";
 	const oid = (import.meta.env.VITE_MOCK_OID as string | undefined) ?? "alice";
 	const rolesRaw =
 		(import.meta.env.VITE_MOCK_ROLES as string | undefined) ?? "SpacebotUser";
-	const roles = rolesRaw.split(",").map((s) => s.trim()).filter(Boolean);
+	const roles = rolesRaw
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean);
 
 	const account: MockAccount = {
 		tid,
@@ -45,9 +61,6 @@ export async function getMockMsalInstance(_cfg: AuthConfigResponse) {
 		roles,
 	};
 
-	// Produce a JSON-base64url token compatible with the daemon's
-	// MockValidator. No signature — MockValidator parses the body
-	// directly after base64url-decoding.
 	const mintToken = (): string => {
 		const mintable = {
 			principal_type: "user",
@@ -59,28 +72,24 @@ export async function getMockMsalInstance(_cfg: AuthConfigResponse) {
 			display_name: account.name,
 		};
 		const json = new TextEncoder().encode(JSON.stringify(mintable));
-		// btoa over a plain char string (String.fromCharCode on the
-		// bytes), then URL-safe transform: + → -, / → _, strip =.
-		let binary = "";
-		for (const byte of json) {
-			binary += String.fromCharCode(byte);
-		}
-		return btoa(binary)
-			.replace(/\+/g, "-")
-			.replace(/\//g, "_")
-			.replace(/=+$/, "");
+		return base64UrlEncode(json);
 	};
 
 	return {
 		initialize: async () => {},
 		handleRedirectPromise: async () => null,
 		getAllAccounts: () => [account],
-		setActiveAccount: (_a: unknown) => {},
+		// Typed contract: match the real MSAL signature rather than
+		// `unknown`, so a caller passing the wrong argument type fails
+		// at the TS boundary instead of silently at runtime.
+		setActiveAccount: (_a: AccountInfo | null) => {},
 		acquireTokenSilent: async () => ({ accessToken: mintToken() }),
 		acquireTokenRedirect: async () => {},
 		loginRedirect: async () => {},
-		logoutRedirect: async () => {
-			window.location.href = "/";
+		logoutRedirect: async (opts?: { postLogoutRedirectUri?: string }) => {
+			// Honor the caller's postLogoutRedirectUri so SPAs served
+			// under a subpath don't land at the wrong root after mock sign-out.
+			window.location.href = opts?.postLogoutRedirectUri ?? "/";
 		},
 	};
 }

--- a/interface/src/auth/msalConfig.ts
+++ b/interface/src/auth/msalConfig.ts
@@ -97,18 +97,10 @@ export async function getMsalInstance(): Promise<MsalInstanceResult> {
 			return { ok: false, reason: "malformed", missing };
 		}
 
-		// Mock mode for local dev / CI. `mockMsal.ts` ships in Task 6.C.5;
-		// this branch only fires when VITE_AUTH_MOCK=1, which is set
-		// explicitly in dev env vars and never in production builds.
-		//
-		// The dynamic-import target is intentionally typed as `any` via
-		// the ts-expect-error pragma: `./mockMsal` does not exist yet, and
-		// writing a fallback .d.ts stub solely to satisfy tsc would leak
-		// Task 6.C.5's API shape up-stack. Error narrowing happens at
-		// runtime in Task 6.C.5's tests.
+		// Mock mode for local dev / CI. Activated by VITE_AUTH_MOCK=1,
+		// which is set in dev env vars and never in production builds.
+		// The dynamic import keeps the mock out of the production bundle.
 		if (import.meta.env.VITE_AUTH_MOCK === "1") {
-			// TODO(6.C.5): remove @ts-expect-error once ./mockMsal exists.
-			// @ts-expect-error Task 6.C.5 creates ./mockMsal; guarded by runtime env flag
 			const mod = await import(/* @vite-ignore */ "./mockMsal");
 			cachedInstance = (await mod.getMockMsalInstance(
 				cfg,

--- a/interface/src/auth/useMe.ts
+++ b/interface/src/auth/useMe.ts
@@ -1,0 +1,50 @@
+// Phase 6 PR C Task 6.C.6 Step 4 — consolidated identity hook.
+//
+// Reads from GET /api/me (A-18 single endpoint). The response carries
+// everything the SPA needs about the signed-in principal: identity,
+// roles, groups (overage-resolved when groups_overage is true),
+// display name/email, and either a photo data URL or initials.
+//
+// Phase 7's useRole(role) reads from this hook, so we cache for 5
+// minutes (matches the daemon's group_cache_ttl_secs default to
+// avoid UI-stale vs daemon-stale interleaving).
+//
+// D11 correction (2026-04-23 PR C audit): authedFetch imported from
+// the sibling exports entry @spacebot/api-client/authedFetch (PR B
+// commit C ships this). getApiBase stays at @spacebot/api-client/client.
+//
+// D17 correction (2026-04-23 PR C audit): throw-on-!ok message matches
+// PR B commit B's fetchJson convention — `API error <status>: <path>`
+// so operator/Sentry breadcrumbs identify the failing endpoint.
+
+import { useQuery } from "@tanstack/react-query";
+import { getApiBase } from "@spacebot/api-client/client";
+import { authedFetch } from "@spacebot/api-client/authedFetch";
+import type { components } from "@spacebot/api-client/schema";
+
+export type MeResponse = components["schemas"]["MeResponse"];
+
+export function useMe() {
+	return useQuery({
+		queryKey: ["me"],
+		queryFn: async (): Promise<MeResponse> => {
+			const path = "/me";
+			const res = await authedFetch(`${getApiBase()}${path}`);
+			if (!res.ok) {
+				throw new Error(`API error ${res.status}: ${path}`);
+			}
+			return res.json();
+		},
+		staleTime: 5 * 60_000,
+	});
+}
+
+/**
+ * Phase 7 preview: `useRole("SpacebotAdmin")` becomes the canonical
+ * gate for admin-only UI surfaces. Reads from the same `/api/me`
+ * cache so there is one source of truth for the principal's roles.
+ */
+export function useRole(role: string): boolean {
+	const { data } = useMe();
+	return Boolean(data?.roles.includes(role));
+}

--- a/interface/src/auth/useMe.ts
+++ b/interface/src/auth/useMe.ts
@@ -1,21 +1,10 @@
-// Phase 6 PR C Task 6.C.6 Step 4 — consolidated identity hook.
+// Consolidated identity hook. Reads from GET /api/me (one payload
+// carrying principal_key, tid/oid, roles, groups, display name/email,
+// and either a photo data URL or initials fallback).
 //
-// Reads from GET /api/me (A-18 single endpoint). The response carries
-// everything the SPA needs about the signed-in principal: identity,
-// roles, groups (overage-resolved when groups_overage is true),
-// display name/email, and either a photo data URL or initials.
-//
-// Phase 7's useRole(role) reads from this hook, so we cache for 5
-// minutes (matches the daemon's group_cache_ttl_secs default to
-// avoid UI-stale vs daemon-stale interleaving).
-//
-// D11 correction (2026-04-23 PR C audit): authedFetch imported from
-// the sibling exports entry @spacebot/api-client/authedFetch (PR B
-// commit C ships this). getApiBase stays at @spacebot/api-client/client.
-//
-// D17 correction (2026-04-23 PR C audit): throw-on-!ok message matches
-// PR B commit B's fetchJson convention — `API error <status>: <path>`
-// so operator/Sentry breadcrumbs identify the failing endpoint.
+// Phase 7's useRole(role) reads from this hook. 5-minute staleTime
+// matches the daemon's group_cache_ttl_secs default so UI-stale and
+// daemon-stale windows don't interleave.
 
 import { useQuery } from "@tanstack/react-query";
 import { getApiBase } from "@spacebot/api-client/client";
@@ -31,20 +20,35 @@ export function useMe() {
 			const path = "/me";
 			const res = await authedFetch(`${getApiBase()}${path}`);
 			if (!res.ok) {
+				// Match fetchJson's convention: status + path so Sentry
+				// breadcrumbs identify the failing endpoint.
 				throw new Error(`API error ${res.status}: ${path}`);
 			}
-			return res.json();
+			try {
+				return (await res.json()) as MeResponse;
+			} catch {
+				// Distinguish malformed daemon response from network
+				// failure. React Query otherwise wraps the SyntaxError
+				// identically to a fetch rejection.
+				throw new Error(`API error: malformed JSON from ${path}`);
+			}
 		},
 		staleTime: 5 * 60_000,
 	});
 }
 
+// Known built-in roles get autocomplete + typo protection. The
+// `(string & {})` intersection preserves the opt-out for ad-hoc roles
+// a future plugin / custom deployment might introduce.
+type KnownRole = "SpacebotAdmin" | "SpacebotUser" | "SpacebotService";
+type RoleLike = KnownRole | (string & {});
+
 /**
- * Phase 7 preview: `useRole("SpacebotAdmin")` becomes the canonical
- * gate for admin-only UI surfaces. Reads from the same `/api/me`
- * cache so there is one source of truth for the principal's roles.
+ * Phase 7: the canonical gate for admin-only UI surfaces. Reads from
+ * the same /api/me cache so there is one source of truth for the
+ * principal's roles.
  */
-export function useRole(role: string): boolean {
+export function useRole(role: RoleLike): boolean {
 	const { data } = useMe();
 	return Boolean(data?.roles.includes(role));
 }

--- a/interface/src/components/UserMenu.tsx
+++ b/interface/src/components/UserMenu.tsx
@@ -1,0 +1,45 @@
+// Phase 6 PR C Task 6.C.4 — header user menu with sign-out.
+//
+// Renders the signed-in principal's name + a Sign out button that
+// calls msal.logoutRedirect to clear both the MSAL cache and the
+// browser session at the Entra endpoint. Post-logout returns to the
+// SPA root (window.location.origin) where AuthGate re-enters the
+// "unauthenticated" state and shows the sign-in prompt.
+//
+// Only renders when there is an active account; in entra_disabled
+// mode the MsalProvider is absent so useMsal returns an empty
+// accounts array and this component returns null.
+
+import { useMsal } from "@azure/msal-react";
+
+export function UserMenu() {
+	const { instance, accounts } = useMsal();
+	const account = accounts[0];
+	if (!account) return null;
+
+	const onSignOut = async () => {
+		await instance.logoutRedirect({
+			account,
+			postLogoutRedirectUri: window.location.origin,
+		});
+	};
+
+	return (
+		<div
+			className="user-menu"
+			style={{
+				display: "flex",
+				alignItems: "center",
+				gap: "0.75rem",
+				padding: "0.5rem 0.75rem",
+			}}
+		>
+			<span aria-label="Signed in as">
+				{account.name ?? account.username}
+			</span>
+			<button type="button" onClick={onSignOut}>
+				Sign out
+			</button>
+		</div>
+	);
+}

--- a/interface/src/hooks/__tests__/useEventSource.test.tsx
+++ b/interface/src/hooks/__tests__/useEventSource.test.tsx
@@ -2,20 +2,22 @@
 // @microsoft/fetch-event-source. Asserts that the hook's public
 // contract (`handlers: Record<string, EventHandler>`) survives the
 // refactor, and that the wrapper's `fetch` option is the authedFetch
-// identity (not a look-alike function).
+// identity (not a look-alike function). Covers the onerror backoff
+// sequence, the `lagged` → onReconnect resync path, and the unmount
+// abort cleanup.
 //
 // The library call receives the event-type name in `ev.event`; we
 // route through `handlers[ev.event]?.(JSON.parse(ev.data))`.
 
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { authedFetch } from "@spacebot/api-client/authedFetch";
 import { useEventSource } from "../useEventSource";
 
-// Stub @microsoft/fetch-event-source. We're testing OUR wiring,
-// not theirs. The library's EventSourceMessage carries `event`,
-// `data`, `id`, `retry`; we emit one with `event: "tick"` so the
-// handlers-map dispatch can be asserted.
+// Stub @microsoft/fetch-event-source. Default mock: simple open →
+// single tick message. Individual tests override via
+// `vi.mocked(fetchEventSource).mockImplementationOnce(...)` to drive
+// onerror / onclose / lagged / unmount paths.
 vi.mock("@microsoft/fetch-event-source", () => ({
 	fetchEventSource: vi.fn(async (_url, options) => {
 		await options.onopen?.(new Response(null, { status: 200 }));
@@ -29,7 +31,29 @@ vi.mock("@microsoft/fetch-event-source", () => ({
 }));
 
 describe("useEventSource", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it("routes inbound events to the correct handler by event type", async () => {
+		const { fetchEventSource } = await import(
+			"@microsoft/fetch-event-source"
+		);
+		vi.mocked(fetchEventSource).mockImplementationOnce(
+			async (_url, options) => {
+				await options?.onopen?.(new Response(null, { status: 200 }));
+				await options?.onmessage?.({
+					event: "tick",
+					data: JSON.stringify({ count: 1 }),
+					id: "",
+					retry: undefined,
+				});
+			},
+		);
 		const tickCalls: Array<unknown> = [];
 		const otherCalls: Array<unknown> = [];
 		renderHook(() =>
@@ -46,18 +70,140 @@ describe("useEventSource", () => {
 	});
 
 	it("passes authedFetch as the fetch option (identity check)", async () => {
-		const { fetchEventSource } = await import("@microsoft/fetch-event-source");
+		const { fetchEventSource } = await import(
+			"@microsoft/fetch-event-source"
+		);
 		renderHook(() =>
 			useEventSource("http://api/events", { handlers: {} }),
 		);
 		await waitFor(() => {
-			const calls = (fetchEventSource as unknown as { mock: { calls: unknown[][] } })
-				.mock.calls;
+			const calls = (
+				fetchEventSource as unknown as { mock: { calls: unknown[][] } }
+			).mock.calls;
 			const call = calls[calls.length - 1];
 			expect(call).toBeTruthy();
 			// Identity check, not `toBeTypeOf("function")`, so a refactor
 			// that swaps in the raw browser fetch fails this test.
 			expect(call[1]).toHaveProperty("fetch", authedFetch);
 		});
+	});
+
+	// Exponential backoff: onerror returns the current delay, then
+	// advances. Sequence: 1000 → 2000 → 4000 → 8000 → 16000 → 30000 →
+	// 30000 (clamped). A regression that throws from onerror (aborts
+	// reconnect) or forgets Math.min(..., MAX_RETRY_MS) is invisible in
+	// the UI until production SSE breaks.
+	it("returns the current backoff delay from onerror and advances per call", async () => {
+		const { fetchEventSource } = await import(
+			"@microsoft/fetch-event-source"
+		);
+		const delays: number[] = [];
+		vi.mocked(fetchEventSource).mockImplementationOnce(
+			async (_url, options) => {
+				// Don't call onopen — we're testing the initial-connection
+				// error path. Call onerror repeatedly and capture the
+				// returned delays.
+				if (!options?.onerror) return;
+				for (let i = 0; i < 7; i++) {
+					const delay = options.onerror(new Error(`attempt-${i}`));
+					delays.push(delay as number);
+				}
+			},
+		);
+		renderHook(() =>
+			useEventSource("http://api/events", { handlers: {} }),
+		);
+		await waitFor(() => expect(delays).toHaveLength(7));
+		// INITIAL_RETRY_MS=1000, BACKOFF_MULTIPLIER=2, MAX_RETRY_MS=30_000.
+		// Sequence: 1000, 2000, 4000, 8000, 16000, 30000 (clamped from
+		// 32000), 30000 (stays at cap).
+		expect(delays).toEqual([1000, 2000, 4000, 8000, 16000, 30000, 30000]);
+	});
+
+	// The `lagged` event is how the daemon tells the SPA "you missed
+	// messages; full resync". Handler is NOT invoked directly from
+	// handlers map; instead it triggers onReconnect to flush caches. A
+	// regression that routes `lagged` through handlers["lagged"] (absent
+	// → no-op) would silently lose messages.
+	it("triggers onReconnect on lagged event, not the handlers map", async () => {
+		const { fetchEventSource } = await import(
+			"@microsoft/fetch-event-source"
+		);
+		vi.mocked(fetchEventSource).mockImplementationOnce(
+			async (_url, options) => {
+				await options?.onopen?.(new Response(null, { status: 200 }));
+				await options?.onmessage?.({
+					event: "lagged",
+					data: JSON.stringify({ skipped: 42 }),
+					id: "",
+					retry: undefined,
+				});
+			},
+		);
+		const handlerCalls: Array<unknown> = [];
+		const onReconnectCalls: Array<void> = [];
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		renderHook(() =>
+			useEventSource("http://api/events", {
+				handlers: {
+					lagged: () => handlerCalls.push("should-not-fire"),
+				},
+				onReconnect: () => onReconnectCalls.push(undefined),
+			}),
+		);
+
+		await waitFor(() => expect(onReconnectCalls.length).toBe(1));
+		// handlers["lagged"] must NOT be consulted for the lagged event
+		// because the hook's lagged branch short-circuits before the
+		// handlers-map lookup.
+		expect(handlerCalls.length).toBe(0);
+		// The skipped count is surfaced to console.warn for operator
+		// triage.
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("42"),
+		);
+		warnSpy.mockRestore();
+	});
+
+	// Unmount must abort the fetch-event-source signal so the library's
+	// retry loop terminates. A regression that forgets the cleanup
+	// function return keeps the loop alive past component teardown.
+	it("aborts the AbortController on unmount", async () => {
+		const { fetchEventSource } = await import(
+			"@microsoft/fetch-event-source"
+		);
+		let capturedSignal: AbortSignal | undefined;
+		vi.mocked(fetchEventSource).mockImplementationOnce(
+			async (_url, options) => {
+				capturedSignal = options?.signal;
+				await options?.onopen?.(new Response(null, { status: 200 }));
+			},
+		);
+		const { unmount } = renderHook(() =>
+			useEventSource("http://api/events", { handlers: {} }),
+		);
+		await waitFor(() => expect(capturedSignal).toBeDefined());
+		expect(capturedSignal?.aborted).toBe(false);
+		unmount();
+		expect(capturedSignal?.aborted).toBe(true);
+	});
+
+	// enabled: false short-circuits without calling fetchEventSource at
+	// all. Catches a regression where `enabled` is dropped from the
+	// options or the condition inverts.
+	it("does not call fetchEventSource when enabled is false", async () => {
+		const { fetchEventSource } = await import(
+			"@microsoft/fetch-event-source"
+		);
+		renderHook(() =>
+			useEventSource("http://api/events", {
+				handlers: {},
+				enabled: false,
+			}),
+		);
+		// Wait a tick for any effects to run.
+		await new Promise((r) => setTimeout(r, 10));
+		expect(fetchEventSource).not.toHaveBeenCalled();
 	});
 });

--- a/interface/src/hooks/__tests__/useEventSource.test.tsx
+++ b/interface/src/hooks/__tests__/useEventSource.test.tsx
@@ -173,7 +173,10 @@ describe("useEventSource", () => {
 		const { fetchEventSource } = await import(
 			"@microsoft/fetch-event-source"
 		);
-		let capturedSignal: AbortSignal | undefined;
+		// The library's `signal` field is typed `AbortSignal | null | undefined`
+		// even though useEventSource always provides an AbortController;
+		// widen to match so strict-mode tsc (CI) accepts the assignment.
+		let capturedSignal: AbortSignal | null | undefined;
 		vi.mocked(fetchEventSource).mockImplementationOnce(
 			async (_url, options) => {
 				capturedSignal = options?.signal;

--- a/interface/src/hooks/__tests__/useEventSource.test.tsx
+++ b/interface/src/hooks/__tests__/useEventSource.test.tsx
@@ -1,0 +1,67 @@
+// Phase 6 PR C Task 6.C.1 — failing vitest for useEventSource.
+//
+// Target: the transport swap from native EventSource to
+// @microsoft/fetch-event-source. Tests assert the hook's public
+// contract (handlers: Record<string, EventHandler>) survives the
+// refactor, and that the wrapper's `fetch` option is authedFetch
+// (identity check per D12 from the 2026-04-23 pre-PR-C audit).
+//
+// D13/D14 corrections: the hook's existing `handlers` + `enabled` +
+// `onReconnect` + `{ connectionState }` shape stays unchanged. The
+// library call receives event-type in `ev.event` which we route
+// through handlers[ev.event]?.(JSON.parse(ev.data)).
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { authedFetch } from "@spacebot/api-client/authedFetch";
+import { useEventSource } from "../useEventSource";
+
+// Stub @microsoft/fetch-event-source. We're testing OUR wiring,
+// not theirs. The library's EventSourceMessage carries `event`,
+// `data`, `id`, `retry`; we emit one with `event: "tick"` so the
+// handlers-map dispatch can be asserted.
+vi.mock("@microsoft/fetch-event-source", () => ({
+	fetchEventSource: vi.fn(async (_url, options) => {
+		await options.onopen?.(new Response(null, { status: 200 }));
+		await options.onmessage?.({
+			event: "tick",
+			data: JSON.stringify({ count: 1 }),
+			id: "",
+			retry: undefined,
+		});
+	}),
+}));
+
+describe("useEventSource", () => {
+	it("routes inbound events to the correct handler by event type", async () => {
+		const tickCalls: Array<unknown> = [];
+		const otherCalls: Array<unknown> = [];
+		renderHook(() =>
+			useEventSource("http://api/events", {
+				handlers: {
+					tick: (data) => tickCalls.push(data),
+					other: (data) => otherCalls.push(data),
+				},
+			}),
+		);
+		await waitFor(() => expect(tickCalls.length).toBeGreaterThan(0));
+		expect(tickCalls[0]).toEqual({ count: 1 });
+		expect(otherCalls.length).toBe(0);
+	});
+
+	it("passes authedFetch as the fetch option (D12: identity check)", async () => {
+		const { fetchEventSource } = await import("@microsoft/fetch-event-source");
+		renderHook(() =>
+			useEventSource("http://api/events", { handlers: {} }),
+		);
+		await waitFor(() => {
+			const calls = (fetchEventSource as unknown as { mock: { calls: unknown[][] } })
+				.mock.calls;
+			const call = calls[calls.length - 1];
+			expect(call).toBeTruthy();
+			// Identity check, not toBeTypeOf("function"), so a refactor that
+			// swaps in the raw browser fetch fails this test.
+			expect(call[1]).toHaveProperty("fetch", authedFetch);
+		});
+	});
+});

--- a/interface/src/hooks/__tests__/useEventSource.test.tsx
+++ b/interface/src/hooks/__tests__/useEventSource.test.tsx
@@ -1,15 +1,11 @@
-// Phase 6 PR C Task 6.C.1 — failing vitest for useEventSource.
+// Tests the transport swap from native EventSource to
+// @microsoft/fetch-event-source. Asserts that the hook's public
+// contract (`handlers: Record<string, EventHandler>`) survives the
+// refactor, and that the wrapper's `fetch` option is the authedFetch
+// identity (not a look-alike function).
 //
-// Target: the transport swap from native EventSource to
-// @microsoft/fetch-event-source. Tests assert the hook's public
-// contract (handlers: Record<string, EventHandler>) survives the
-// refactor, and that the wrapper's `fetch` option is authedFetch
-// (identity check per D12 from the 2026-04-23 pre-PR-C audit).
-//
-// D13/D14 corrections: the hook's existing `handlers` + `enabled` +
-// `onReconnect` + `{ connectionState }` shape stays unchanged. The
-// library call receives event-type in `ev.event` which we route
-// through handlers[ev.event]?.(JSON.parse(ev.data)).
+// The library call receives the event-type name in `ev.event`; we
+// route through `handlers[ev.event]?.(JSON.parse(ev.data))`.
 
 import { describe, it, expect, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
@@ -49,7 +45,7 @@ describe("useEventSource", () => {
 		expect(otherCalls.length).toBe(0);
 	});
 
-	it("passes authedFetch as the fetch option (D12: identity check)", async () => {
+	it("passes authedFetch as the fetch option (identity check)", async () => {
 		const { fetchEventSource } = await import("@microsoft/fetch-event-source");
 		renderHook(() =>
 			useEventSource("http://api/events", { handlers: {} }),
@@ -59,8 +55,8 @@ describe("useEventSource", () => {
 				.mock.calls;
 			const call = calls[calls.length - 1];
 			expect(call).toBeTruthy();
-			// Identity check, not toBeTypeOf("function"), so a refactor that
-			// swaps in the raw browser fetch fails this test.
+			// Identity check, not `toBeTypeOf("function")`, so a refactor
+			// that swaps in the raw browser fetch fails this test.
 			expect(call[1]).toHaveProperty("fetch", authedFetch);
 		});
 	});

--- a/interface/src/hooks/useEventSource.ts
+++ b/interface/src/hooks/useEventSource.ts
@@ -1,8 +1,14 @@
-import { useEffect, useRef, useCallback, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { fetchEventSource } from "@microsoft/fetch-event-source";
+import { authedFetch } from "@spacebot/api-client/authedFetch";
 
 type EventHandler = (data: unknown) => void;
 
-export type ConnectionState = "connecting" | "connected" | "reconnecting" | "disconnected";
+export type ConnectionState =
+	| "connecting"
+	| "connected"
+	| "reconnecting"
+	| "disconnected";
 
 interface UseEventSourceOptions {
 	/** Map of SSE event types to handlers */
@@ -18,8 +24,13 @@ const MAX_RETRY_MS = 30_000;
 const BACKOFF_MULTIPLIER = 2;
 
 /**
- * SSE hook with exponential backoff, connection state tracking,
- * and reconnect notification for state recovery.
+ * SSE hook with exponential backoff, connection state tracking, and
+ * reconnect notification for state recovery. Phase 6 PR C swapped the
+ * transport from native EventSource to @microsoft/fetch-event-source
+ * so the stream carries Authorization: Bearer <token> via authedFetch.
+ * The public contract is unchanged: handlers dispatch by SSE event
+ * name, onReconnect fires on recovery, and { connectionState } is
+ * returned for the ConnectionBanner to render.
  */
 export function useEventSource(url: string, options: UseEventSourceOptions) {
 	const { handlers, enabled = true, onReconnect } = options;
@@ -29,67 +40,11 @@ export function useEventSource(url: string, options: UseEventSourceOptions) {
 	const onReconnectRef = useRef(onReconnect);
 	onReconnectRef.current = onReconnect;
 
-	const [connectionState, setConnectionState] = useState<ConnectionState>("connecting");
-
-	const reconnectTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const eventSourceRef = useRef<EventSource | null>(null);
+	const [connectionState, setConnectionState] = useState<ConnectionState>(
+		"connecting",
+	);
 	const retryDelayRef = useRef(INITIAL_RETRY_MS);
 	const hadConnectionRef = useRef(false);
-
-	const connect = useCallback(() => {
-		if (eventSourceRef.current) {
-			eventSourceRef.current.close();
-		}
-
-		setConnectionState(hadConnectionRef.current ? "reconnecting" : "connecting");
-
-		const source = new EventSource(url);
-		eventSourceRef.current = source;
-
-		source.onopen = () => {
-			const wasReconnect = hadConnectionRef.current;
-			hadConnectionRef.current = true;
-			retryDelayRef.current = INITIAL_RETRY_MS;
-			setConnectionState("connected");
-
-			if (wasReconnect) {
-				onReconnectRef.current?.();
-			}
-		};
-
-		// Register a listener for each event type in handlers
-		for (const eventType of Object.keys(handlersRef.current)) {
-			source.addEventListener(eventType, (event: MessageEvent) => {
-				try {
-					const data = JSON.parse(event.data);
-					handlersRef.current[eventType]?.(data);
-				} catch {
-					handlersRef.current[eventType]?.(event.data);
-				}
-			});
-		}
-
-		// Handle the lagged event from the server
-		source.addEventListener("lagged", (event: MessageEvent) => {
-			try {
-				const data = JSON.parse(event.data);
-				console.warn(`SSE lagged, skipped ${data.skipped} events`);
-			} catch {
-				console.warn("SSE lagged, skipped events");
-			}
-			// Trigger re-sync since we missed events
-			onReconnectRef.current?.();
-		});
-
-		source.onerror = () => {
-			source.close();
-			setConnectionState("reconnecting");
-
-			const delay = retryDelayRef.current;
-			retryDelayRef.current = Math.min(delay * BACKOFF_MULTIPLIER, MAX_RETRY_MS);
-			reconnectTimeout.current = setTimeout(connect, delay);
-		};
-	}, [url]);
 
 	useEffect(() => {
 		if (!enabled) {
@@ -97,15 +52,85 @@ export function useEventSource(url: string, options: UseEventSourceOptions) {
 			return;
 		}
 
-		connect();
+		const controller = new AbortController();
+		setConnectionState(
+			hadConnectionRef.current ? "reconnecting" : "connecting",
+		);
 
-		return () => {
-			if (reconnectTimeout.current) {
-				clearTimeout(reconnectTimeout.current);
-			}
-			eventSourceRef.current?.close();
-		};
-	}, [connect, enabled]);
+		void fetchEventSource(url, {
+			signal: controller.signal,
+			// authedFetch carries Authorization + inherits the two-budget
+			// retry + spacebot:auth-exhausted observability (PR B).
+			fetch: authedFetch,
+			// Keep streaming when the tab is hidden so worker/chat updates
+			// don't stall on inactive tabs.
+			openWhenHidden: true,
+			onopen: async (res) => {
+				if (!res.ok) {
+					throw new Error(`SSE open failed: ${res.status}`);
+				}
+				const wasReconnect = hadConnectionRef.current;
+				hadConnectionRef.current = true;
+				retryDelayRef.current = INITIAL_RETRY_MS;
+				setConnectionState("connected");
+				if (wasReconnect) {
+					onReconnectRef.current?.();
+				}
+			},
+			onmessage: (ev) => {
+				// Server emits the event-type name in ev.event. Route onto
+				// the existing handlers dictionary the same way the native
+				// EventSource version did via addEventListener.
+				const eventName = ev.event || "message";
+				// `lagged` marks that the broadcast channel skipped events;
+				// trigger resync via onReconnect.
+				if (eventName === "lagged") {
+					try {
+						const data = JSON.parse(ev.data) as { skipped?: number };
+						console.warn(`SSE lagged, skipped ${data.skipped} events`);
+					} catch {
+						console.warn("SSE lagged, skipped events");
+					}
+					onReconnectRef.current?.();
+					return;
+				}
+				const handler = handlersRef.current[eventName];
+				if (!handler) return;
+				try {
+					handler(JSON.parse(ev.data));
+				} catch {
+					handler(ev.data);
+				}
+			},
+			onerror: (_err) => {
+				setConnectionState("reconnecting");
+				// Return the current backoff delay so fetch-event-source
+				// waits this long before reconnecting. Advance for the next
+				// failure. Throwing from onerror aborts; returning a number
+				// keeps the retry loop alive.
+				const delay = retryDelayRef.current;
+				retryDelayRef.current = Math.min(
+					delay * BACKOFF_MULTIPLIER,
+					MAX_RETRY_MS,
+				);
+				return delay;
+			},
+			onclose: () => {
+				// The library closes after onerror returns. Throw only if the
+				// component has unmounted so the loop terminates cleanly.
+				if (controller.signal.aborted) {
+					throw new Error("aborted");
+				}
+			},
+		}).catch((err: unknown) => {
+			// AbortError lands here on unmount; everything else should have
+			// been handled by onerror. Swallow quietly on abort.
+			if (controller.signal.aborted) return;
+			console.error("fetchEventSource terminated:", err);
+		});
+
+		return () => controller.abort();
+	}, [url, enabled]);
 
 	return { connectionState };
 }

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -1413,6 +1413,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["me"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/messaging/disconnect": {
         parameters: {
             query?: never;
@@ -3397,6 +3413,25 @@ export interface components {
             name: string;
             state: components["schemas"]["McpConnectionState"];
             transport: string;
+        };
+        MeResponse: {
+            display_email?: string | null;
+            display_name?: string | null;
+            /** @description Base64 data URL for the user's Graph profile photo, or None. */
+            display_photo_data_url?: string | null;
+            groups: string[];
+            groups_overage: boolean;
+            /**
+             * @description Computed initials (1-3 chars) derived from display_name. Present
+             *     when display_photo_data_url is None, so the SPA never has to
+             *     branch on both absent.
+             */
+            initials?: string | null;
+            oid: string;
+            principal_key: string;
+            principal_type: string;
+            roles: string[];
+            tid: string;
         };
         MemoriesListResponse: {
             memories: components["schemas"]["Memory"][];
@@ -8170,6 +8205,33 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["McpAgentStatus"][];
                 };
+            };
+        };
+    };
+    me: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Signed-in principal identity + groups + photo */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MeResponse"];
+                };
+            };
+            /** @description No valid authentication */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -3429,7 +3429,13 @@ export interface components {
             initials?: string | null;
             oid: string;
             principal_key: string;
-            principal_type: string;
+            /**
+             * @description Typed enum so downstream TypeScript clients get a string-literal
+             *     union (`"user" | "service_principal" | "system" | "legacy_static"`)
+             *     instead of an opaque string. Snake-case serialization inherited
+             *     from `PrincipalType`'s `#[serde(rename_all = "snake_case")]`.
+             */
+            principal_type: components["schemas"]["PrincipalType"];
             roles: string[];
             tid: string;
         };
@@ -3750,6 +3756,15 @@ export interface components {
             name: string;
             tags?: string[];
         };
+        /**
+         * @description Stable identifier category for the authenticated principal. The four
+         *     variants map to disjoint authz paths: human users authenticate via
+         *     delegated Entra tokens, service principals via client-credentials
+         *     grant, the system (cortex) principal constructs internally, and the
+         *     static-token branch represents operator-level coarse access.
+         * @enum {string}
+         */
+        PrincipalType: "user" | "system" | "service_principal" | "legacy_static";
         ProcessTokens: {
             /** Format: int64 */
             cache_read: number;

--- a/src/api.rs
+++ b/src/api.rs
@@ -18,6 +18,7 @@ mod factory;
 mod ingest;
 mod links;
 mod mcp;
+mod me;
 mod memories;
 mod messaging;
 mod models;

--- a/src/api/me.rs
+++ b/src/api/me.rs
@@ -128,11 +128,7 @@ fn compute_initials(name: Option<&str>) -> String {
     };
     let parts: Vec<&str> = name.split_whitespace().take(3).collect();
     if parts.is_empty() {
-        return name
-            .chars()
-            .take(1)
-            .collect::<String>()
-            .to_uppercase();
+        return name.chars().take(1).collect::<String>().to_uppercase();
     }
     parts
         .iter()
@@ -157,10 +153,7 @@ mod tests {
 
     #[test]
     fn initials_from_four_word_name_truncates_to_three() {
-        assert_eq!(
-            compute_initials(Some("Alice B Example Four")),
-            "ABE"
-        );
+        assert_eq!(compute_initials(Some("Alice B Example Four")), "ABE");
     }
 
     #[test]

--- a/src/api/me.rs
+++ b/src/api/me.rs
@@ -1,0 +1,182 @@
+//! Consolidated identity endpoint for the SPA.
+//!
+//! Returns everything the signed-in user needs in one payload: principal
+//! identity, roles, teams, display name/email, profile photo or initials
+//! fallback. Replaces the Phase-6-era plan to ship `/api/me/groups`
+//! separately (A-18).
+//!
+//! Photo handling (A-19): `display_photo_b64` is populated by the
+//! middleware's fire-and-forget `sync_user_photo_for_principal` call
+//! (weekly TTL via `photo_updated_at`). When the cached row is absent
+//! or null, `initials` is computed from the display name so the SPA
+//! never has to branch on both absent.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+
+use crate::api::state::ApiState;
+use crate::auth::context::AuthContext;
+
+#[derive(serde::Serialize, utoipa::ToSchema)]
+pub struct MeResponse {
+    pub principal_key: String,
+    pub tid: String,
+    pub oid: String,
+    pub principal_type: String,
+    pub display_name: Option<String>,
+    pub display_email: Option<String>,
+    /// Base64 data URL for the user's Graph profile photo, or None.
+    pub display_photo_data_url: Option<String>,
+    /// Computed initials (1-3 chars) derived from display_name. Present
+    /// when display_photo_data_url is None, so the SPA never has to
+    /// branch on both absent.
+    pub initials: Option<String>,
+    pub roles: Vec<String>,
+    pub groups: Vec<String>,
+    pub groups_overage: bool,
+}
+
+#[utoipa::path(
+    get,
+    path = "/me",
+    responses(
+        (status = 200, body = MeResponse, description = "Signed-in principal identity + groups + photo"),
+        (status = 401, description = "No valid authentication")
+    )
+)]
+pub(super) async fn me(
+    State(state): State<Arc<ApiState>>,
+    axum::Extension(ctx): axum::Extension<AuthContext>,
+) -> Json<MeResponse> {
+    // Canonical ArcSwap peek — the instance pool is set atomically at
+    // startup and may still be None if the daemon is running with
+    // [api.auth.entra] enabled but no instance DB yet.
+    let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() else {
+        return Json(default_me(&ctx));
+    };
+
+    let team_rows: Vec<(String,)> =
+        sqlx::query_as("SELECT team_id FROM team_memberships WHERE principal_key = ?")
+            .bind(ctx.principal_key())
+            .fetch_all(&pool)
+            .await
+            .unwrap_or_default();
+
+    // A-19: read the cached photo row keyed on principal_key.
+    // Column names match migration 20260420120006_users_photo.sql:
+    // `display_photo_b64` (TEXT, nullable) + `photo_updated_at` (TEXT,
+    // nullable). The `_photo_updated_at` result is unused here but the
+    // column is present for the middleware's weekly-TTL freshness check
+    // to inspect before re-fetching from Graph.
+    let photo_row: Option<(Option<String>, Option<String>)> = sqlx::query_as(
+        "SELECT display_photo_b64, photo_updated_at FROM users WHERE principal_key = ?",
+    )
+    .bind(ctx.principal_key())
+    .fetch_optional(&pool)
+    .await
+    .unwrap_or(None);
+
+    let display_photo_data_url = photo_row.and_then(|(b64, _photo_updated_at)| {
+        let b64 = b64?;
+        Some(format!("data:image/jpeg;base64,{b64}"))
+    });
+
+    let display_name_owned = ctx.display_name.as_deref().map(|s| s.to_string());
+    let initials = if display_photo_data_url.is_none() {
+        Some(compute_initials(display_name_owned.as_deref()))
+    } else {
+        None
+    };
+
+    Json(MeResponse {
+        principal_key: ctx.principal_key(),
+        tid: ctx.tid.to_string(),
+        oid: ctx.oid.to_string(),
+        // Canonical snake_case via as_canonical_str (Phase 5 Task 5.6).
+        principal_type: ctx.principal_type.as_canonical_str().to_string(),
+        display_name: display_name_owned,
+        display_email: ctx.display_email.as_deref().map(|s| s.to_string()),
+        display_photo_data_url,
+        initials,
+        roles: ctx.roles.iter().map(|r| r.to_string()).collect(),
+        groups: team_rows.into_iter().map(|(id,)| id).collect(),
+        groups_overage: ctx.groups_overage,
+    })
+}
+
+fn default_me(ctx: &AuthContext) -> MeResponse {
+    MeResponse {
+        principal_key: ctx.principal_key(),
+        tid: ctx.tid.to_string(),
+        oid: ctx.oid.to_string(),
+        principal_type: ctx.principal_type.as_canonical_str().to_string(),
+        display_name: None,
+        display_email: None,
+        display_photo_data_url: None,
+        initials: Some("?".to_string()),
+        roles: vec![],
+        groups: vec![],
+        groups_overage: false,
+    }
+}
+
+fn compute_initials(name: Option<&str>) -> String {
+    let Some(name) = name else {
+        return "?".to_string();
+    };
+    let parts: Vec<&str> = name.split_whitespace().take(3).collect();
+    if parts.is_empty() {
+        return name
+            .chars()
+            .take(1)
+            .collect::<String>()
+            .to_uppercase();
+    }
+    parts
+        .iter()
+        .filter_map(|p| p.chars().next())
+        .map(|c| c.to_uppercase().to_string())
+        .collect::<String>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initials_from_two_word_name() {
+        assert_eq!(compute_initials(Some("Alice Example")), "AE");
+    }
+
+    #[test]
+    fn initials_from_three_word_name_takes_three() {
+        assert_eq!(compute_initials(Some("Alice B Example")), "ABE");
+    }
+
+    #[test]
+    fn initials_from_four_word_name_truncates_to_three() {
+        assert_eq!(
+            compute_initials(Some("Alice B Example Four")),
+            "ABE"
+        );
+    }
+
+    #[test]
+    fn initials_from_single_word_uses_first_char() {
+        assert_eq!(compute_initials(Some("alice")), "A");
+    }
+
+    #[test]
+    fn initials_from_none_is_question_mark() {
+        assert_eq!(compute_initials(None), "?");
+    }
+
+    #[test]
+    fn initials_from_whitespace_only_uses_first_char() {
+        // split_whitespace yields empty parts vec, falls through to
+        // the chars().take(1) branch.
+        assert_eq!(compute_initials(Some("  ")), " ");
+    }
+}

--- a/src/api/me.rs
+++ b/src/api/me.rs
@@ -2,14 +2,14 @@
 //!
 //! Returns everything the signed-in user needs in one payload: principal
 //! identity, roles, teams, display name/email, profile photo or initials
-//! fallback. Replaces the Phase-6-era plan to ship `/api/me/groups`
-//! separately (A-18).
+//! fallback. Replaces the plan-era split into `/api/me` +
+//! `/api/me/groups`.
 //!
-//! Photo handling (A-19): `display_photo_b64` is populated by the
-//! middleware's fire-and-forget `sync_user_photo_for_principal` call
-//! (weekly TTL via `photo_updated_at`). When the cached row is absent
-//! or null, `initials` is computed from the display name so the SPA
-//! never has to branch on both absent.
+//! Photo handling: `display_photo_b64` is populated by the middleware's
+//! fire-and-forget `sync_user_photo_for_principal` call with a 7-day
+//! TTL keyed on `photo_updated_at`. When the cached row is absent or
+//! null, `initials` is computed from the display name so the SPA never
+//! has to branch on both absent.
 
 use std::sync::Arc;
 
@@ -17,14 +17,18 @@ use axum::Json;
 use axum::extract::State;
 
 use crate::api::state::ApiState;
-use crate::auth::context::AuthContext;
+use crate::auth::context::{AuthContext, PrincipalType};
 
 #[derive(serde::Serialize, utoipa::ToSchema)]
 pub struct MeResponse {
     pub principal_key: String,
     pub tid: String,
     pub oid: String,
-    pub principal_type: String,
+    /// Typed enum so downstream TypeScript clients get a string-literal
+    /// union (`"user" | "service_principal" | "system" | "legacy_static"`)
+    /// instead of an opaque string. Snake-case serialization inherited
+    /// from `PrincipalType`'s `#[serde(rename_all = "snake_case")]`.
+    pub principal_type: PrincipalType,
     pub display_name: Option<String>,
     pub display_email: Option<String>,
     /// Base64 data URL for the user's Graph profile photo, or None.
@@ -50,42 +54,78 @@ pub(super) async fn me(
     State(state): State<Arc<ApiState>>,
     axum::Extension(ctx): axum::Extension<AuthContext>,
 ) -> Json<MeResponse> {
-    // Canonical ArcSwap peek — the instance pool is set atomically at
+    // Canonical ArcSwap peek. The instance pool is set atomically at
     // startup and may still be None if the daemon is running with
     // [api.auth.entra] enabled but no instance DB yet.
     let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() else {
+        // Not silent: operators seeing this repeatedly in steady state
+        // indicates a startup-ordering regression. Every other request
+        // for the signed-in user reaching the default path is a real
+        // signal, not a fallback edge case.
+        tracing::warn!(
+            principal = %ctx.principal_key(),
+            "me: instance_pool unset; serving default identity"
+        );
         return Json(default_me(&ctx));
     };
 
     let team_rows: Vec<(String,)> =
-        sqlx::query_as("SELECT team_id FROM team_memberships WHERE principal_key = ?")
+        match sqlx::query_as("SELECT team_id FROM team_memberships WHERE principal_key = ?")
             .bind(ctx.principal_key())
             .fetch_all(&pool)
             .await
-            .unwrap_or_default();
+        {
+            Ok(rows) => rows,
+            Err(err) => {
+                // Pool exhaustion, schema drift, or column rename leaves
+                // the user looking like they belong to no teams. Loud-log
+                // the error so the "user lost all group access" report
+                // has a grep target.
+                tracing::warn!(
+                    error = %err,
+                    principal = %ctx.principal_key(),
+                    "me: team_memberships query failed; returning empty groups"
+                );
+                Vec::new()
+            }
+        };
 
-    // A-19: read the cached photo row keyed on principal_key.
-    // Column names match migration 20260420120006_users_photo.sql:
-    // `display_photo_b64` (TEXT, nullable) + `photo_updated_at` (TEXT,
-    // nullable). The `_photo_updated_at` result is unused here but the
-    // column is present for the middleware's weekly-TTL freshness check
-    // to inspect before re-fetching from Graph.
-    let photo_row: Option<(Option<String>, Option<String>)> = sqlx::query_as(
+    // Read the cached photo row keyed on principal_key. The
+    // photo_updated_at column is selected alongside the blob but the
+    // binding is discarded here. The middleware runs its own freshness
+    // check at `sync_user_photo_for_principal` before re-fetching from
+    // Graph; this handler does not re-validate.
+    let photo_row: Option<(Option<String>, Option<String>)> = match sqlx::query_as(
         "SELECT display_photo_b64, photo_updated_at FROM users WHERE principal_key = ?",
     )
     .bind(ctx.principal_key())
     .fetch_optional(&pool)
     .await
-    .unwrap_or(None);
+    {
+        Ok(row) => row,
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                principal = %ctx.principal_key(),
+                "me: users photo query failed; serving without photo"
+            );
+            None
+        }
+    };
 
     let display_photo_data_url = photo_row.and_then(|(b64, _photo_updated_at)| {
         let b64 = b64?;
         Some(format!("data:image/jpeg;base64,{b64}"))
     });
 
-    let display_name_owned = ctx.display_name.as_deref().map(|s| s.to_string());
+    let display_name_owned = ctx.display_name.as_ref().map(|s| s.to_string());
     let initials = if display_photo_data_url.is_none() {
-        Some(compute_initials(display_name_owned.as_deref()))
+        Some(
+            display_name_owned
+                .as_deref()
+                .map(compute_initials)
+                .unwrap_or_else(|| "?".to_string()),
+        )
     } else {
         None
     };
@@ -94,10 +134,9 @@ pub(super) async fn me(
         principal_key: ctx.principal_key(),
         tid: ctx.tid.to_string(),
         oid: ctx.oid.to_string(),
-        // Canonical snake_case via as_canonical_str (Phase 5 Task 5.6).
-        principal_type: ctx.principal_type.as_canonical_str().to_string(),
+        principal_type: ctx.principal_type,
         display_name: display_name_owned,
-        display_email: ctx.display_email.as_deref().map(|s| s.to_string()),
+        display_email: ctx.display_email.as_ref().map(|s| s.to_string()),
         display_photo_data_url,
         initials,
         roles: ctx.roles.iter().map(|r| r.to_string()).collect(),
@@ -111,7 +150,7 @@ fn default_me(ctx: &AuthContext) -> MeResponse {
         principal_key: ctx.principal_key(),
         tid: ctx.tid.to_string(),
         oid: ctx.oid.to_string(),
-        principal_type: ctx.principal_type.as_canonical_str().to_string(),
+        principal_type: ctx.principal_type,
         display_name: None,
         display_email: None,
         display_photo_data_url: None,
@@ -122,13 +161,16 @@ fn default_me(ctx: &AuthContext) -> MeResponse {
     }
 }
 
-fn compute_initials(name: Option<&str>) -> String {
-    let Some(name) = name else {
-        return "?".to_string();
-    };
+/// Total function: the caller handles the None-display-name case by
+/// passing a concrete `"?"` fallback rather than threading `Option`
+/// through this helper. Returns `"?"` for all-whitespace input so the
+/// SPA renders a stable fallback badge instead of an invisible space.
+fn compute_initials(name: &str) -> String {
     let parts: Vec<&str> = name.split_whitespace().take(3).collect();
     if parts.is_empty() {
-        return name.chars().take(1).collect::<String>().to_uppercase();
+        // All-whitespace input. Return `"?"` so the SPA's avatar
+        // fallback renders something legible rather than a bare space.
+        return "?".to_string();
     }
     parts
         .iter()
@@ -143,33 +185,33 @@ mod tests {
 
     #[test]
     fn initials_from_two_word_name() {
-        assert_eq!(compute_initials(Some("Alice Example")), "AE");
+        assert_eq!(compute_initials("Alice Example"), "AE");
     }
 
     #[test]
     fn initials_from_three_word_name_takes_three() {
-        assert_eq!(compute_initials(Some("Alice B Example")), "ABE");
+        assert_eq!(compute_initials("Alice B Example"), "ABE");
     }
 
     #[test]
     fn initials_from_four_word_name_truncates_to_three() {
-        assert_eq!(compute_initials(Some("Alice B Example Four")), "ABE");
+        assert_eq!(compute_initials("Alice B Example Four"), "ABE");
     }
 
     #[test]
     fn initials_from_single_word_uses_first_char() {
-        assert_eq!(compute_initials(Some("alice")), "A");
+        assert_eq!(compute_initials("alice"), "A");
     }
 
     #[test]
-    fn initials_from_none_is_question_mark() {
-        assert_eq!(compute_initials(None), "?");
+    fn initials_from_whitespace_only_returns_question_mark() {
+        // Previously returned a literal space. Whitespace-only names
+        // should render a stable fallback instead of an invisible badge.
+        assert_eq!(compute_initials("   "), "?");
     }
 
     #[test]
-    fn initials_from_whitespace_only_uses_first_char() {
-        // split_whitespace yields empty parts vec, falls through to
-        // the chars().take(1) branch.
-        assert_eq!(compute_initials(Some("  ")), " ");
+    fn initials_from_empty_string_returns_question_mark() {
+        assert_eq!(compute_initials(""), "?");
     }
 }

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -3,7 +3,7 @@
 use super::state::ApiState;
 use super::{
     activity, agents, attachments, audit, auth_config, bindings, channels, config, cortex, cron,
-    factory, ingest, links, mcp, memories, messaging, models, notifications, opencode_proxy,
+    factory, ingest, links, mcp, me, memories, messaging, models, notifications, opencode_proxy,
     portal, projects, providers, secrets, settings, skills, ssh, system, tasks, tools, usage, wiki,
     workers,
 };
@@ -55,6 +55,11 @@ pub fn api_router() -> OpenApiRouter<Arc<ApiState>> {
         // Auth bypass for this path is wired in the middleware allowlists
         // below (static-token) and in src/auth/middleware.rs (Entra JWT).
         .routes(routes!(auth_config::get_auth_config))
+        // Consolidated identity endpoint (Phase 6 PR C, A-18). Returns
+        // principal_key + tid/oid + roles + groups + photo/initials in
+        // one payload so the SPA's useMe hook does not have to assemble
+        // from multiple endpoints.
+        .routes(routes!(me::me))
         .routes(routes!(system::idle))
         .routes(routes!(system::status))
         .routes(routes!(system::storage_status))

--- a/src/auth/context.rs
+++ b/src/auth/context.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 /// delegated Entra tokens, service principals via client-credentials
 /// grant, the system (cortex) principal constructs internally, and the
 /// static-token branch represents operator-level coarse access.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, utoipa::ToSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum PrincipalType {
     /// A human user, identified by Entra `tid` + `oid`.

--- a/tests/api_me.rs
+++ b/tests/api_me.rs
@@ -1,11 +1,12 @@
-//! Integration tests for the consolidated `GET /api/me` endpoint
-//! (Phase 6 PR C Task 6.C.6, A-18).
+//! Integration tests for the consolidated `GET /api/me` endpoint.
 //!
 //! Verifies the handler's observable contract: authenticated principal
 //! gets a 200 with the MeResponse shape; roles + groups + display name
 //! fields come from AuthContext; photo data URL is populated from the
 //! cached `users.display_photo_b64` row when present; initials are
-//! computed when photo is absent.
+//! computed when photo is absent. Also covers the non-User
+//! principal_type serialization path and the photo-row-with-null-blob
+//! edge case.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode, header};
@@ -76,7 +77,7 @@ async fn returns_photo_data_url_when_cached() {
     let alice = user_ctx("alice", Some("Alice Example"), vec![ROLE_USER]);
     upsert_user_from_auth(&pool, &alice).await.unwrap();
 
-    // Seed the cached photo row — mimics what the middleware's
+    // Seed the cached photo row. Mimics what the middleware's
     // fire-and-forget sync_user_photo_for_principal would write after
     // Graph's /me/photo/$value 200 response.
     let fake_b64 = "FAKEBASE64PAYLOAD==";
@@ -135,4 +136,64 @@ async fn rejects_missing_bearer_with_401() {
         .await
         .unwrap();
     assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn photo_row_present_with_null_blob_falls_back_to_initials() {
+    // The 404-from-Graph normal case: upsert_user_from_auth created
+    // the users row with display_photo_b64 = NULL (default). This
+    // differentiates "row missing" from "row present with null blob".
+    let (state, pool) = ApiState::new_test_state_with_mock_entra().await;
+    let alice = user_ctx("alice", Some("Alice Example"), vec![ROLE_USER]);
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+
+    // Explicitly set display_photo_b64 = NULL + a fresh photo_updated_at
+    // to simulate the state the photo-sync middleware leaves after
+    // Graph returned 404 (normal for accounts with no photo).
+    sqlx::query("UPDATE users SET display_photo_b64 = NULL, photo_updated_at = datetime('now') WHERE principal_key = ?")
+        .bind(alice.principal_key())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let app = build_test_router_entra(state);
+    let token = mint_mock_token(&alice);
+    let res = app.oneshot(req_me(&token)).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = read_json(res).await;
+    assert!(body["display_photo_data_url"].is_null());
+    // Initials must still compute from display_name even when the row
+    // exists (just with null blob). A regression that checks "row
+    // exists" instead of "b64 is Some" would serve data:image/jpeg,null.
+    assert_eq!(body["initials"], "AE");
+}
+
+#[tokio::test]
+async fn service_principal_serializes_as_snake_case() {
+    // PrincipalType::ServicePrincipal must serialize as
+    // "service_principal" on the wire, not "serviceprincipal" or
+    // "ServicePrincipal". The enum's `#[serde(rename_all = "snake_case")]`
+    // gates this; a refactor that falls back to `format!("{:?}")`
+    // would ship the wrong value.
+    let (state, pool) = ApiState::new_test_state_with_mock_entra().await;
+    let sp = AuthContext {
+        principal_type: PrincipalType::ServicePrincipal,
+        tid: Arc::from("tenant-1"),
+        oid: Arc::from("app-client-1"),
+        roles: vec![Arc::from("SpacebotService")],
+        groups: vec![],
+        groups_overage: false,
+        display_email: None,
+        display_name: Some(Arc::from("Builder Service")),
+    };
+    upsert_user_from_auth(&pool, &sp).await.unwrap();
+
+    let app = build_test_router_entra(state);
+    let token = mint_mock_token(&sp);
+    let res = app.oneshot(req_me(&token)).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = read_json(res).await;
+    assert_eq!(body["principal_type"], "service_principal");
 }

--- a/tests/api_me.rs
+++ b/tests/api_me.rs
@@ -1,0 +1,142 @@
+//! Integration tests for the consolidated `GET /api/me` endpoint
+//! (Phase 6 PR C Task 6.C.6, A-18).
+//!
+//! Verifies the handler's observable contract: authenticated principal
+//! gets a 200 with the MeResponse shape; roles + groups + display name
+//! fields come from AuthContext; photo data URL is populated from the
+//! cached `users.display_photo_b64` row when present; initials are
+//! computed when photo is absent.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use http_body_util::BodyExt as _;
+use serde_json::Value;
+use spacebot::api::ApiState;
+use spacebot::api::test_support::build_test_router_entra;
+use spacebot::auth::context::{AuthContext, PrincipalType};
+use spacebot::auth::repository::upsert_user_from_auth;
+use spacebot::auth::roles::ROLE_USER;
+use spacebot::auth::testing::mint_mock_token;
+use std::sync::Arc;
+use tower::ServiceExt as _;
+
+fn user_ctx(oid: &str, display_name: Option<&str>, roles: Vec<&str>) -> AuthContext {
+    AuthContext {
+        principal_type: PrincipalType::User,
+        tid: Arc::from("tenant-1"),
+        oid: Arc::from(oid),
+        roles: roles.into_iter().map(Arc::from).collect(),
+        groups: vec![],
+        groups_overage: false,
+        display_email: Some(Arc::from(format!("{oid}@example.com").as_str())),
+        display_name: display_name.map(Arc::from),
+    }
+}
+
+fn req_me(bearer: &str) -> Request<Body> {
+    Request::builder()
+        .uri("/api/me")
+        .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn read_json(res: axum::response::Response) -> Value {
+    let body_bytes = res.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&body_bytes).unwrap()
+}
+
+#[tokio::test]
+async fn returns_initials_when_photo_absent() {
+    let (state, pool) = ApiState::new_test_state_with_mock_entra().await;
+    let alice = user_ctx("alice", Some("Alice Example"), vec![ROLE_USER]);
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+
+    let app = build_test_router_entra(state);
+    let token = mint_mock_token(&alice);
+    let res = app.oneshot(req_me(&token)).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = read_json(res).await;
+    assert_eq!(body["principal_key"], "tenant-1:alice");
+    assert_eq!(body["tid"], "tenant-1");
+    assert_eq!(body["oid"], "alice");
+    assert_eq!(body["principal_type"], "user");
+    assert_eq!(body["display_name"], "Alice Example");
+    assert_eq!(body["display_email"], "alice@example.com");
+    // Photo absent → data URL null, initials computed from display name.
+    assert!(body["display_photo_data_url"].is_null());
+    assert_eq!(body["initials"], "AE");
+    assert_eq!(body["groups_overage"], false);
+}
+
+#[tokio::test]
+async fn returns_photo_data_url_when_cached() {
+    let (state, pool) = ApiState::new_test_state_with_mock_entra().await;
+    let alice = user_ctx("alice", Some("Alice Example"), vec![ROLE_USER]);
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+
+    // Seed the cached photo row — mimics what the middleware's
+    // fire-and-forget sync_user_photo_for_principal would write after
+    // Graph's /me/photo/$value 200 response.
+    let fake_b64 = "FAKEBASE64PAYLOAD==";
+    sqlx::query("UPDATE users SET display_photo_b64 = ?, photo_updated_at = datetime('now') WHERE principal_key = ?")
+        .bind(fake_b64)
+        .bind(alice.principal_key())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let app = build_test_router_entra(state);
+    let token = mint_mock_token(&alice);
+    let res = app.oneshot(req_me(&token)).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = read_json(res).await;
+    assert_eq!(
+        body["display_photo_data_url"],
+        format!("data:image/jpeg;base64,{fake_b64}")
+    );
+    // When photo is present, initials must be null so the SPA does
+    // not fall back to initials and ignore the photo.
+    assert!(body["initials"].is_null());
+}
+
+#[tokio::test]
+async fn returns_roles_from_auth_context() {
+    let (state, pool) = ApiState::new_test_state_with_mock_entra().await;
+    let alice = user_ctx(
+        "alice",
+        Some("Alice"),
+        vec![ROLE_USER, "SpacebotAdmin"],
+    );
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+
+    let app = build_test_router_entra(state);
+    let token = mint_mock_token(&alice);
+    let res = app.oneshot(req_me(&token)).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = read_json(res).await;
+    let roles = body["roles"].as_array().unwrap();
+    assert_eq!(roles.len(), 2);
+    let role_strs: Vec<&str> = roles.iter().map(|r| r.as_str().unwrap()).collect();
+    assert!(role_strs.contains(&ROLE_USER));
+    assert!(role_strs.contains(&"SpacebotAdmin"));
+}
+
+#[tokio::test]
+async fn rejects_missing_bearer_with_401() {
+    let (state, _pool) = ApiState::new_test_state_with_mock_entra().await;
+    let app = build_test_router_entra(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/me")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}

--- a/tests/api_me.rs
+++ b/tests/api_me.rs
@@ -105,11 +105,7 @@ async fn returns_photo_data_url_when_cached() {
 #[tokio::test]
 async fn returns_roles_from_auth_context() {
     let (state, pool) = ApiState::new_test_state_with_mock_entra().await;
-    let alice = user_ctx(
-        "alice",
-        Some("Alice"),
-        vec![ROLE_USER, "SpacebotAdmin"],
-    );
+    let alice = user_ctx("alice", Some("Alice"), vec![ROLE_USER, "SpacebotAdmin"]);
     upsert_user_from_auth(&pool, &alice).await.unwrap();
 
     let app = build_test_router_entra(state);


### PR DESCRIPTION
## Summary

Phase 6 PR C — the third and final PR in the Phase 6 Entra ID rollout. Ships:

1. **`useEventSource` transport swap** (`EventSource` → `@microsoft/fetch-event-source`) so SSE streams carry `Authorization: Bearer <token>` via `authedFetch`. Transport-only refactor; the hook's `handlers` + `enabled` + `onReconnect` + `{ connectionState }` contract is preserved byte-for-byte.
2. **`/api/me` consolidated endpoint (A-18, A-19)** — single endpoint returning principal identity + roles + groups + photo data URL or initials fallback. Frontend `useMe()` and `useRole()` hooks consume it.
3. **`UserMenu.tsx`** — header component with MSAL `logoutRedirect` sign-out.
4. **`spacebot:auth-exhausted` listener in AuthGate** — global window event handler (D21 correction) that covers both REST and SSE session-expiry paths.
5. **`mockMsal.ts`** — VITE_AUTH_MOCK=1 local-dev path that mints JSON-base64url tokens compatible with the daemon's `MockValidator` (Phase 4 PR 1).
6. **Removed** `@ts-expect-error` pragma in `msalConfig.ts` now that `./mockMsal` exists (D6).
7. **Operator docs delta** — appended 98 lines to PR A's existing 198-line `entra-auth.mdx` (SSE transport, sign-out, `/api/me`, VITE_AUTH_MOCK, PR C troubleshooting). **Did not overwrite** PR A's file (D18).

## Design highlights

### SSE transport preserves the hook contract (D13/D14)

The original plan framed Task 6.C.2 as a breaking API change swapping `handlers: Record<string, EventHandler>` for a single `onMessage` callback. The pre-code audit caught that this would force rewriting 17+ event listeners across `useLiveContext`, 3 in `Overlay`, and break `ConnectionBanner` which imports `ConnectionState`.

The actual refactor is transport-only: `new EventSource(url)` → `fetchEventSource(url, { fetch: authedFetch, ... })`. The library's `onmessage(ev)` callback receives `ev.event` (the SSE event name), which we route onto the existing handlers map. Exponential backoff (1s → 30s ×2) preserved via `onerror` returning the delay. `lagged` event handling + `onReconnect` resync preserved.

Zero caller changes needed. `useLiveContext`, `Overlay`, `ConnectionBanner`, and `ChannelLiveState` all continue to work unchanged.

### `/api/me` shape (A-18)

Single endpoint replaces the plan-era split into `/api/me` + `/api/me/groups`. Response:

```json
{
  "principal_key": "tenant-1:alice",
  "tid": "tenant-1",
  "oid": "alice",
  "principal_type": "user",
  "display_name": "Alice Example",
  "display_email": "alice@example.com",
  "display_photo_data_url": "data:image/jpeg;base64,…",
  "initials": null,
  "roles": ["SpacebotUser"],
  "groups": ["engineering", "platform"],
  "groups_overage": false
}
```

- `display_photo_data_url` populated from the 7-day TTL cache of `users.display_photo_b64` (Phase 3 migration `20260420120006_users_photo.sql`).
- `initials` computed from display_name first letters (1-3 chars) and populated only when photo data URL is null, so the SPA never branches on both absent.
- `groups` resolved from `team_memberships` keyed on `principal_key`.

### Retry token threading for SSE auth (inherited from PR B)

SSE via `fetchEventSource(fetch: authedFetch)` inherits PR B's:
- Authorization header attached per request
- 401 retry once with fresh token (auth cap = 1)
- `spacebot:auth-exhausted` CustomEvent dispatch on unrecoverable auth

The new AuthGate listener covers both REST and SSE with one piece of code.

## Pre-code audit corrections applied (D11–D26, 2026-04-23)

- **D11** — `authedFetch` imports use the sibling `@spacebot/api-client/authedFetch` path (PR B exports entry)
- **D13/D14** — hook contract preserved, not rewritten
- **D16** — `AuthConfigResponse` imported from `@spacebot/api-client/types` not `./msalConfig`
- **D17** — `useMe` error pattern matches PR B's `API error <status>: <path>`
- **D18** — docs append only, zero deletions against PR A's 198-line file
- **D20** — exponential backoff preserved via fetch-event-source `onerror` delay-return
- **D21** — global `spacebot:auth-exhausted` listener wired in AuthGate
- **D6** — `@ts-expect-error` pragma in msalConfig.ts removed once `./mockMsal` exists
- **F5, F6, F9, F11** — no new migration (Phase 3 columns), bare utoipa path, correct column names, `pub mod me` in `src/api.rs`

## Verification

```bash
cd interface && bunx tsc --noEmit           # clean
cd interface && bunx vitest run             # 34/34 green (24 auth + 2 SSE + 4 useMe + 4 AuthGate)
cd interface && bun run build               # clean
cargo nextest run --test api_me             # 4/4 green
just gate-pr                                # all checks passed
```

## Test coverage delta

- New integration tests: `tests/api_me.rs` (4 cases: photo-absent → initials, photo-cached → data URL + null initials, roles round-trip, missing bearer → 401)
- New vitest files:
  - `interface/src/hooks/__tests__/useEventSource.test.tsx` (2 cases: handler-by-event-name, authedFetch identity)
  - `interface/src/auth/__tests__/useMe.test.tsx` (4 cases: happy path, D17 error pattern, useRole match, useRole miss)
- New unit tests: `src/api/me.rs::tests` (6 cases for compute_initials edge cases)
- Rust integration suite: 40 files → 41 files
- Interface vitest suite: 28 → 34 tests

## Deploy ordering

With PR C merged, the Phase 6 rollout is complete. Operator order to flip Entra on in production:

1. Merge PR A (runtime config + AuthGate) — done
2. Merge PR B (authedFetch + 88-site migration) — done
3. Merge PR C (SSE polyfill + /api/me + mock mode) — this PR
4. Enable `[api.auth.entra].enabled = true` in production config

## Test plan

- [x] TDD red (useEventSource.test.tsx fails on native-EventSource hook)
- [x] TDD green after transport swap
- [x] Typecheck clean across interface + Rust
- [x] Full vitest suite 34/34 green
- [x] Rust integration tests compile + pass per-file (api_me.rs 4/4 green)
- [x] `just gate-pr` all checks passed
- [x] Writing-guide em-dash self-check passes (only allowed bullet-label em-dashes in operator docs)
- [ ] Manual smoke in mock mode (deferred: requires starting daemon + SPA end-to-end; mock mode paths verified via unit + integration tests)
- [ ] Playwright e2e (O5 deferred item — tracked for post-Phase-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)