### PR TITLE
feat(spa): Phase 7 PR 1 — visibility primitives + auth batch helpers

### DIFF
--- a/interface/src/auth/__tests__/useMe-principal-key.test.tsx
+++ b/interface/src/auth/__tests__/useMe-principal-key.test.tsx
@@ -1,0 +1,71 @@
+// useMyPrincipalKey test — co-located with useMe per D27. Follows the
+// same harness as useMe.test.tsx (QueryClientProvider + fetch spy)
+// rather than the mock-of-useMe pattern, because the plan's mock
+// pattern bypasses module-scope lookups and leaves the real useQuery
+// call un-mocked (triggers "No QueryClient set").
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import React from "react";
+import { setAuthTokenProvider } from "@spacebot/api-client/client";
+import { useMyPrincipalKey } from "../useMe";
+
+function wrapper({ children }: { children: ReactNode }) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return React.createElement(
+		QueryClientProvider,
+		{ client },
+		children,
+	);
+}
+
+describe("useMyPrincipalKey", () => {
+	beforeEach(() => {
+		setAuthTokenProvider(async () => "mock-token");
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		setAuthTokenProvider(null);
+	});
+
+	it("returns the principal_key from /api/me", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					principal_key: "tenant-1:alice",
+					tid: "tenant-1",
+					oid: "alice",
+					principal_type: "user",
+					display_name: null,
+					display_email: null,
+					display_photo_data_url: null,
+					initials: "?",
+					roles: [],
+					groups: [],
+					groups_overage: false,
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const { result } = renderHook(() => useMyPrincipalKey(), { wrapper });
+		await waitFor(() => expect(result.current).toBe("tenant-1:alice"));
+	});
+
+	it("returns null before data arrives", () => {
+		// No fetch spy + no await — hook runs in its initial "loading" state
+		// where useMe().data is still undefined. A-18 pattern: the helper
+		// returns null so callers can render a neutral placeholder instead
+		// of throwing or showing "undefined".
+		vi.spyOn(globalThis, "fetch").mockImplementation(
+			() => new Promise(() => {}),
+		);
+
+		const { result } = renderHook(() => useMyPrincipalKey(), { wrapper });
+		expect(result.current).toBeNull();
+	});
+});

--- a/interface/src/auth/__tests__/useMe-principal-key.test.tsx
+++ b/interface/src/auth/__tests__/useMe-principal-key.test.tsx
@@ -1,8 +1,10 @@
-// useMyPrincipalKey test — co-located with useMe per D27. Follows the
-// same harness as useMe.test.tsx (QueryClientProvider + fetch spy)
-// rather than the mock-of-useMe pattern, because the plan's mock
-// pattern bypasses module-scope lookups and leaves the real useQuery
-// call un-mocked (triggers "No QueryClient set").
+// useMyPrincipalKey test. Co-located with useMe per Phase 7 plan
+// D27 correction (see `.scratchpad/plans/entraid-auth/
+// phase-7-ui-surfaces.md`). Follows the same harness as useMe.test.tsx
+// (QueryClientProvider + fetch spy) rather than the mock-of-useMe
+// pattern, because the plan's mock pattern bypasses module-scope
+// lookups and leaves the real useQuery call un-mocked, which triggers
+// "No QueryClient set".
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
@@ -57,15 +59,47 @@ describe("useMyPrincipalKey", () => {
 	});
 
 	it("returns null before data arrives", () => {
-		// No fetch spy + no await — hook runs in its initial "loading" state
-		// where useMe().data is still undefined. A-18 pattern: the helper
-		// returns null so callers can render a neutral placeholder instead
-		// of throwing or showing "undefined".
+		// No fetch spy plus no await: the hook runs in its initial
+		// "loading" state where useMe().data is still undefined. A-18
+		// pattern: the helper returns null so callers can render a neutral
+		// placeholder instead of throwing or showing "undefined".
 		vi.spyOn(globalThis, "fetch").mockImplementation(
 			() => new Promise(() => {}),
 		);
 
 		const { result } = renderHook(() => useMyPrincipalKey(), { wrapper });
 		expect(result.current).toBeNull();
+	});
+
+	it("returns the raw empty string when /api/me sends principal_key: ''", async () => {
+		// S4 (pr-test-analyzer + silent-failure-hunter): pin the current
+		// contract that an empty principal_key from the server passes
+		// through as "" (not null) so callers using `if (!key)` as a
+		// signed-in gate still fail closed (empty string is falsy). If
+		// this ever changes to null-coercion, this test forces an explicit
+		// documented decision rather than a silent behavior flip.
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					principal_key: "",
+					tid: "tenant-1",
+					oid: "alice",
+					principal_type: "user",
+					display_name: null,
+					display_email: null,
+					display_photo_data_url: null,
+					initials: "?",
+					roles: [],
+					groups: [],
+					groups_overage: false,
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const { result } = renderHook(() => useMyPrincipalKey(), { wrapper });
+		await waitFor(() => expect(result.current).toBe(""));
+		// Document the falsy-gate invariant that callers rely on.
+		expect(Boolean(result.current)).toBe(false);
 	});
 });

--- a/interface/src/auth/useMe.ts
+++ b/interface/src/auth/useMe.ts
@@ -52,3 +52,12 @@ export function useRole(role: RoleLike): boolean {
 	const { data } = useMe();
 	return Boolean(data?.roles.includes(role));
 }
+
+/**
+ * Consolidated principal-key helper. Draws from the same /api/me cache
+ * as useMe + useRole, so a sign-out invalidates all three together.
+ */
+export function useMyPrincipalKey(): string | null {
+	const { data } = useMe();
+	return data?.principal_key ?? null;
+}

--- a/interface/src/components/ShareResourceModal.tsx
+++ b/interface/src/components/ShareResourceModal.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import type { Visibility } from "./VisibilityChip";
+
+export function ShareResourceModal({
+	resourceType,
+	currentVisibility,
+	teams,
+	onSubmit,
+	onClose,
+}: {
+	resourceType: string;
+	resourceId: string;
+	currentVisibility: Visibility;
+	teams: { id: string; name: string }[];
+	onSubmit: (args: {
+		visibility: Visibility;
+		sharedWithTeamId: string | null;
+	}) => Promise<void>;
+	onClose: () => void;
+}) {
+	const [visibility, setVisibility] = useState<Visibility>(currentVisibility);
+	const [teamId, setTeamId] = useState<string>("");
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const onConfirm = async () => {
+		if (visibility === "team" && !teamId) {
+			setError("Select a team.");
+			return;
+		}
+		setSubmitting(true);
+		try {
+			await onSubmit({
+				visibility,
+				sharedWithTeamId: visibility === "team" ? teamId : null,
+			});
+			onClose();
+		} catch (e) {
+			setError(String(e));
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<div role="dialog" aria-labelledby="share-title">
+			<h2 id="share-title">Share {resourceType}</h2>
+			<fieldset>
+				<legend>Visibility</legend>
+				{(["personal", "team", "org"] as Visibility[]).map((v) => (
+					<label key={v}>
+						<input
+							type="radio"
+							name="vis"
+							value={v}
+							checked={visibility === v}
+							onChange={() => setVisibility(v)}
+						/>
+						{v[0].toUpperCase() + v.slice(1)}
+					</label>
+				))}
+			</fieldset>
+			{visibility === "team" && (
+				<select
+					aria-label="Team"
+					value={teamId}
+					onChange={(e) => setTeamId(e.target.value)}
+				>
+					<option value="">(select a team)</option>
+					{teams.map((t) => (
+						<option key={t.id} value={t.id}>
+							{t.name}
+						</option>
+					))}
+				</select>
+			)}
+			{error && <p role="alert">{error}</p>}
+			<button type="button" onClick={onClose}>
+				Cancel
+			</button>
+			<button type="button" onClick={onConfirm} disabled={submitting}>
+				Confirm
+			</button>
+		</div>
+	);
+}

--- a/interface/src/components/ShareResourceModal.tsx
+++ b/interface/src/components/ShareResourceModal.tsx
@@ -3,6 +3,7 @@ import type { Visibility } from "./VisibilityChip";
 
 export function ShareResourceModal({
 	resourceType,
+	resourceId,
 	currentVisibility,
 	teams,
 	onSubmit,
@@ -23,6 +24,8 @@ export function ShareResourceModal({
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
+	const descriptionId = `share-description-${resourceType}-${resourceId}`;
+
 	const onConfirm = async () => {
 		if (visibility === "team" && !teamId) {
 			setError("Select a team.");
@@ -36,15 +39,34 @@ export function ShareResourceModal({
 			});
 			onClose();
 		} catch (e) {
-			setError(String(e));
+			// Narrow to API errors (authedFetch throws `Error("API error ...")`).
+			// Programmer errors (TypeError, unmount-race, missing provider) are
+			// rethrown so the React error boundary sees them. Log the full
+			// Error before narrowing so operators have a stack trace in the
+			// browser console even when only a human-readable message reaches
+			// the dialog.
+			const isApiError = e instanceof Error && e.message.startsWith("API error");
+			if (!isApiError) {
+				console.error("ShareResourceModal: non-API error in onSubmit", e);
+				throw e;
+			}
+			console.error("ShareResourceModal: share submit failed", e);
+			setError(e.message);
 		} finally {
 			setSubmitting(false);
 		}
 	};
 
 	return (
-		<div role="dialog" aria-labelledby="share-title">
+		<div
+			role="dialog"
+			aria-labelledby="share-title"
+			aria-describedby={descriptionId}
+		>
 			<h2 id="share-title">Share {resourceType}</h2>
+			<p id={descriptionId} className="sr-only">
+				Change the visibility of {resourceType} {resourceId}.
+			</p>
 			<fieldset>
 				<legend>Visibility</legend>
 				{(["personal", "team", "org"] as Visibility[]).map((v) => (

--- a/interface/src/components/ShareResourceModal.tsx
+++ b/interface/src/components/ShareResourceModal.tsx
@@ -1,6 +1,18 @@
 import { useState } from "react";
 import type { Visibility } from "./VisibilityChip";
 
+/**
+ * Discriminated-union payload passed to `onSubmit`. Makes the previously
+ * illegal pair `{ visibility: "personal", sharedWithTeamId: "t1" }`
+ * unrepresentable at the type level — "team" is the only branch that
+ * carries a team id. Replaces the old `{ visibility: Visibility;
+ * sharedWithTeamId: string | null }` product type per PR #110 review
+ * finding I4 (type-design-analyzer).
+ */
+export type ShareSubmitArgs =
+	| { visibility: "team"; sharedWithTeamId: string }
+	| { visibility: "personal" | "org" };
+
 export function ShareResourceModal({
 	resourceType,
 	resourceId,
@@ -13,10 +25,7 @@ export function ShareResourceModal({
 	resourceId: string;
 	currentVisibility: Visibility;
 	teams: { id: string; name: string }[];
-	onSubmit: (args: {
-		visibility: Visibility;
-		sharedWithTeamId: string | null;
-	}) => Promise<void>;
+	onSubmit: (args: ShareSubmitArgs) => Promise<void>;
 	onClose: () => void;
 }) {
 	const [visibility, setVisibility] = useState<Visibility>(currentVisibility);
@@ -27,16 +36,25 @@ export function ShareResourceModal({
 	const descriptionId = `share-description-${resourceType}-${resourceId}`;
 
 	const onConfirm = async () => {
-		if (visibility === "team" && !teamId) {
-			setError("Select a team.");
-			return;
+		// Build the payload first so TypeScript exhaustiveness narrowing
+		// handles the personal/org/team split. The old code constructed an
+		// object where `sharedWithTeamId: visibility === "team" ? teamId :
+		// null` embedded the invariant in a runtime expression; the
+		// discriminated union below moves that invariant into the type.
+		let args: ShareSubmitArgs;
+		if (visibility === "team") {
+			if (!teamId) {
+				setError("Select a team.");
+				return;
+			}
+			args = { visibility: "team", sharedWithTeamId: teamId };
+		} else {
+			args = { visibility };
 		}
+
 		setSubmitting(true);
 		try {
-			await onSubmit({
-				visibility,
-				sharedWithTeamId: visibility === "team" ? teamId : null,
-			});
+			await onSubmit(args);
 			onClose();
 		} catch (e) {
 			// Narrow to API errors (authedFetch throws `Error("API error ...")`).

--- a/interface/src/components/VisibilityChip.tsx
+++ b/interface/src/components/VisibilityChip.tsx
@@ -1,0 +1,33 @@
+export type Visibility = "personal" | "team" | "org";
+
+export function VisibilityChip({
+	visibility,
+	teamName,
+}: {
+	visibility: Visibility;
+	teamName?: string;
+}) {
+	const label =
+		visibility === "personal"
+			? "Personal"
+			: visibility === "team"
+				? `Team${teamName ? `: ${teamName}` : ""}`
+				: visibility === "org"
+					? "Org"
+					: "Unknown";
+
+	const tone =
+		visibility === "personal"
+			? "neutral"
+			: visibility === "team"
+				? "info"
+				: visibility === "org"
+					? "success"
+					: "warning";
+
+	return (
+		<span data-tone={tone} className="visibility-chip">
+			{label}
+		</span>
+	);
+}

--- a/interface/src/components/VisibilityFilter.tsx
+++ b/interface/src/components/VisibilityFilter.tsx
@@ -1,0 +1,27 @@
+export type VisibilityFilterValue = "all" | "personal" | "team" | "org";
+
+export function VisibilityFilter({
+	value,
+	onChange,
+}: {
+	value: VisibilityFilterValue;
+	onChange: (v: VisibilityFilterValue) => void;
+}) {
+	const options: VisibilityFilterValue[] = ["all", "personal", "team", "org"];
+	return (
+		<div role="radiogroup" aria-label="Visibility filter">
+			{options.map((v) => (
+				<label key={v}>
+					<input
+						type="radio"
+						name="visibility-filter"
+						value={v}
+						checked={value === v}
+						onChange={() => onChange(v)}
+					/>
+					{v[0].toUpperCase() + v.slice(1)}
+				</label>
+			))}
+		</div>
+	);
+}

--- a/interface/src/components/VisibilityFilter.tsx
+++ b/interface/src/components/VisibilityFilter.tsx
@@ -1,4 +1,12 @@
-export type VisibilityFilterValue = "all" | "personal" | "team" | "org";
+import type { Visibility } from "./VisibilityChip";
+
+// Derived union: the three `Visibility` values plus an "all" catch-all
+// for the list filter. Deriving from `Visibility` means a future schema
+// addition (e.g., "system") propagates here automatically once the Rust
+// enum changes land via `just typegen`. Avoids the hand-duplicated-
+// literal drift class PR #110 review finding S1 (type-design-analyzer)
+// called out.
+export type VisibilityFilterValue = "all" | Visibility;
 
 export function VisibilityFilter({
 	value,

--- a/interface/src/components/__tests__/ShareResourceModal.test.tsx
+++ b/interface/src/components/__tests__/ShareResourceModal.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ShareResourceModal } from "../ShareResourceModal";
+
+describe("ShareResourceModal", () => {
+	it("submits visibility + team when confirmed", async () => {
+		const onSubmit = vi.fn(async () => {});
+		render(
+			<ShareResourceModal
+				resourceType="memory"
+				resourceId="m-1"
+				currentVisibility="personal"
+				teams={[
+					{ id: "t1", name: "Platform" },
+					{ id: "t2", name: "Sec" },
+				]}
+				onSubmit={onSubmit}
+				onClose={() => {}}
+			/>,
+		);
+		fireEvent.click(screen.getByLabelText(/team/i));
+		fireEvent.change(screen.getByRole("combobox"), {
+			target: { value: "t1" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /confirm|share/i }));
+		await vi.waitFor(() => expect(onSubmit).toHaveBeenCalled());
+		expect(onSubmit).toHaveBeenCalledWith({
+			visibility: "team",
+			sharedWithTeamId: "t1",
+		});
+	});
+
+	it("prevents confirming team visibility without a team selection", () => {
+		const onSubmit = vi.fn();
+		render(
+			<ShareResourceModal
+				resourceType="memory"
+				resourceId="m-1"
+				currentVisibility="personal"
+				teams={[{ id: "t1", name: "Platform" }]}
+				onSubmit={onSubmit}
+				onClose={() => {}}
+			/>,
+		);
+		fireEvent.click(screen.getByLabelText(/team/i));
+		const confirm = screen.getByRole("button", { name: /confirm|share/i });
+		fireEvent.click(confirm);
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+});

--- a/interface/src/components/__tests__/ShareResourceModal.test.tsx
+++ b/interface/src/components/__tests__/ShareResourceModal.test.tsx
@@ -1,8 +1,21 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ShareResourceModal } from "../ShareResourceModal";
 
 describe("ShareResourceModal", () => {
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		// Silence the intentional console.error calls in onSubmit's catch
+		// (see C1/C2 remediation) so test output stays clean. We still assert
+		// the spy was invoked in the rejection test below.
+		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		consoleErrorSpy.mockRestore();
+	});
+
 	it("submits visibility + team when confirmed", async () => {
 		const onSubmit = vi.fn(async () => {});
 		render(
@@ -22,7 +35,7 @@ describe("ShareResourceModal", () => {
 		fireEvent.change(screen.getByRole("combobox"), {
 			target: { value: "t1" },
 		});
-		fireEvent.click(screen.getByRole("button", { name: /confirm|share/i }));
+		fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
 		await vi.waitFor(() => expect(onSubmit).toHaveBeenCalled());
 		expect(onSubmit).toHaveBeenCalledWith({
 			visibility: "team",
@@ -43,8 +56,110 @@ describe("ShareResourceModal", () => {
 			/>,
 		);
 		fireEvent.click(screen.getByLabelText(/team/i));
-		const confirm = screen.getByRole("button", { name: /confirm|share/i });
+		const confirm = screen.getByRole("button", { name: /confirm/i });
 		fireEvent.click(confirm);
 		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("shows error + keeps modal open + re-enables Confirm when onSubmit rejects with an API error", async () => {
+		const onClose = vi.fn();
+		const onSubmit = vi.fn(async () => {
+			throw new Error("API error 409: /api/resources/memory/m-1/visibility");
+		});
+		render(
+			<ShareResourceModal
+				resourceType="memory"
+				resourceId="m-1"
+				currentVisibility="personal"
+				teams={[{ id: "t1", name: "Platform" }]}
+				onSubmit={onSubmit}
+				onClose={onClose}
+			/>,
+		);
+		fireEvent.click(screen.getByLabelText(/team/i));
+		fireEvent.change(screen.getByRole("combobox"), {
+			target: { value: "t1" },
+		});
+		const confirm = screen.getByRole("button", { name: /confirm/i }) as HTMLButtonElement;
+		fireEvent.click(confirm);
+
+		// Error message surfaces in the role="alert" region.
+		const alert = await screen.findByRole("alert");
+		expect(alert.textContent).toMatch(/API error 409/);
+
+		// Modal stayed open (onClose not called on rejection path).
+		expect(onClose).not.toHaveBeenCalled();
+
+		// Confirm button re-enabled in the finally block.
+		expect(confirm.disabled).toBe(false);
+
+		// console.error was called so operators have a stack trace.
+		expect(consoleErrorSpy).toHaveBeenCalled();
+	});
+
+	it("does not render an alert + does not close on non-API programmer errors (it rethrows so the error boundary handles them)", async () => {
+		const onClose = vi.fn();
+		// Simulate a programmer-error path: a TypeError from a caller bug.
+		// The component's catch narrows to API errors and rethrows others
+		// after logging via console.error. In jsdom the rethrow surfaces as
+		// an unhandled promise rejection at the vitest test-runner level;
+		// we can't observe that rejection directly through a window listener
+		// (jsdom batches them post-microtask), so we verify the observable
+		// effects: (1) console.error was called, (2) no alert rendered,
+		// (3) onClose was not called.
+		const onSubmit = vi.fn(async () => {
+			throw new TypeError("cannot read properties of undefined");
+		});
+
+		// Absorb the expected unhandled rejection so vitest's test-runner
+		// catcher does not fail the suite. In jsdom, unhandled promise
+		// rejections surface through node's `process` because vitest runs
+		// jsdom inside a node worker. `globalThis` is typed by @types/node
+		// (via vitest's global augmentation) to carry `process`, so no
+		// extra import is needed; we just reach for it here with a narrow
+		// assertion to avoid polluting the file with a node/ types import.
+		interface NodeLikeProcess {
+			on(event: "unhandledRejection", handler: (reason: unknown) => void): void;
+			off(event: "unhandledRejection", handler: (reason: unknown) => void): void;
+		}
+		const proc = (
+			globalThis as unknown as { process?: NodeLikeProcess }
+		).process;
+		const unhandled = vi.fn();
+		proc?.on("unhandledRejection", unhandled);
+
+		try {
+			render(
+				<ShareResourceModal
+					resourceType="memory"
+					resourceId="m-1"
+					currentVisibility="personal"
+					teams={[{ id: "t1", name: "Platform" }]}
+					onSubmit={onSubmit}
+					onClose={onClose}
+				/>,
+			);
+			fireEvent.click(screen.getByLabelText(/team/i));
+			fireEvent.change(screen.getByRole("combobox"), {
+				target: { value: "t1" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+
+			// Wait for the component's log-before-rethrow to land.
+			await vi.waitFor(() => expect(consoleErrorSpy).toHaveBeenCalled());
+
+			// The dialog must NOT render an alert for programmer errors —
+			// only API errors get the user-facing banner.
+			expect(screen.queryByRole("alert")).toBeNull();
+			expect(onClose).not.toHaveBeenCalled();
+
+			// The log line is for a non-API error (check the first arg).
+			const errorArg = consoleErrorSpy.mock.calls.find((call) =>
+				(call[0] as string).includes("non-API error"),
+			);
+			expect(errorArg).toBeDefined();
+		} finally {
+			proc?.off("unhandledRejection", unhandled);
+		}
 	});
 });

--- a/interface/src/components/__tests__/VisibilityChip.test.tsx
+++ b/interface/src/components/__tests__/VisibilityChip.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { VisibilityChip, type Visibility } from "../VisibilityChip";
+
+describe("VisibilityChip", () => {
+	it("renders 'Personal' label", () => {
+		render(<VisibilityChip visibility="personal" />);
+		expect(screen.getByText(/personal/i)).toBeInTheDocument();
+	});
+
+	it("renders team name when team-scoped", () => {
+		render(<VisibilityChip visibility="team" teamName="Platform" />);
+		expect(screen.getByText(/platform/i)).toBeInTheDocument();
+	});
+
+	it("renders 'Org' for org visibility", () => {
+		render(<VisibilityChip visibility="org" />);
+		expect(screen.getByText(/org/i)).toBeInTheDocument();
+	});
+
+	it("handles unknown visibility gracefully", () => {
+		render(<VisibilityChip visibility={"mystery" as Visibility} />);
+		expect(screen.getByText(/unknown/i)).toBeInTheDocument();
+	});
+});

--- a/interface/src/components/__tests__/VisibilityChip.test.tsx
+++ b/interface/src/components/__tests__/VisibilityChip.test.tsx
@@ -22,4 +22,14 @@ describe("VisibilityChip", () => {
 		render(<VisibilityChip visibility={"mystery" as Visibility} />);
 		expect(screen.getByText(/unknown/i)).toBeInTheDocument();
 	});
+
+	it("ignores teamName when visibility is not 'team'", () => {
+		// S3 (pr-test-analyzer): pin the contract that a stray teamName
+		// passed alongside personal/org visibility does not leak into the
+		// label. Guards against a future refactor that accidentally
+		// threads teamName into every branch.
+		render(<VisibilityChip visibility="personal" teamName="Platform" />);
+		expect(screen.getByText(/^Personal$/)).toBeInTheDocument();
+		expect(screen.queryByText(/platform/i)).toBeNull();
+	});
 });

--- a/interface/src/components/__tests__/VisibilityFilter.test.tsx
+++ b/interface/src/components/__tests__/VisibilityFilter.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+	VisibilityFilter,
+	type VisibilityFilterValue,
+} from "../VisibilityFilter";
+
+describe("VisibilityFilter", () => {
+	it("renders all options including 'all'", () => {
+		render(<VisibilityFilter value="all" onChange={() => {}} />);
+		expect(screen.getByLabelText(/all/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/personal/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/team/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/org/i)).toBeInTheDocument();
+	});
+
+	it("invokes onChange with new value when clicked", () => {
+		const onChange = vi.fn();
+		render(<VisibilityFilter value="all" onChange={onChange} />);
+		fireEvent.click(screen.getByLabelText(/personal/i));
+		expect(onChange).toHaveBeenCalledWith(
+			"personal" satisfies VisibilityFilterValue,
+		);
+	});
+});

--- a/src/auth/repository.rs
+++ b/src/auth/repository.rs
@@ -228,3 +228,71 @@ pub async fn get_ownership(
     .with_context(|| format!("read ownership resource={resource_type}:{resource_id}"))?;
     Ok(row)
 }
+
+/// Batch-read ownership rows for a list of resources of the same type. Used by
+/// Phase 7 list-handler enrichment where a single page of memories/cron/agents
+/// needs its visibility + team-binding looked up in one roundtrip. Returns a
+/// map keyed by `resource_id` so callers can `.get(&row.id)` during response
+/// assembly. Missing entries mean "no ownership row", and the handler decides
+/// how to render that. The SPA treats `None` as "Legacy" and never defaults
+/// to "personal" per the no-auto-broadening policy in
+/// `entra-backfill-strategy.md`.
+///
+/// Empty `resource_ids` returns an empty map without hitting the pool. Binds
+/// one placeholder per id, following the pattern proven in
+/// `src/memory/store.rs:462` for SQLite variadic IN clauses.
+pub async fn list_ownerships_by_ids(
+    pool: &SqlitePool,
+    resource_type: &str,
+    resource_ids: &[String],
+) -> anyhow::Result<std::collections::HashMap<String, ResourceOwnershipRecord>> {
+    if resource_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let placeholders: String = resource_ids
+        .iter()
+        .map(|_| "?")
+        .collect::<Vec<_>>()
+        .join(",");
+    let query_str = format!(
+        "SELECT * FROM resource_ownership \
+         WHERE resource_type = ? AND resource_id IN ({placeholders})"
+    );
+    let mut query = sqlx::query_as::<_, ResourceOwnershipRecord>(&query_str).bind(resource_type);
+    for id in resource_ids {
+        query = query.bind(id);
+    }
+    let rows = query.fetch_all(pool).await.with_context(|| {
+        format!(
+            "batch read ownership resource_type={resource_type} count={}",
+            resource_ids.len()
+        )
+    })?;
+    Ok(rows
+        .into_iter()
+        .map(|r| (r.resource_id.clone(), r))
+        .collect())
+}
+
+/// Batch-read team records by `id`. Used by Phase 7 list-handler enrichment
+/// to resolve `shared_with_team_id` references into display names. Returns a
+/// map keyed by `id`. Empty input short-circuits without a roundtrip.
+pub async fn get_teams_by_ids(
+    pool: &SqlitePool,
+    team_ids: &[String],
+) -> anyhow::Result<std::collections::HashMap<String, TeamRecord>> {
+    if team_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let placeholders: String = team_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let query_str = format!("SELECT * FROM teams WHERE id IN ({placeholders})");
+    let mut query = sqlx::query_as::<_, TeamRecord>(&query_str);
+    for id in team_ids {
+        query = query.bind(id);
+    }
+    let rows = query
+        .fetch_all(pool)
+        .await
+        .with_context(|| format!("batch read teams count={}", team_ids.len()))?;
+    Ok(rows.into_iter().map(|r| (r.id.clone(), r)).collect())
+}

--- a/src/auth/repository.rs
+++ b/src/auth/repository.rs
@@ -240,7 +240,9 @@ pub async fn get_ownership(
 ///
 /// Empty `resource_ids` returns an empty map without hitting the pool. Binds
 /// one placeholder per id, following the pattern proven in
-/// `src/memory/store.rs:462` for SQLite variadic IN clauses.
+/// `MemoryStore::get_associations_between` for SQLite variadic IN clauses.
+/// Cited by function name rather than line number so the citation survives
+/// unrelated edits to the memory store.
 pub async fn list_ownerships_by_ids(
     pool: &SqlitePool,
     resource_type: &str,

--- a/tests/authz_data_model.rs
+++ b/tests/authz_data_model.rs
@@ -4,7 +4,8 @@
 use spacebot::auth::context::{AuthContext, PrincipalType};
 use spacebot::auth::principals::Visibility;
 use spacebot::auth::repository::{
-    RepositoryError, get_ownership, set_ownership, upsert_team, upsert_user_from_auth,
+    RepositoryError, get_ownership, get_teams_by_ids, list_ownerships_by_ids, set_ownership,
+    upsert_team, upsert_user_from_auth,
 };
 use sqlx::sqlite::SqlitePoolOptions;
 use std::sync::Arc;
@@ -281,4 +282,75 @@ async fn raw_team_memberships_insert_rejects_unknown_source() {
         result.is_err(),
         "CHECK constraint must reject team_memberships.source = 'manual_admin'"
     );
+}
+
+#[tokio::test]
+async fn list_ownerships_by_ids_empty_short_circuits() {
+    let pool = setup_pool().await;
+    let result = list_ownerships_by_ids(&pool, "memory", &[]).await.unwrap();
+    assert!(result.is_empty());
+}
+
+#[tokio::test]
+async fn list_ownerships_by_ids_returns_map_keyed_by_resource_id() {
+    let pool = setup_pool().await;
+    let ctx = make_ctx("tid-1", "oid-a");
+    upsert_user_from_auth(&pool, &ctx).await.unwrap();
+    let key = ctx.principal_key();
+    let team = upsert_team(&pool, "grp-batch", "Batch Team").await.unwrap();
+
+    set_ownership(
+        &pool,
+        "memory",
+        "m-1",
+        Some("agent-1"),
+        &key,
+        Visibility::Personal,
+        None,
+    )
+    .await
+    .unwrap();
+    set_ownership(
+        &pool,
+        "memory",
+        "m-2",
+        Some("agent-1"),
+        &key,
+        Visibility::Team,
+        Some(&team.id),
+    )
+    .await
+    .unwrap();
+
+    let ids = vec!["m-1".to_string(), "m-2".to_string(), "m-missing".to_string()];
+    let map = list_ownerships_by_ids(&pool, "memory", &ids).await.unwrap();
+    assert_eq!(map.len(), 2, "only 2 ownership rows exist");
+    assert_eq!(
+        map.get("m-1").unwrap().visibility.as_str(),
+        Visibility::Personal.as_str()
+    );
+    let m2 = map.get("m-2").unwrap();
+    assert_eq!(m2.visibility.as_str(), Visibility::Team.as_str());
+    assert_eq!(m2.shared_with_team_id.as_deref(), Some(team.id.as_str()));
+    assert!(
+        !map.contains_key("m-missing"),
+        "missing ids must not appear in the map so callers can detect no-row state"
+    );
+}
+
+#[tokio::test]
+async fn get_teams_by_ids_returns_display_names() {
+    let pool = setup_pool().await;
+    let t1 = upsert_team(&pool, "grp-alpha", "Alpha").await.unwrap();
+    let t2 = upsert_team(&pool, "grp-beta", "Beta").await.unwrap();
+
+    let ids = vec![t1.id.clone(), t2.id.clone(), "team-missing".to_string()];
+    let map = get_teams_by_ids(&pool, &ids).await.unwrap();
+    assert_eq!(map.len(), 2);
+    assert_eq!(map.get(&t1.id).unwrap().display_name, "Alpha");
+    assert_eq!(map.get(&t2.id).unwrap().display_name, "Beta");
+    assert!(!map.contains_key("team-missing"));
+
+    let empty = get_teams_by_ids(&pool, &[]).await.unwrap();
+    assert!(empty.is_empty());
 }

--- a/tests/authz_data_model.rs
+++ b/tests/authz_data_model.rs
@@ -322,7 +322,11 @@ async fn list_ownerships_by_ids_returns_map_keyed_by_resource_id() {
     .await
     .unwrap();
 
-    let ids = vec!["m-1".to_string(), "m-2".to_string(), "m-missing".to_string()];
+    let ids = vec![
+        "m-1".to_string(),
+        "m-2".to_string(),
+        "m-missing".to_string(),
+    ];
     let map = list_ownerships_by_ids(&pool, "memory", &ids).await.unwrap();
     assert_eq!(map.len(), 2, "only 2 ownership rows exist");
     assert_eq!(
@@ -353,4 +357,88 @@ async fn get_teams_by_ids_returns_display_names() {
 
     let empty = get_teams_by_ids(&pool, &[]).await.unwrap();
     assert!(empty.is_empty());
+}
+
+#[tokio::test]
+async fn list_ownerships_by_ids_dedupes_duplicate_inputs() {
+    // S2 (pr-test-analyzer): a caller flattening paginated results could
+    // pass the same id twice. The SQL IN clause dedupes, and the HashMap
+    // assembly overwrites the second row with identical data. Pin the
+    // contract so a future regression (e.g., switching to Vec<Record> with
+    // duplicate-preserving semantics) is caught.
+    let pool = setup_pool().await;
+    let ctx = make_ctx("tid-dup", "oid-dup");
+    upsert_user_from_auth(&pool, &ctx).await.unwrap();
+    let key = ctx.principal_key();
+
+    set_ownership(
+        &pool,
+        "memory",
+        "m-dup",
+        Some("agent-dup"),
+        &key,
+        Visibility::Personal,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let ids = vec![
+        "m-dup".to_string(),
+        "m-dup".to_string(),
+        "m-dup".to_string(),
+    ];
+    let map = list_ownerships_by_ids(&pool, "memory", &ids).await.unwrap();
+    assert_eq!(
+        map.len(),
+        1,
+        "duplicate ids collapse to a single HashMap entry; the IN clause \
+         returns one row per distinct key regardless of how many times it \
+         appeared in the input"
+    );
+    assert!(map.contains_key("m-dup"));
+}
+
+#[tokio::test]
+async fn list_ownerships_by_ids_handles_small_batches_up_to_known_safe_cap() {
+    // I3 (pr-test-analyzer): SQLite's SQLITE_MAX_VARIABLE_NUMBER defaults
+    // to 999 on older builds and 32766 on recent ones. One bind for
+    // resource_type plus N for ids caps the safe input at 998 worst-case.
+    // Phase 7 list handlers page results (<=200 today), but a future
+    // caller flattening pagination could exceed that. This test pins the
+    // safe region (N=500) so a future regression in placeholder emission
+    // (e.g., accidental quadratic allocation, or an off-by-one in the
+    // bind count) is caught without forcing a guard into the helper.
+    //
+    // The helper does not chunk; callers of list_ownerships_by_ids must
+    // stay under SQLITE_MAX_VARIABLE_NUMBER. If/when a caller approaches
+    // the cap, add chunk-loop logic here rather than relying on SQLite
+    // version detection at runtime.
+    let pool = setup_pool().await;
+    let ctx = make_ctx("tid-batch", "oid-batch");
+    upsert_user_from_auth(&pool, &ctx).await.unwrap();
+    let key = ctx.principal_key();
+
+    // Seed 50 ownership rows (fast, deterministic) and query for 500 ids
+    // (250 hits + 250 misses) to exercise a realistically-sized batch.
+    for i in 0..50 {
+        set_ownership(
+            &pool,
+            "memory",
+            &format!("m-{i}"),
+            Some("agent-batch"),
+            &key,
+            Visibility::Personal,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    let mut ids: Vec<String> = (0..250).map(|i| format!("m-{i}")).collect();
+    ids.extend((0..250).map(|i| format!("miss-{i}")));
+    assert_eq!(ids.len(), 500, "500 binds plus 1 for resource_type = 501");
+
+    let map = list_ownerships_by_ids(&pool, "memory", &ids).await.unwrap();
+    assert_eq!(map.len(), 50, "only seeded rows resolve; misses are absent");
 }


### PR DESCRIPTION
## Summary

Phase 7 PR 1 of 5. Ships the **shared primitives** shipping-unit committed at the plan's line 41: reusable SPA components for the personal / team / org visibility axis (VisibilityChip, VisibilityFilter, ShareResourceModal, useMyPrincipalKey) + auth-layer batch helpers (`list_ownerships_by_ids`, `get_teams_by_ids`) that every per-resource rollout PR (2-5) will depend on.

Per-handler list-response enrichment (Task 7.5a) and the `PUT /api/resources/{type}/{id}/visibility` endpoint (Task 7.5) move to a follow-up **PR 1.5** after a pre-code audit (D36) surfaced that the plan's inline-LEFT-JOIN approach is architecturally incompatible with 3 of 4 list handlers (memories + cron + agents use per-agent pools or in-memory config; only Tasks is in the instance pool).

## What's new

### SPA primitives (Tasks 7.1 – 7.4, 7.6)
- `interface/src/components/VisibilityChip.tsx` — labeled pill (personal/team/org + Unknown fallback) with `data-tone` for downstream theming. 4 vitest cases.
- `interface/src/components/VisibilityFilter.tsx` — controlled radiogroup (`all | personal | team | org`) with an accessible `aria-label`. 2 vitest cases.
- `interface/src/components/ShareResourceModal.tsx` — admin/owner dialog for changing a resource's visibility + team binding. Two-state guard: submit disabled while in-flight, empty team selection for team-scope shows inline `role="alert"` error. 2 vitest cases.
- `interface/src/auth/useMe.ts` — appended `useMyPrincipalKey()` helper per D27 (D27 explicitly prohibits creating a separate `useRole.ts` because `useRole` already shipped in PR C). 2 vitest cases.

### Auth-layer batch helpers (new substrate for PR 1.5 + PR 2-5)
- `src/auth/repository.rs` — two new `pub` helpers following the placeholder-binding pattern proven at `src/memory/store.rs:462`:
  - `list_ownerships_by_ids(pool, resource_type, &[String]) -> HashMap<String, ResourceOwnershipRecord>`
  - `get_teams_by_ids(pool, &[String]) -> HashMap<String, TeamRecord>`
- Both short-circuit on empty input (no pool roundtrip). Missing entries are absent from the returned map so handlers can distinguish "no ownership row" (render as Legacy per the no-auto-broadening policy in `docs/design-docs/entra-backfill-strategy.md`) from "personal ownership row with visibility='personal'".

## Pre-code audit (D36)

A `phase-plan-auditor` pass at branch creation produced `READY_TO_IMPLEMENT_TASK_7_1`. Mid-PR, I ran a parallel `/sc:analyze + /sc:research` architecture audit with a `backend-architect` + `Explore` pair. Findings:

| Handler | Store | Pool | LEFT JOIN feasible? |
|---|---|---|---|
| Memories | `MemoryStore` `src/memory/store.rs:12` | **Per-agent SQLite** | No — cross-DB unsupported |
| Tasks | `TaskStore` `src/tasks/store.rs:275` | **Instance SQLite** | Yes — inline JOIN works |
| Cron | `CronStore` `src/cron/store.rs:10` | **Per-agent SQLite** | No — cross-DB unsupported |
| Agents | `ArcSwap<Vec<AgentInfo>>` `src/api/state.rs:99` | **In-memory (TOML)** | No — no query at all |

The audit also confirmed that `resource_ownership` and `teams` live exclusively in the instance pool (`migrations/global/20260420120002_teams.sql`, `migrations/global/20260420120005_resource_ownership.sql`), that no batch-by-ids helper existed before this PR, and that the plan's "default 'personal' when row absent" at line 554 conflicts with the no-auto-broadening policy. The right wire shape is `visibility: Option<String>` (PR 1.5 scope) so the SPA can render "Legacy" honestly.

D36 is now recorded inline in the plan header at `.scratchpad/plans/entraid-auth/phase-7-ui-surfaces.md:27-28` (gitignored; plan is local-only).

## Boundary rationale — PR 1 stops at the substrate

Original plan mixed SPA primitives + handler enrichment + new mutation endpoint into a single PR. With the D36 audit in hand, the cleaner split is:

- **PR 1 (this PR):** 5 SPA primitives + 2 auth batch helpers. Review burden: small + cohesive. No `just typegen` needed. 1 Rust module touched. Reusable substrate for PR 1.5 + PR 2-5.
- **PR 1.5 (next):** Extend 4 list-handler DTOs with `visibility: Option<String>` + `team_name: Option<String>`. Apply post-fetch enrichment for Memories/Cron/Agents; inline JOIN for Tasks. Add `PUT /api/resources/{type}/{id}/visibility` endpoint. Run `just typegen` + commit the `schema.d.ts` diff. ~4 cargo builds, typegen regen, 1 new endpoint, new integration tests. Reviewed as backend-only.

## Test plan

- [x] Interface vitest: 47 → 57 tests (10 files). Zero Phase 6 regressions.
- [x] Interface `bunx tsc --noEmit`: clean.
- [x] Rust integration: 12 → 15 tests in `tests/authz_data_model.rs`. `cargo nextest run --test authz_data_model`: 15/15 PASS.
- [x] `cargo fmt --all -- --check`: clean.
- [x] `cargo clippy --lib --no-deps`: clean.
- [x] `just gate-pr`: all gate checks passed (preflight + check-sidecar-naming + check-workspace-protocol + check-vite-dedupe + check-adr-anchors + fmt-check + clippy with `-D warnings` + unit tests via nextest + integration compile across 41 test binaries).
- [x] Em-dash writing-guide check: zero prose violations in new content.

## Amendments applied

- **A-18** (`useRole` + `useMe` read from `/api/me`, NOT `idTokenClaims.roles`): preserved by co-locating `useMyPrincipalKey` inside `useMe.ts`.
- **A-19** (sidebar header shows user avatar or initials from `/api/me`): preserved; no changes to existing avatar wiring in this PR.

## Out of scope (explicitly)

- List-handler DTO extension (Task 7.5a) → PR 1.5
- `PUT /api/resources/{type}/{id}/visibility` endpoint (Task 7.5) → PR 1.5
- Per-resource chip rollout (Tasks 7.7+) → PR 2-5
- AuthGate `spacebot:auth-exhausted` handler body upgrade (console.warn → toast) → PR 5
- CA claims challenge handling → Phase 6.5 hardening PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)