### PR TITLE
feat(api): Phase 7 PR 1.5 — resource-visibility endpoint + list-handler chip enrichment

### DIFF
--- a/interface/bun.lock
+++ b/interface/bun.lock
@@ -82,6 +82,9 @@
     "../packages/api-client": {
       "name": "@spacebot/api-client",
       "version": "0.1.0",
+      "devDependencies": {
+        "vitest": "^3",
+      },
     },
     "../spaceui/packages/ai": {
       "name": "@spacedrive/ai",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -8,5 +8,12 @@
     "./authedFetch": "./src/authedFetch.ts",
     "./types": "./src/types.ts",
     "./schema": "./src/schema.d.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^3"
   }
 }

--- a/packages/api-client/src/__tests__/setResourceVisibility.test.ts
+++ b/packages/api-client/src/__tests__/setResourceVisibility.test.ts
@@ -1,0 +1,115 @@
+// Vitest for `api.setResourceVisibility`. PR #111 review I2 remediation.
+//
+// Exercises the three branches of the SetResourceVisibilityArgs
+// discriminated union + the non-ok throw path. The helper translates
+// the camelCase React-side arg shape (mirrors PR 1's ShareSubmitArgs)
+// to the snake_case wire payload expected by PUT /api/resources/.../
+// visibility. A regression that breaks the translation would ship
+// through CI and surface as confusing 400s in PR 2's consumers.
+// These tests pin the wire contract so the regression is caught at
+// unit level.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { api, setServerUrl, setAuthTokenProvider } from "../client";
+
+describe("api.setResourceVisibility", () => {
+	beforeEach(() => {
+		// authedFetch calls getApiBase() which composes {_serverUrl}/api
+		// when a server URL is set. Pin to a stable literal so URL
+		// assertions do not depend on BASE_PATH (which defaults to "").
+		setServerUrl("http://test.invalid");
+		// No auth token needed for the mocked fetch. authedFetch skips
+		// the Authorization header when the provider is null.
+		setAuthTokenProvider(null);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("translates team branch to snake_case with shared_with_team_id", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("", { status: 200 }));
+
+		await api.setResourceVisibility("memory", "m-1", {
+			visibility: "team",
+			sharedWithTeamId: "team-alpha",
+		});
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const call = fetchSpy.mock.calls[0];
+		const url = call[0] as string;
+		const init = call[1] as RequestInit;
+		expect(url).toBe(
+			"http://test.invalid/api/resources/memory/m-1/visibility",
+		);
+		expect(init.method).toBe("PUT");
+		const body = JSON.parse(init.body as string);
+		expect(body).toEqual({
+			visibility: "team",
+			shared_with_team_id: "team-alpha",
+		});
+	});
+
+	it("translates personal branch with explicit shared_with_team_id: null", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("", { status: 200 }));
+
+		await api.setResourceVisibility("task", "t-1", {
+			visibility: "personal",
+		});
+
+		const body = JSON.parse(
+			(fetchSpy.mock.calls[0][1] as RequestInit).body as string,
+		);
+		expect(body).toEqual({
+			visibility: "personal",
+			shared_with_team_id: null,
+		});
+	});
+
+	it("translates org branch with explicit shared_with_team_id: null", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("", { status: 200 }));
+
+		await api.setResourceVisibility("cron", "c-1", {
+			visibility: "org",
+		});
+
+		const body = JSON.parse(
+			(fetchSpy.mock.calls[0][1] as RequestInit).body as string,
+		);
+		expect(body).toEqual({
+			visibility: "org",
+			shared_with_team_id: null,
+		});
+	});
+
+	it("throws `API error <status>: <path>` on !ok response", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("", { status: 403 }),
+		);
+
+		await expect(
+			api.setResourceVisibility("memory", "m-1", { visibility: "org" }),
+		).rejects.toThrow("API error 403: /resources/memory/m-1/visibility");
+	});
+
+	it("url-encodes resource_type + resource_id path segments", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("", { status: 200 }));
+
+		await api.setResourceVisibility("mem ory", "m 1/slash", {
+			visibility: "personal",
+		});
+
+		const url = fetchSpy.mock.calls[0][0] as string;
+		expect(url).toBe(
+			"http://test.invalid/api/resources/mem%20ory/m%201%2Fslash/visibility",
+		);
+	});
+});

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -2727,7 +2727,56 @@ export const api = {
 		const query = qs.toString();
 		return fetchJson<ActivityResponse>(`/activity${query ? `?${query}` : ""}`);
 	},
+
+	/**
+	 * Rotate a resource's visibility (Phase 7 PR 1.5 Task 7.5).
+	 *
+	 * Accepts the camelCase `SetResourceVisibilityArgs` discriminated union
+	 * so callers can pass through the `ShareResourceModal` onSubmit payload
+	 * unchanged. Translates to the snake_case wire format (`visibility`,
+	 * `shared_with_team_id`) at the boundary so downstream call sites do
+	 * not repeat the branch.
+	 *
+	 * The backend returns 200 on success, 400 for invalid visibility /
+	 * missing team id, 404 for non-owner non-admin callers (per the
+	 * no-auto-broadening policy), and 500 for the startup-window
+	 * pool-not-attached path.
+	 */
+	setResourceVisibility: async (
+		resourceType: string,
+		resourceId: string,
+		args: SetResourceVisibilityArgs,
+	): Promise<void> => {
+		const body = args.visibility === "team"
+			? { visibility: "team" as const, shared_with_team_id: args.sharedWithTeamId }
+			: { visibility: args.visibility, shared_with_team_id: null };
+		const response = await authedFetch(
+			`${getApiBase()}/resources/${encodeURIComponent(resourceType)}/${encodeURIComponent(resourceId)}/visibility`,
+			{
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(body),
+			},
+		);
+		if (!response.ok) {
+			throw new Error(
+				`API error ${response.status}: /resources/${resourceType}/${resourceId}/visibility`,
+			);
+		}
+	},
 }
+
+/**
+ * Discriminated-union payload for `api.setResourceVisibility`. Mirrors the
+ * `ShareSubmitArgs` type in `interface/src/components/ShareResourceModal.tsx`
+ * so consumers pass the modal's `onSubmit` payload through unchanged. The
+ * "team" branch is the only one that carries `sharedWithTeamId`, making
+ * `{visibility: "personal", sharedWithTeamId: "t1"}` unrepresentable at
+ * the type level.
+ */
+export type SetResourceVisibilityArgs =
+	| { visibility: "team"; sharedWithTeamId: string }
+	| { visibility: "personal" | "org" };
 
 export interface UsageTotals {
 	input_tokens: number;

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1350,7 +1350,7 @@ export interface ProjectListResponse {
 	projects: Project[];
 }
 
-/** GET /agents/projects/:id response — project fields are flattened */
+/** GET /agents/projects/:id response. Project fields are flattened. */
 export interface ProjectWithRelations extends Project {
 	repos: ProjectRepo[];
 	worktrees: ProjectWorktreeWithRepo[];

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -2616,6 +2616,12 @@ export interface components {
             role?: string | null;
             workspace: string;
         };
+        /**
+         * @description Phase 7 PR 1.5 Task 7.5a wrapper. Keeps `AgentInfo` unchanged (it's a
+         *     config-loader type used well beyond the list endpoint) while surfacing
+         *     the chip fields additively on the wire.
+         */
+        AgentListItem: components["schemas"]["AgentInfo"] & components["schemas"]["VisibilityTag"];
         AgentMcpResponse: {
             servers: components["schemas"]["McpServerStatus"][];
         };
@@ -2659,7 +2665,7 @@ export interface components {
             profile?: null | components["schemas"]["AgentProfile"];
         };
         AgentsResponse: {
-            agents: components["schemas"]["AgentInfo"][];
+            agents: components["schemas"]["AgentListItem"][];
         };
         ApproveRequest: {
             approved_by?: string | null;
@@ -3173,8 +3179,14 @@ export interface components {
             last_executed_at?: string | null;
             prompt: string;
             run_once: boolean;
+            team_name?: string | null;
             /** Format: int64 */
             timeout_secs?: number | null;
+            /**
+             * @description Phase 7 PR 1.5 Task 7.5a. Additive fields for the visibility chip.
+             *     `None` encodes "unowned/legacy" per the no-auto-broadening policy.
+             */
+            visibility?: string | null;
         };
         CronListResponse: {
             jobs: components["schemas"]["CronJobWithStats"][];
@@ -3456,7 +3468,7 @@ export interface components {
             tid: string;
         };
         MemoriesListResponse: {
-            memories: components["schemas"]["Memory"][];
+            memories: components["schemas"]["MemoryListItem"][];
             total: number;
         };
         MemoriesSearchResponse: {
@@ -3494,6 +3506,12 @@ export interface components {
             nodes: components["schemas"]["Memory"][];
             total: number;
         };
+        /**
+         * @description Wrapper around `Memory` that carries Phase 7 enrichment fields inline
+         *     via `#[serde(flatten)]`. Additive on the wire: clients that ignore
+         *     unknown fields continue to work; chip-aware clients see the tag.
+         */
+        MemoryListItem: components["schemas"]["Memory"] & components["schemas"]["VisibilityTag"];
         /**
          * @description Memory mode controls how memory is used in a conversation.
          * @enum {string}
@@ -4174,8 +4192,13 @@ export interface components {
             message: string;
             success: boolean;
         };
+        /**
+         * @description Phase 7 PR 1.5 Task 7.5a wrapper around `Task` with enrichment fields
+         *     inline via `#[serde(flatten)]`. Additive on the wire.
+         */
+        TaskListItem: components["schemas"]["Task"] & components["schemas"]["VisibilityTag"];
         TaskListResponse: {
-            tasks: components["schemas"]["Task"][];
+            tasks: components["schemas"]["TaskListItem"][];
         };
         /** @enum {string} */
         TaskPriority: "critical" | "high" | "medium" | "low";
@@ -4524,6 +4547,23 @@ export interface components {
             /** Format: int64 */
             total_rows: number;
             valid: boolean;
+        };
+        /**
+         * @description Per-item enrichment attached to list responses alongside the domain type.
+         *
+         *     Phase 7 PR 1.5 Task 7.5a. `visibility: None` encodes "unowned/legacy"
+         *     per the no-auto-broadening policy in `docs/design-docs/entra-backfill-
+         *     strategy.md`. The SPA renders `None` as "Legacy" rather than defaulting
+         *     to "personal" (which would contradict Phase 4 authz, where unowned
+         *     resources are admin-only). Both fields are additive: handlers that do
+         *     not enrich pass `VisibilityTag::default()`, which serializes to `{}`
+         *     via `skip_serializing_if`.
+         */
+        VisibilityTag: {
+            /** @description Team display name when `visibility == Some("team")`; absent otherwise. */
+            team_name?: string | null;
+            /** @description `"personal"`, `"team"`, `"org"`, or absent (unowned/legacy). */
+            visibility?: string | null;
         };
         WarmupSection: {
             eager_embedding_load: boolean;

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -4119,7 +4119,12 @@ export interface components {
         /**
          * @description Payload accepted by `PUT /api/resources/{type}/{id}/visibility`. Keep the
          *     wire shape snake_case (Rust default) so the TS client can pass
-         *     `{visibility, shared_with_team_id}` without custom serde rules.
+         *     `{visibility, shared_with_team_id}` without custom serde rules. Visibility
+         *     stays stringly-typed at the deserialization boundary for forward-compat
+         *     (a future fourth variant added in Rust does not break existing TS clients
+         *     deserializing the schema). The [`Self::validate`] method does the
+         *     three-step translation (parse enum + enforce team-has-team-id + extract
+         *     the owned fields) in one place, so the handler body stays single-purpose.
          */
         SetVisibilityRequest: {
             shared_with_team_id?: string | null;

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -4551,18 +4551,26 @@ export interface components {
         /**
          * @description Per-item enrichment attached to list responses alongside the domain type.
          *
-         *     Phase 7 PR 1.5 Task 7.5a. `visibility: None` encodes "unowned/legacy"
-         *     per the no-auto-broadening policy in `docs/design-docs/entra-backfill-
-         *     strategy.md`. The SPA renders `None` as "Legacy" rather than defaulting
-         *     to "personal" (which would contradict Phase 4 authz, where unowned
-         *     resources are admin-only). Both fields are additive: handlers that do
-         *     not enrich pass `VisibilityTag::default()`, which serializes to `{}`
-         *     via `skip_serializing_if`.
+         *     Phase 7 PR 1.5 Task 7.5a. `visibility: None` encodes an unowned resource
+         *     (no `resource_ownership` row) per the no-auto-broadening policy in
+         *     `docs/design-docs/entra-backfill-strategy.md`. The SPA's `VisibilityChip`
+         *     renders `None` via its runtime fallback branch (`"Unknown"` with
+         *     `tone="warning"` at `interface/src/components/VisibilityChip.tsx:17`)
+         *     rather than defaulting to `"personal"`. Defaulting to personal would
+         *     contradict Phase 4 authz, which treats unowned resources as admin-only.
+         *
+         *     Wire shape is two flat fields (`visibility`, `team_name`) because the
+         *     SPA's `VisibilityChip` consumes them as two independent props; nesting
+         *     into a discriminated enum would break the PR-1 component API. Instead,
+         *     fields are private and the invariant `team_name.is_some() ⇒ visibility
+         *     == Some("team")` is enforced at construction by the [`Self::new`]
+         *     builder, so callers cannot emit the illegal `{visibility: None,
+         *     team_name: Some(_)}` shape. (S1 structural narrowing, PR #111 review.)
          */
         VisibilityTag: {
             /** @description Team display name when `visibility == Some("team")`; absent otherwise. */
             team_name?: string | null;
-            /** @description `"personal"`, `"team"`, `"org"`, or absent (unowned/legacy). */
+            /** @description `"personal"`, `"team"`, `"org"`, or absent for unowned resources. */
             visibility?: string | null;
         };
         WarmupSection: {

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -1814,6 +1814,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/resources/{resource_type}/{resource_id}/visibility": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put: operations["set_visibility"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/secrets": {
         parameters: {
             query?: never;
@@ -4081,6 +4097,15 @@ export interface components {
             agent_id: string;
             archived: boolean;
             channel_id: string;
+        };
+        /**
+         * @description Payload accepted by `PUT /api/resources/{type}/{id}/visibility`. Keep the
+         *     wire shape snake_case (Rust default) so the TS client can pass
+         *     `{visibility, shared_with_team_id}` without custom serde rules.
+         */
+        SetVisibilityRequest: {
+            shared_with_team_id?: string | null;
+            visibility: string;
         };
         SkillContentResponse: {
             base_dir: string;
@@ -9076,6 +9101,61 @@ export interface operations {
                 };
             };
             /** @description Provider not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    set_visibility: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource type (memory, task, wiki, cron, portal, agent, etc.) */
+                resource_type: string;
+                /** @description Resource identifier */
+                resource_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetVisibilityRequest"];
+            };
+        };
+        responses: {
+            /** @description Visibility updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid visibility value or missing team_id for team scope */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authenticated but not authorized */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found or caller is not owner/admin */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/api-client/vitest.config.ts
+++ b/packages/api-client/vitest.config.ts
@@ -1,0 +1,14 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config";
+
+// Minimal vitest config for @spacebot/api-client. jsdom env because
+// client.ts evaluates `window.__SPACEBOT_BASE_PATH` at module load
+// (line 7): in node env that reference throws. The tests themselves
+// exercise pure fetch wrappers so the DOM surface area is minimal;
+// jsdom just provides a working `window` stub.
+export default defineConfig({
+	test: {
+		environment: "jsdom",
+		globals: true,
+	},
+});

--- a/src/api.rs
+++ b/src/api.rs
@@ -27,6 +27,7 @@ mod opencode_proxy;
 mod portal;
 mod projects;
 pub(crate) mod providers;
+mod resources;
 mod secrets;
 mod server;
 mod settings;

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -88,7 +88,18 @@ pub async fn register_agent_ownership(
 
 #[derive(Serialize, utoipa::ToSchema)]
 pub(super) struct AgentsResponse {
-    agents: Vec<AgentInfo>,
+    agents: Vec<AgentListItem>,
+}
+
+/// Phase 7 PR 1.5 Task 7.5a wrapper. Keeps `AgentInfo` unchanged (it's a
+/// config-loader type used well beyond the list endpoint) while surfacing
+/// the chip fields additively on the wire.
+#[derive(Serialize, utoipa::ToSchema)]
+pub(super) struct AgentListItem {
+    #[serde(flatten)]
+    agent: AgentInfo,
+    #[serde(flatten)]
+    tag: crate::api::resources::VisibilityTag,
 }
 
 #[derive(Serialize, utoipa::ToSchema)]
@@ -349,10 +360,30 @@ pub(super) async fn list_agents(State(state): State<Arc<ApiState>>) -> Json<Agen
     // authenticated caller. Agent configs are lower-sensitivity than
     // memories or portal conversations (no private content), so this
     // matches the `list_memories` / `list_tasks` unfiltered-path TODO.
-    let agents = state.agent_configs.load();
-    Json(AgentsResponse {
-        agents: agents.as_ref().clone(),
-    })
+    let configs = state.agent_configs.load();
+
+    // Phase 7 PR 1.5 Task 7.5a. Agents are in-memory (ArcSwap<Vec<AgentInfo>>
+    // loaded from TOML config at startup), so no SQL query exists to
+    // extend with a JOIN. Enrichment is a secondary lookup against the
+    // instance pool keyed on the agent's id.
+    let ids: Vec<String> = configs.iter().map(|a| a.id.clone()).collect();
+    let tags = if let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() {
+        crate::api::resources::enrich_visibility_tags(&pool, "agent", &ids).await
+    } else {
+        std::collections::HashMap::new()
+    };
+    let agents: Vec<AgentListItem> = configs
+        .iter()
+        .map(|agent| {
+            let tag = tags.get(&agent.id).cloned().unwrap_or_default();
+            AgentListItem {
+                agent: agent.clone(),
+                tag,
+            }
+        })
+        .collect();
+
+    Json(AgentsResponse { agents })
 }
 
 /// List MCP connection status for an agent.

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -370,6 +370,12 @@ pub(super) async fn list_agents(State(state): State<Arc<ApiState>>) -> Json<Agen
     let tags = if let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() {
         crate::api::resources::enrich_visibility_tags(&pool, "agent", &ids).await
     } else {
+        // I4: mirror the authz-skipped pattern.
+        tracing::warn!(
+            handler = "agents",
+            count = ids.len(),
+            "enrichment skipped: instance_pool not attached (boot window or startup-ordering bug)"
+        );
         std::collections::HashMap::new()
     };
     let agents: Vec<AgentListItem> = configs

--- a/src/api/cron.rs
+++ b/src/api/cron.rs
@@ -236,8 +236,10 @@ pub(super) async fn list_cron_jobs(
     })?;
 
     // Phase 7 PR 1.5 Task 7.5a. Batch-enrich visibility + team_name for
-    // the whole page in one roundtrip against the instance pool (cron
-    // lives in a per-agent store, so cross-DB JOIN is impossible per D36).
+    // the whole page in one roundtrip against the instance pool. Cron
+    // lives in a per-agent CronStore (cron_jobs.db per agent) while
+    // resource_ownership + teams live in the instance pool, and SQLite
+    // does not support cross-database JOIN.
     let ids: Vec<String> = configs.iter().map(|c| c.id.clone()).collect();
     let tags = if let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() {
         crate::api::resources::enrich_visibility_tags(&pool, "cron", &ids).await

--- a/src/api/cron.rs
+++ b/src/api/cron.rs
@@ -257,7 +257,12 @@ pub(super) async fn list_cron_jobs(
             .get_execution_stats(&config.id)
             .await
             .unwrap_or_default();
+        // VisibilityTag fields are private (S1 narrowing). Use the
+        // accessors; the team_name-only-with-team invariant was
+        // enforced at construction time by VisibilityTag::new.
         let tag = tags.get(&config.id).cloned().unwrap_or_default();
+        let visibility = tag.visibility().map(str::to_string);
+        let team_name = tag.team_name().map(str::to_string);
 
         jobs.push(CronJobWithStats {
             id: config.id,
@@ -275,8 +280,8 @@ pub(super) async fn list_cron_jobs(
             delivery_failure_count: stats.delivery_failure_count,
             delivery_skipped_count: stats.delivery_skipped_count,
             last_executed_at: stats.last_executed_at,
-            visibility: tag.visibility,
-            team_name: tag.team_name,
+            visibility,
+            team_name,
         });
     }
 

--- a/src/api/cron.rs
+++ b/src/api/cron.rs
@@ -891,3 +891,72 @@ pub(super) async fn toggle_cron(
         message: format!("Cron job '{}' {}", request.cron_id, status),
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CronJobWithStats;
+
+    /// S5 (pr-test-analyzer): pin the CronJobWithStats wire shape for
+    /// the Phase 7 enrichment fields. CronJobWithStats inlines
+    /// `visibility` + `team_name` directly instead of flattening a
+    /// VisibilityTag; a future refactor to the wrapper pattern would
+    /// silently change the wire shape. This test freezes the
+    /// skip_serializing_if contract on both fields.
+    #[test]
+    fn visibility_fields_omitted_when_none() {
+        let job = CronJobWithStats {
+            id: "c-1".into(),
+            prompt: "do the thing".into(),
+            cron_expr: None,
+            interval_secs: 60,
+            delivery_target: "bulletin".into(),
+            enabled: true,
+            run_once: false,
+            active_hours: None,
+            timeout_secs: None,
+            execution_success_count: 0,
+            execution_failure_count: 0,
+            delivery_success_count: 0,
+            delivery_failure_count: 0,
+            delivery_skipped_count: 0,
+            last_executed_at: None,
+            visibility: None,
+            team_name: None,
+        };
+        let json = serde_json::to_string(&job).unwrap();
+        assert!(
+            !json.contains("\"visibility\""),
+            "visibility: None must be omitted from wire: {json}"
+        );
+        assert!(
+            !json.contains("\"team_name\""),
+            "team_name: None must be omitted from wire: {json}"
+        );
+    }
+
+    #[test]
+    fn visibility_fields_present_when_some() {
+        let job = CronJobWithStats {
+            id: "c-2".into(),
+            prompt: "do the thing".into(),
+            cron_expr: None,
+            interval_secs: 60,
+            delivery_target: "bulletin".into(),
+            enabled: true,
+            run_once: false,
+            active_hours: None,
+            timeout_secs: None,
+            execution_success_count: 0,
+            execution_failure_count: 0,
+            delivery_success_count: 0,
+            delivery_failure_count: 0,
+            delivery_skipped_count: 0,
+            last_executed_at: None,
+            visibility: Some("team".into()),
+            team_name: Some("Platform".into()),
+        };
+        let json = serde_json::to_string(&job).unwrap();
+        assert!(json.contains("\"visibility\":\"team\""));
+        assert!(json.contains("\"team_name\":\"Platform\""));
+    }
+}

--- a/src/api/cron.rs
+++ b/src/api/cron.rs
@@ -131,6 +131,12 @@ struct CronJobWithStats {
     delivery_failure_count: u64,
     delivery_skipped_count: u64,
     last_executed_at: Option<String>,
+    /// Phase 7 PR 1.5 Task 7.5a. Additive fields for the visibility chip.
+    /// `None` encodes "unowned/legacy" per the no-auto-broadening policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    visibility: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    team_name: Option<String>,
 }
 
 #[derive(Serialize, utoipa::ToSchema)]
@@ -229,12 +235,23 @@ pub(super) async fn list_cron_jobs(
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    // Phase 7 PR 1.5 Task 7.5a. Batch-enrich visibility + team_name for
+    // the whole page in one roundtrip against the instance pool (cron
+    // lives in a per-agent store, so cross-DB JOIN is impossible per D36).
+    let ids: Vec<String> = configs.iter().map(|c| c.id.clone()).collect();
+    let tags = if let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() {
+        crate::api::resources::enrich_visibility_tags(&pool, "cron", &ids).await
+    } else {
+        std::collections::HashMap::new()
+    };
+
     let mut jobs = Vec::new();
     for config in configs {
         let stats = store
             .get_execution_stats(&config.id)
             .await
             .unwrap_or_default();
+        let tag = tags.get(&config.id).cloned().unwrap_or_default();
 
         jobs.push(CronJobWithStats {
             id: config.id,
@@ -252,6 +269,8 @@ pub(super) async fn list_cron_jobs(
             delivery_failure_count: stats.delivery_failure_count,
             delivery_skipped_count: stats.delivery_skipped_count,
             last_executed_at: stats.last_executed_at,
+            visibility: tag.visibility,
+            team_name: tag.team_name,
         });
     }
 

--- a/src/api/cron.rs
+++ b/src/api/cron.rs
@@ -242,6 +242,12 @@ pub(super) async fn list_cron_jobs(
     let tags = if let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() {
         crate::api::resources::enrich_visibility_tags(&pool, "cron", &ids).await
     } else {
+        // I4: mirror the authz-skipped pattern.
+        tracing::warn!(
+            handler = "cron",
+            count = ids.len(),
+            "enrichment skipped: instance_pool not attached (boot window or startup-ordering bug)"
+        );
         std::collections::HashMap::new()
     };
 

--- a/src/api/memories.rs
+++ b/src/api/memories.rs
@@ -269,9 +269,11 @@ pub(super) async fn list_memories(
     let total = all.len();
     let page: Vec<Memory> = all.into_iter().skip(query.offset).collect();
 
-    // Phase 7 PR 1.5 Task 7.5a. Post-fetch enrichment for the
-    // per-agent store (cross-DB JOIN is impossible per D36, so we
-    // batch-lookup against the instance pool and attach inline).
+    // Phase 7 PR 1.5 Task 7.5a. Post-fetch enrichment for the per-agent
+    // store: MemoryStore's pool is the per-agent memories.db while
+    // resource_ownership + teams live in the instance pool, and SQLite
+    // does not support cross-database JOIN. Batch-lookup against
+    // state.instance_pool and attach visibility + team_name inline.
     let ids: Vec<String> = page.iter().map(|m| m.id.clone()).collect();
     let tags = if let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() {
         crate::api::resources::enrich_visibility_tags(&pool, "memory", &ids).await

--- a/src/api/memories.rs
+++ b/src/api/memories.rs
@@ -276,6 +276,16 @@ pub(super) async fn list_memories(
     let tags = if let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() {
         crate::api::resources::enrich_visibility_tags(&pool, "memory", &ids).await
     } else {
+        // I4: match the authz-skipped observability pattern above. A
+        // persistent pool-None on this path means enrichment is silently
+        // degraded — chips absent across every memories list — and no
+        // counter fires today. One grep-friendly message per handler so
+        // "boot window" vs "startup-ordering bug" is distinguishable.
+        tracing::warn!(
+            handler = "memories",
+            count = ids.len(),
+            "enrichment skipped: instance_pool not attached (boot window or startup-ordering bug)"
+        );
         std::collections::HashMap::new()
     };
     let memories: Vec<MemoryListItem> = page

--- a/src/api/memories.rs
+++ b/src/api/memories.rs
@@ -41,8 +41,19 @@ use std::sync::Arc;
 
 #[derive(Serialize, utoipa::ToSchema)]
 pub(super) struct MemoriesListResponse {
-    memories: Vec<Memory>,
+    memories: Vec<MemoryListItem>,
     total: usize,
+}
+
+/// Wrapper around `Memory` that carries Phase 7 enrichment fields inline
+/// via `#[serde(flatten)]`. Additive on the wire: clients that ignore
+/// unknown fields continue to work; chip-aware clients see the tag.
+#[derive(Serialize, utoipa::ToSchema)]
+pub(super) struct MemoryListItem {
+    #[serde(flatten)]
+    memory: Memory,
+    #[serde(flatten)]
+    tag: crate::api::resources::VisibilityTag,
 }
 
 #[derive(Serialize, utoipa::ToSchema)]
@@ -256,7 +267,24 @@ pub(super) async fn list_memories(
         })?;
 
     let total = all.len();
-    let memories = all.into_iter().skip(query.offset).collect();
+    let page: Vec<Memory> = all.into_iter().skip(query.offset).collect();
+
+    // Phase 7 PR 1.5 Task 7.5a. Post-fetch enrichment for the
+    // per-agent store (cross-DB JOIN is impossible per D36, so we
+    // batch-lookup against the instance pool and attach inline).
+    let ids: Vec<String> = page.iter().map(|m| m.id.clone()).collect();
+    let tags = if let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() {
+        crate::api::resources::enrich_visibility_tags(&pool, "memory", &ids).await
+    } else {
+        std::collections::HashMap::new()
+    };
+    let memories: Vec<MemoryListItem> = page
+        .into_iter()
+        .map(|memory| {
+            let tag = tags.get(&memory.id).cloned().unwrap_or_default();
+            MemoryListItem { memory, tag }
+        })
+        .collect();
 
     Ok(Json(MemoriesListResponse { memories, total }))
 }

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -76,11 +76,17 @@ pub(super) async fn enrich_visibility_tags(
     let owns = list_ownerships_by_ids(pool, resource_type, resource_ids)
         .await
         .unwrap_or_else(|error| {
-            tracing::warn!(
+            // I3 elevation: sqlx-level failures mean the instance pool is
+            // broken (closed, migration mismatch, disk full). The list
+            // still returns 200 with chips absent — from the user's
+            // perspective a cosmetic degradation — so without error-level
+            // severity SRE alerts would not fire. Blast radius is every
+            // list response until the pool recovers.
+            tracing::error!(
                 %error,
                 resource_type = %resource_type,
                 count = resource_ids.len(),
-                "enrich_visibility_tags: list_ownerships_by_ids failed, returning empty map"
+                "enrich_visibility_tags: list_ownerships_by_ids failed, returning empty map (chips absent)"
             );
             HashMap::new()
         });
@@ -94,10 +100,11 @@ pub(super) async fn enrich_visibility_tags(
         get_teams_by_ids(pool, &team_ids)
             .await
             .unwrap_or_else(|error| {
-                tracing::warn!(
+                // I3 elevation: same rationale as the ownership lookup.
+                tracing::error!(
                     %error,
                     count = team_ids.len(),
-                    "enrich_visibility_tags: get_teams_by_ids failed, returning empty map"
+                    "enrich_visibility_tags: get_teams_by_ids failed, returning empty map (team names absent)"
                 );
                 HashMap::new()
             })

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -27,7 +27,9 @@ use crate::api::state::ApiState;
 use crate::auth::context::AuthContext;
 use crate::auth::policy::check_write;
 use crate::auth::principals::Visibility;
-use crate::auth::repository::{get_teams_by_ids, list_ownerships_by_ids, set_ownership};
+use crate::auth::repository::{
+    get_teams_by_ids, list_ownerships_by_ids, update_visibility_only,
+};
 
 /// Per-item enrichment attached to list responses alongside the domain type.
 ///
@@ -290,12 +292,17 @@ pub(super) async fn set_visibility(
         return Err(access.to_status());
     }
 
-    set_ownership(
+    // C1 correction (PR #111 review): use `update_visibility_only` rather
+    // than `set_ownership` to preserve `owner_agent_id` + `owner_principal_key`.
+    // The previous UPSERT unconditionally clobbered `owner_agent_id` to None,
+    // silently re-parenting agent-owned resources on every rotation. The new
+    // helper UPDATEs only the visibility + team fields and returns false if
+    // the row does not exist (so non-owned resources surface as 404 rather
+    // than being silently claimed by the caller's principal).
+    let updated = update_visibility_only(
         &pool,
         &resource_type,
         &resource_id,
-        None,
-        &auth_ctx.principal_key(),
         vis,
         req.shared_with_team_id.as_deref(),
     )
@@ -306,10 +313,18 @@ pub(super) async fn set_visibility(
             actor = %auth_ctx.principal_key(),
             resource_type = %resource_type,
             resource_id = %resource_id,
-            "set_visibility: set_ownership failed"
+            "set_visibility: update_visibility_only failed"
         );
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
+
+    if !updated {
+        // `check_write` already passed, so the row must exist if we got
+        // here under normal conditions. A zero-row UPDATE after a passing
+        // check_write means a concurrent delete raced our rotation; treat
+        // as 404 so the SPA can re-fetch and show "resource gone".
+        return Err(StatusCode::NOT_FOUND);
+    }
 
     Ok(StatusCode::OK)
 }

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -1,0 +1,121 @@
+//! `PUT /api/resources/{resource_type}/{resource_id}/visibility` — rotate a
+//! resource's visibility between Personal / Team / Org and re-bind the
+//! optional `shared_with_team_id`. Phase 7 PR 1.5 Task 7.5.
+//!
+//! Semantics:
+//! - `check_write` gates: owner OR admin may change visibility. Non-owner
+//!   non-admin gets 404 per the no-auto-broadening policy so a stranger
+//!   cannot even confirm the resource exists.
+//! - The handler validates the payload (visibility parse + team-without-
+//!   team-id) BEFORE touching the pool, so malformed requests surface as
+//!   400 Bad Request rather than 500 Internal Server Error from a CHECK
+//!   constraint violation.
+//! - On success, `set_ownership` upserts the ownership row (new
+//!   `visibility` + `shared_with_team_id`; `owner_principal_key` is
+//!   preserved as the caller, which matches the Phase 2 ownership model
+//!   where the caller is the authoritative owner at write time).
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use serde::Deserialize;
+use std::sync::Arc;
+
+use crate::api::state::ApiState;
+use crate::auth::context::AuthContext;
+use crate::auth::policy::check_write;
+use crate::auth::principals::Visibility;
+use crate::auth::repository::set_ownership;
+
+/// Payload accepted by `PUT /api/resources/{type}/{id}/visibility`. Keep the
+/// wire shape snake_case (Rust default) so the TS client can pass
+/// `{visibility, shared_with_team_id}` without custom serde rules.
+#[derive(Deserialize, utoipa::ToSchema)]
+pub(super) struct SetVisibilityRequest {
+    visibility: String,
+    #[serde(default)]
+    shared_with_team_id: Option<String>,
+}
+
+#[utoipa::path(
+    put,
+    path = "/resources/{resource_type}/{resource_id}/visibility",
+    params(
+        ("resource_type" = String, Path, description = "Resource type (memory, task, wiki, cron, portal, agent, etc.)"),
+        ("resource_id" = String, Path, description = "Resource identifier"),
+    ),
+    request_body = SetVisibilityRequest,
+    responses(
+        (status = 200, description = "Visibility updated"),
+        (status = 400, description = "Invalid visibility value or missing team_id for team scope"),
+        (status = 401, description = "Not authenticated"),
+        (status = 403, description = "Authenticated but not authorized"),
+        (status = 404, description = "Resource not found or caller is not owner/admin"),
+    ),
+    tag = "resources",
+)]
+pub(super) async fn set_visibility(
+    State(state): State<Arc<ApiState>>,
+    auth_ctx: AuthContext,
+    Path((resource_type, resource_id)): Path<(String, String)>,
+    Json(req): Json<SetVisibilityRequest>,
+) -> Result<StatusCode, StatusCode> {
+    // Parse + guard BEFORE touching the pool so malformed requests fail
+    // fast with a clear 400 (not a 500 CHECK-constraint leak from the DB
+    // layer). The Visibility CHECK on the `resource_ownership` table
+    // enforces the same invariant as a belt-and-suspenders defense.
+    let vis = Visibility::parse(&req.visibility).ok_or(StatusCode::BAD_REQUEST)?;
+    if matches!(vis, Visibility::Team) && req.shared_with_team_id.is_none() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    // D30 correction: canonical ArcSwap peek matching `src/api/me.rs:60`.
+    let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() else {
+        tracing::warn!(
+            actor = %auth_ctx.principal_key(),
+            resource_type = %resource_type,
+            resource_id = %resource_id,
+            "set_visibility: instance_pool not attached (boot window or startup-ordering bug)"
+        );
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    };
+
+    let access = check_write(&pool, &auth_ctx, &resource_type, &resource_id)
+        .await
+        .map_err(|error| {
+            tracing::warn!(
+                %error,
+                actor = %auth_ctx.principal_key(),
+                resource_type = %resource_type,
+                resource_id = %resource_id,
+                "authz check_write failed"
+            );
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    if !access.is_allowed() {
+        return Err(access.to_status());
+    }
+
+    set_ownership(
+        &pool,
+        &resource_type,
+        &resource_id,
+        None,
+        &auth_ctx.principal_key(),
+        vis,
+        req.shared_with_team_id.as_deref(),
+    )
+    .await
+    .map_err(|error| {
+        tracing::warn!(
+            %error,
+            actor = %auth_ctx.principal_key(),
+            resource_type = %resource_type,
+            resource_id = %resource_id,
+            "set_visibility: set_ownership failed"
+        );
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(StatusCode::OK)
+}

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -271,6 +271,50 @@ mod tests {
         assert_eq!(tag.team_name(), None);
     }
 
+    #[test]
+    fn validate_accepts_known_visibility_values() {
+        let req = SetVisibilityRequest {
+            visibility: "personal".into(),
+            shared_with_team_id: None,
+        };
+        let (vis, team_id) = req.validate().unwrap();
+        assert_eq!(vis.as_str(), "personal");
+        assert_eq!(team_id, None);
+
+        let req = SetVisibilityRequest {
+            visibility: "team".into(),
+            shared_with_team_id: Some("team-1".into()),
+        };
+        let (vis, team_id) = req.validate().unwrap();
+        assert_eq!(vis.as_str(), "team");
+        assert_eq!(team_id.as_deref(), Some("team-1"));
+
+        let req = SetVisibilityRequest {
+            visibility: "org".into(),
+            shared_with_team_id: None,
+        };
+        let (vis, _) = req.validate().unwrap();
+        assert_eq!(vis.as_str(), "org");
+    }
+
+    #[test]
+    fn validate_rejects_unknown_visibility() {
+        let req = SetVisibilityRequest {
+            visibility: "global".into(),
+            shared_with_team_id: None,
+        };
+        assert_eq!(req.validate(), Err(StatusCode::BAD_REQUEST));
+    }
+
+    #[test]
+    fn validate_rejects_team_without_team_id() {
+        let req = SetVisibilityRequest {
+            visibility: "team".into(),
+            shared_with_team_id: None,
+        };
+        assert_eq!(req.validate(), Err(StatusCode::BAD_REQUEST));
+    }
+
     #[tokio::test]
     async fn tag_constructor_drops_team_name_when_visibility_is_not_team() {
         // S1 structural narrowing. VisibilityTag::new must reject the
@@ -298,12 +342,33 @@ mod tests {
 
 /// Payload accepted by `PUT /api/resources/{type}/{id}/visibility`. Keep the
 /// wire shape snake_case (Rust default) so the TS client can pass
-/// `{visibility, shared_with_team_id}` without custom serde rules.
+/// `{visibility, shared_with_team_id}` without custom serde rules. Visibility
+/// stays stringly-typed at the deserialization boundary for forward-compat
+/// (a future fourth variant added in Rust does not break existing TS clients
+/// deserializing the schema). The [`Self::validate`] method does the
+/// three-step translation (parse enum + enforce team-has-team-id + extract
+/// the owned fields) in one place, so the handler body stays single-purpose.
 #[derive(Deserialize, utoipa::ToSchema)]
 pub(super) struct SetVisibilityRequest {
     visibility: String,
     #[serde(default)]
     shared_with_team_id: Option<String>,
+}
+
+impl SetVisibilityRequest {
+    /// Validate the payload and project into `(Visibility, Option<team_id>)`.
+    /// Centralizes the two rules the handler would otherwise inline:
+    ///   1. `visibility` parses to one of the known variants.
+    ///   2. A `team` visibility carries a non-None `shared_with_team_id`.
+    /// Returns `Err(StatusCode::BAD_REQUEST)` on either violation so the
+    /// caller can `?`-propagate without restating the error.
+    fn validate(self) -> Result<(Visibility, Option<String>), StatusCode> {
+        let vis = Visibility::parse(&self.visibility).ok_or(StatusCode::BAD_REQUEST)?;
+        if matches!(vis, Visibility::Team) && self.shared_with_team_id.is_none() {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+        Ok((vis, self.shared_with_team_id))
+    }
 }
 
 #[utoipa::path(
@@ -331,12 +396,11 @@ pub(super) async fn set_visibility(
 ) -> Result<StatusCode, StatusCode> {
     // Parse + guard BEFORE touching the pool so malformed requests fail
     // fast with a clear 400 (not a 500 CHECK-constraint leak from the DB
-    // layer). The Visibility CHECK on the `resource_ownership` table
-    // enforces the same invariant as a belt-and-suspenders defense.
-    let vis = Visibility::parse(&req.visibility).ok_or(StatusCode::BAD_REQUEST)?;
-    if matches!(vis, Visibility::Team) && req.shared_with_team_id.is_none() {
-        return Err(StatusCode::BAD_REQUEST);
-    }
+    // layer). Validation lives on SetVisibilityRequest::validate so it is
+    // unit-testable independent of the whole-handler harness. The DB's
+    // CHECK constraint enforces the same invariant as a belt-and-
+    // suspenders defense.
+    let (vis, shared_with_team_id) = req.validate()?;
 
     // D30 correction: canonical ArcSwap peek matching `src/api/me.rs:60`.
     let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() else {
@@ -377,7 +441,7 @@ pub(super) async fn set_visibility(
         &resource_type,
         &resource_id,
         vis,
-        req.shared_with_team_id.as_deref(),
+        shared_with_team_id.as_deref(),
     )
     .await
     .map_err(|error| {

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -33,16 +33,19 @@ use crate::auth::repository::{
 
 /// Per-item enrichment attached to list responses alongside the domain type.
 ///
-/// Phase 7 PR 1.5 Task 7.5a. `visibility: None` encodes "unowned/legacy"
-/// per the no-auto-broadening policy in `docs/design-docs/entra-backfill-
-/// strategy.md`. The SPA renders `None` as "Legacy" rather than defaulting
-/// to "personal" (which would contradict Phase 4 authz, where unowned
-/// resources are admin-only). Both fields are additive: handlers that do
-/// not enrich pass `VisibilityTag::default()`, which serializes to `{}`
-/// via `skip_serializing_if`.
+/// Phase 7 PR 1.5 Task 7.5a. `visibility: None` encodes an unowned resource
+/// (no `resource_ownership` row) per the no-auto-broadening policy in
+/// `docs/design-docs/entra-backfill-strategy.md`. The SPA's `VisibilityChip`
+/// renders `None` via its runtime fallback branch (`"Unknown"` with
+/// `tone="warning"` at `interface/src/components/VisibilityChip.tsx:17`)
+/// rather than defaulting to `"personal"`. Defaulting to personal would
+/// contradict Phase 4 authz, which treats unowned resources as admin-only.
+/// Both fields are additive: handlers that do not enrich pass
+/// `VisibilityTag::default()`, which serializes to `{}` via
+/// `skip_serializing_if`.
 #[derive(Debug, Clone, Default, Serialize, utoipa::ToSchema)]
 pub struct VisibilityTag {
-    /// `"personal"`, `"team"`, `"org"`, or absent (unowned/legacy).
+    /// `"personal"`, `"team"`, `"org"`, or absent for unowned resources.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub visibility: Option<String>,
     /// Team display name when `visibility == Some("team")`; absent otherwise.
@@ -54,9 +57,12 @@ pub struct VisibilityTag {
 /// a map from resource_id to VisibilityTag. Missing ids map to the default
 /// (both fields None) so the caller can `.unwrap_or_default()` safely.
 ///
-/// D36 pattern. Use when the backing store is per-agent or in-memory
-/// (memories, cron, agents); tasks can inline-JOIN instead since its
-/// `TaskStore` shares the instance pool.
+/// D36 pattern: cross-DB JOIN is impossible in SQLite, and 3 of 4 list
+/// handlers (memories, cron, agents) use per-agent pools or in-memory
+/// config, so enrichment must happen post-fetch against the instance pool.
+/// Tasks' `TaskStore` does share the instance pool and could inline-JOIN,
+/// but PR 1.5 chose post-fetch enrichment for all 4 handlers so readers
+/// do not context-switch on which storage backs which endpoint.
 pub(super) async fn enrich_visibility_tags(
     pool: &SqlitePool,
     resource_type: &str,
@@ -184,7 +190,9 @@ mod tests {
     async fn enrich_missing_ownership_row_returns_none_fields_not_personal_default() {
         // Pins the D36 policy correction. A resource without an ownership
         // row must NOT default to "personal" on the wire; it must surface
-        // as None so the SPA renders "Legacy" rather than lying.
+        // as None so the SPA renders the fallback branch (currently
+        // "Unknown" per VisibilityChip.tsx) rather than lying about
+        // a visibility the backend never recorded.
         let pool = setup_pool().await;
         let ids = vec!["orphan".to_string()];
         let tags = enrich_visibility_tags(&pool, "memory", &ids).await;

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -15,14 +15,6 @@
 //!   preserved as the caller, which matches the Phase 2 ownership model
 //!   where the caller is the authoritative owner at write time).
 
-use axum::Json;
-use axum::extract::{Path, State};
-use axum::http::StatusCode;
-use serde::{Deserialize, Serialize};
-use sqlx::SqlitePool;
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use crate::api::state::ApiState;
 use crate::auth::context::AuthContext;
 use crate::auth::policy::check_write;
@@ -30,6 +22,15 @@ use crate::auth::principals::Visibility;
 use crate::auth::repository::{
     get_teams_by_ids, list_ownerships_by_ids, update_visibility_only,
 };
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
+
+use std::collections::HashMap;
+use std::sync::Arc;
 
 /// Per-item enrichment attached to list responses alongside the domain type.
 ///

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -10,18 +10,17 @@
 //!   team-id) BEFORE touching the pool, so malformed requests surface as
 //!   400 Bad Request rather than 500 Internal Server Error from a CHECK
 //!   constraint violation.
-//! - On success, `set_ownership` upserts the ownership row (new
-//!   `visibility` + `shared_with_team_id`; `owner_principal_key` is
-//!   preserved as the caller, which matches the Phase 2 ownership model
-//!   where the caller is the authoritative owner at write time).
+//! - On success, `update_visibility_only` UPDATEs the existing ownership
+//!   row's `visibility` + `shared_with_team_id` fields. Per PR #111
+//!   review C1, this preserves `owner_agent_id` + `owner_principal_key`
+//!   on rotation. Non-existent rows return 404 so the endpoint cannot
+//!   silently create ownership under the caller's principal.
 
 use crate::api::state::ApiState;
 use crate::auth::context::AuthContext;
 use crate::auth::policy::check_write;
 use crate::auth::principals::Visibility;
-use crate::auth::repository::{
-    get_teams_by_ids, list_ownerships_by_ids, update_visibility_only,
-};
+use crate::auth::repository::{get_teams_by_ids, list_ownerships_by_ids, update_visibility_only};
 
 use axum::Json;
 use axum::extract::{Path, State};
@@ -321,7 +320,8 @@ mod tests {
         // illegal-state pair {visibility: "personal" | "org" | None,
         // team_name: Some(_)} at construction time.
         assert_eq!(
-            VisibilityTag::new(Some("personal".to_string()), Some("Platform".to_string())).team_name(),
+            VisibilityTag::new(Some("personal".to_string()), Some("Platform".to_string()))
+                .team_name(),
             None
         );
         assert_eq!(
@@ -360,6 +360,7 @@ impl SetVisibilityRequest {
     /// Centralizes the two rules the handler would otherwise inline:
     ///   1. `visibility` parses to one of the known variants.
     ///   2. A `team` visibility carries a non-None `shared_with_team_id`.
+    ///
     /// Returns `Err(StatusCode::BAD_REQUEST)` on either violation so the
     /// caller can `?`-propagate without restating the error.
     fn validate(self) -> Result<(Visibility, Option<String>), StatusCode> {

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -41,17 +41,52 @@ use std::sync::Arc;
 /// `tone="warning"` at `interface/src/components/VisibilityChip.tsx:17`)
 /// rather than defaulting to `"personal"`. Defaulting to personal would
 /// contradict Phase 4 authz, which treats unowned resources as admin-only.
-/// Both fields are additive: handlers that do not enrich pass
-/// `VisibilityTag::default()`, which serializes to `{}` via
-/// `skip_serializing_if`.
+///
+/// Wire shape is two flat fields (`visibility`, `team_name`) because the
+/// SPA's `VisibilityChip` consumes them as two independent props; nesting
+/// into a discriminated enum would break the PR-1 component API. Instead,
+/// fields are private and the invariant `team_name.is_some() ⇒ visibility
+/// == Some("team")` is enforced at construction by the [`Self::new`]
+/// builder, so callers cannot emit the illegal `{visibility: None,
+/// team_name: Some(_)}` shape. (S1 structural narrowing, PR #111 review.)
 #[derive(Debug, Clone, Default, Serialize, utoipa::ToSchema)]
 pub struct VisibilityTag {
     /// `"personal"`, `"team"`, `"org"`, or absent for unowned resources.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub visibility: Option<String>,
+    visibility: Option<String>,
     /// Team display name when `visibility == Some("team")`; absent otherwise.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub team_name: Option<String>,
+    team_name: Option<String>,
+}
+
+impl VisibilityTag {
+    /// Construct from a `resource_ownership` row. Enforces the
+    /// `team_name.is_some() ⇒ visibility == "team"` invariant by
+    /// dropping any `team_name` that arrives with a non-team visibility
+    /// (defensive: callers should only pass a team_name when the row's
+    /// `shared_with_team_id` resolved to an active team, but the
+    /// narrowing here is free and makes the illegal state
+    /// unrepresentable on the wire regardless).
+    pub fn new(visibility: Option<String>, team_name: Option<String>) -> Self {
+        let team_name = match visibility.as_deref() {
+            Some("team") => team_name,
+            _ => None,
+        };
+        Self {
+            visibility,
+            team_name,
+        }
+    }
+
+    /// Accessor for handlers that construct flat DTOs (cron).
+    pub fn visibility(&self) -> Option<&str> {
+        self.visibility.as_deref()
+    }
+
+    /// Accessor for handlers that construct flat DTOs (cron).
+    pub fn team_name(&self) -> Option<&str> {
+        self.team_name.as_deref()
+    }
 }
 
 /// Batch-enrich a slice of resource ids for a single resource type. Returns
@@ -118,13 +153,10 @@ pub(super) async fn enrich_visibility_tags(
             let team_name = own
                 .and_then(|o| o.shared_with_team_id.as_ref())
                 .and_then(|tid| teams.get(tid).map(|t| t.display_name.clone()));
-            (
-                id.clone(),
-                VisibilityTag {
-                    visibility,
-                    team_name,
-                },
-            )
+            // S1 narrowing: VisibilityTag::new drops team_name if the
+            // visibility is anything other than "team", making the
+            // illegal-state pair unrepresentable on the wire.
+            (id.clone(), VisibilityTag::new(visibility, team_name))
         })
         .collect()
 }
@@ -190,8 +222,8 @@ mod tests {
         let ids = vec!["m-1".to_string()];
         let tags = enrich_visibility_tags(&pool, "memory", &ids).await;
         let tag = tags.get("m-1").expect("m-1 present");
-        assert_eq!(tag.visibility.as_deref(), Some("team"));
-        assert_eq!(tag.team_name.as_deref(), Some("Platform"));
+        assert_eq!(tag.visibility(), Some("team"));
+        assert_eq!(tag.team_name(), Some("Platform"));
     }
 
     #[tokio::test]
@@ -208,10 +240,11 @@ mod tests {
             .get("orphan")
             .expect("entry present even for missing row");
         assert_eq!(
-            tag.visibility, None,
+            tag.visibility(),
+            None,
             "unowned resource serializes as None, not \"personal\""
         );
-        assert_eq!(tag.team_name, None);
+        assert_eq!(tag.team_name(), None);
     }
 
     #[tokio::test]
@@ -234,8 +267,32 @@ mod tests {
         let ids = vec!["m-2".to_string()];
         let tags = enrich_visibility_tags(&pool, "memory", &ids).await;
         let tag = tags.get("m-2").unwrap();
-        assert_eq!(tag.visibility.as_deref(), Some("personal"));
-        assert_eq!(tag.team_name, None);
+        assert_eq!(tag.visibility(), Some("personal"));
+        assert_eq!(tag.team_name(), None);
+    }
+
+    #[tokio::test]
+    async fn tag_constructor_drops_team_name_when_visibility_is_not_team() {
+        // S1 structural narrowing. VisibilityTag::new must reject the
+        // illegal-state pair {visibility: "personal" | "org" | None,
+        // team_name: Some(_)} at construction time.
+        assert_eq!(
+            VisibilityTag::new(Some("personal".to_string()), Some("Platform".to_string())).team_name(),
+            None
+        );
+        assert_eq!(
+            VisibilityTag::new(Some("org".to_string()), Some("Platform".to_string())).team_name(),
+            None
+        );
+        assert_eq!(
+            VisibilityTag::new(None, Some("Platform".to_string())).team_name(),
+            None
+        );
+        // Only "team" preserves team_name.
+        assert_eq!(
+            VisibilityTag::new(Some("team".to_string()), Some("Platform".to_string())).team_name(),
+            Some("Platform")
+        );
     }
 }
 

--- a/src/api/resources.rs
+++ b/src/api/resources.rs
@@ -1,5 +1,5 @@
-//! `PUT /api/resources/{resource_type}/{resource_id}/visibility` — rotate a
-//! resource's visibility between Personal / Team / Org and re-bind the
+//! `PUT /api/resources/{resource_type}/{resource_id}/visibility`. Rotates a
+//! resource's visibility between Personal / Team / Org and rebinds the
 //! optional `shared_with_team_id`. Phase 7 PR 1.5 Task 7.5.
 //!
 //! Semantics:
@@ -18,14 +18,208 @@
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::api::state::ApiState;
 use crate::auth::context::AuthContext;
 use crate::auth::policy::check_write;
 use crate::auth::principals::Visibility;
-use crate::auth::repository::set_ownership;
+use crate::auth::repository::{get_teams_by_ids, list_ownerships_by_ids, set_ownership};
+
+/// Per-item enrichment attached to list responses alongside the domain type.
+///
+/// Phase 7 PR 1.5 Task 7.5a. `visibility: None` encodes "unowned/legacy"
+/// per the no-auto-broadening policy in `docs/design-docs/entra-backfill-
+/// strategy.md`. The SPA renders `None` as "Legacy" rather than defaulting
+/// to "personal" (which would contradict Phase 4 authz, where unowned
+/// resources are admin-only). Both fields are additive: handlers that do
+/// not enrich pass `VisibilityTag::default()`, which serializes to `{}`
+/// via `skip_serializing_if`.
+#[derive(Debug, Clone, Default, Serialize, utoipa::ToSchema)]
+pub struct VisibilityTag {
+    /// `"personal"`, `"team"`, `"org"`, or absent (unowned/legacy).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<String>,
+    /// Team display name when `visibility == Some("team")`; absent otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team_name: Option<String>,
+}
+
+/// Batch-enrich a slice of resource ids for a single resource type. Returns
+/// a map from resource_id to VisibilityTag. Missing ids map to the default
+/// (both fields None) so the caller can `.unwrap_or_default()` safely.
+///
+/// D36 pattern. Use when the backing store is per-agent or in-memory
+/// (memories, cron, agents); tasks can inline-JOIN instead since its
+/// `TaskStore` shares the instance pool.
+pub(super) async fn enrich_visibility_tags(
+    pool: &SqlitePool,
+    resource_type: &str,
+    resource_ids: &[String],
+) -> HashMap<String, VisibilityTag> {
+    // list_ownerships_by_ids short-circuits on empty input, but make it
+    // explicit here so skim-reading is cheap.
+    if resource_ids.is_empty() {
+        return HashMap::new();
+    }
+    let owns = list_ownerships_by_ids(pool, resource_type, resource_ids)
+        .await
+        .unwrap_or_else(|error| {
+            tracing::warn!(
+                %error,
+                resource_type = %resource_type,
+                count = resource_ids.len(),
+                "enrich_visibility_tags: list_ownerships_by_ids failed, returning empty map"
+            );
+            HashMap::new()
+        });
+    let team_ids: Vec<String> = owns
+        .values()
+        .filter_map(|o| o.shared_with_team_id.clone())
+        .collect();
+    let teams = if team_ids.is_empty() {
+        HashMap::new()
+    } else {
+        get_teams_by_ids(pool, &team_ids)
+            .await
+            .unwrap_or_else(|error| {
+                tracing::warn!(
+                    %error,
+                    count = team_ids.len(),
+                    "enrich_visibility_tags: get_teams_by_ids failed, returning empty map"
+                );
+                HashMap::new()
+            })
+    };
+    resource_ids
+        .iter()
+        .map(|id| {
+            let own = owns.get(id);
+            let visibility = own.map(|o| o.visibility.clone());
+            let team_name = own
+                .and_then(|o| o.shared_with_team_id.as_ref())
+                .and_then(|tid| teams.get(tid).map(|t| t.display_name.clone()));
+            (
+                id.clone(),
+                VisibilityTag {
+                    visibility,
+                    team_name,
+                },
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::context::{AuthContext, PrincipalType};
+    use crate::auth::repository::{set_ownership, upsert_team, upsert_user_from_auth};
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn setup_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connect memory sqlite");
+        sqlx::migrate!("./migrations/global")
+            .run(&pool)
+            .await
+            .expect("run global migrations");
+        pool
+    }
+
+    fn user_ctx(tid: &str, oid: &str) -> AuthContext {
+        AuthContext {
+            principal_type: PrincipalType::User,
+            tid: Arc::from(tid),
+            oid: Arc::from(oid),
+            roles: vec![],
+            groups: vec![],
+            groups_overage: false,
+            display_email: None,
+            display_name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn enrich_empty_ids_returns_empty_map() {
+        let pool = setup_pool().await;
+        let result = enrich_visibility_tags(&pool, "memory", &[]).await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn enrich_attaches_visibility_and_team_name_for_team_scoped_resource() {
+        let pool = setup_pool().await;
+        let ctx = user_ctx("t1", "alice");
+        upsert_user_from_auth(&pool, &ctx).await.unwrap();
+        let team = upsert_team(&pool, "grp-1", "Platform").await.unwrap();
+        set_ownership(
+            &pool,
+            "memory",
+            "m-1",
+            None,
+            &ctx.principal_key(),
+            Visibility::Team,
+            Some(&team.id),
+        )
+        .await
+        .unwrap();
+
+        let ids = vec!["m-1".to_string()];
+        let tags = enrich_visibility_tags(&pool, "memory", &ids).await;
+        let tag = tags.get("m-1").expect("m-1 present");
+        assert_eq!(tag.visibility.as_deref(), Some("team"));
+        assert_eq!(tag.team_name.as_deref(), Some("Platform"));
+    }
+
+    #[tokio::test]
+    async fn enrich_missing_ownership_row_returns_none_fields_not_personal_default() {
+        // Pins the D36 policy correction. A resource without an ownership
+        // row must NOT default to "personal" on the wire; it must surface
+        // as None so the SPA renders "Legacy" rather than lying.
+        let pool = setup_pool().await;
+        let ids = vec!["orphan".to_string()];
+        let tags = enrich_visibility_tags(&pool, "memory", &ids).await;
+        let tag = tags
+            .get("orphan")
+            .expect("entry present even for missing row");
+        assert_eq!(
+            tag.visibility, None,
+            "unowned resource serializes as None, not \"personal\""
+        );
+        assert_eq!(tag.team_name, None);
+    }
+
+    #[tokio::test]
+    async fn enrich_personal_visibility_has_no_team_name() {
+        let pool = setup_pool().await;
+        let ctx = user_ctx("t1", "alice");
+        upsert_user_from_auth(&pool, &ctx).await.unwrap();
+        set_ownership(
+            &pool,
+            "memory",
+            "m-2",
+            None,
+            &ctx.principal_key(),
+            Visibility::Personal,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ids = vec!["m-2".to_string()];
+        let tags = enrich_visibility_tags(&pool, "memory", &ids).await;
+        let tag = tags.get("m-2").unwrap();
+        assert_eq!(tag.visibility.as_deref(), Some("personal"));
+        assert_eq!(tag.team_name, None);
+    }
+}
 
 /// Payload accepted by `PUT /api/resources/{type}/{id}/visibility`. Keep the
 /// wire shape snake_case (Rust default) so the TS client can pass

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -4,8 +4,8 @@ use super::state::ApiState;
 use super::{
     activity, agents, attachments, audit, auth_config, bindings, channels, config, cortex, cron,
     factory, ingest, links, mcp, me, memories, messaging, models, notifications, opencode_proxy,
-    portal, projects, providers, secrets, settings, skills, ssh, system, tasks, tools, usage, wiki,
-    workers,
+    portal, projects, providers, resources, secrets, settings, skills, ssh, system, tasks, tools,
+    usage, wiki, workers,
 };
 
 use axum::Json;
@@ -174,6 +174,9 @@ pub fn api_router() -> OpenApiRouter<Arc<ApiState>> {
         .routes(routes!(projects::delete_repo))
         .routes(routes!(projects::create_worktree))
         .routes(routes!(projects::delete_worktree))
+        // Resource visibility mutation (Phase 7 PR 1.5 Task 7.5).
+        // Owner + admin can rotate visibility and rebind shared_with_team_id.
+        .routes(routes!(resources::set_visibility))
         // Ingest routes
         .routes(routes!(
             ingest::list_ingest_files,

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -325,6 +325,13 @@ pub(super) async fn list_tasks(
     let tags = if let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() {
         crate::api::resources::enrich_visibility_tags(&pool, "task", &ids).await
     } else {
+        // I4: mirror the authz-skipped pattern. Silent enrichment miss at
+        // the startup window would leave every task list unchipped.
+        tracing::warn!(
+            handler = "tasks",
+            count = ids.len(),
+            "enrichment skipped: instance_pool not attached (boot window or startup-ordering bug)"
+        );
         std::collections::HashMap::new()
     };
     let tasks: Vec<TaskListItem> = tasks_raw

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -120,7 +120,17 @@ pub(super) struct AssignRequest {
 
 #[derive(Serialize, utoipa::ToSchema)]
 pub(super) struct TaskListResponse {
-    tasks: Vec<crate::tasks::Task>,
+    tasks: Vec<TaskListItem>,
+}
+
+/// Phase 7 PR 1.5 Task 7.5a wrapper around `Task` with enrichment fields
+/// inline via `#[serde(flatten)]`. Additive on the wire.
+#[derive(Serialize, utoipa::ToSchema)]
+pub(super) struct TaskListItem {
+    #[serde(flatten)]
+    task: crate::tasks::Task,
+    #[serde(flatten)]
+    tag: crate::api::resources::VisibilityTag,
 }
 
 #[derive(Serialize, utoipa::ToSchema)]
@@ -290,7 +300,7 @@ pub(super) async fn list_tasks(
     let status = parse_status(query.status.as_deref())?;
     let priority = parse_priority(query.priority.as_deref())?;
 
-    let tasks = store
+    let tasks_raw = store
         .list(crate::tasks::TaskListFilter {
             agent_id: query.agent_id,
             owner_agent_id: query.owner_agent_id,
@@ -305,6 +315,25 @@ pub(super) async fn list_tasks(
             tracing::warn!(%error, "failed to list tasks");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
+
+    // Phase 7 PR 1.5 Task 7.5a. Uniform post-fetch enrichment pattern
+    // across all 4 list handlers (Memories, Tasks, Cron, Agents) per
+    // the D36 architectural decision. Tasks' store shares the instance
+    // pool and could inline-JOIN, but uniformity wins over micro-
+    // optimization here.
+    let ids: Vec<String> = tasks_raw.iter().map(|t| t.id.clone()).collect();
+    let tags = if let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() {
+        crate::api::resources::enrich_visibility_tags(&pool, "task", &ids).await
+    } else {
+        std::collections::HashMap::new()
+    };
+    let tasks: Vec<TaskListItem> = tasks_raw
+        .into_iter()
+        .map(|task| {
+            let tag = tags.get(&task.id).cloned().unwrap_or_default();
+            TaskListItem { task, tag }
+        })
+        .collect();
 
     Ok(Json(TaskListResponse { tasks }))
 }

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -317,10 +317,13 @@ pub(super) async fn list_tasks(
         })?;
 
     // Phase 7 PR 1.5 Task 7.5a. Uniform post-fetch enrichment pattern
-    // across all 4 list handlers (Memories, Tasks, Cron, Agents) per
-    // the D36 architectural decision. Tasks' store shares the instance
-    // pool and could inline-JOIN, but uniformity wins over micro-
-    // optimization here.
+    // across all 4 list handlers (Memories, Tasks, Cron, Agents).
+    // Tasks' TaskStore is the only one that shares state.instance_pool
+    // (where resource_ownership + teams live), so inline LEFT JOIN is
+    // architecturally feasible here; the other 3 handlers route through
+    // per-agent pools or in-memory config where cross-DB JOIN is
+    // unsupported by SQLite. We chose post-fetch enrichment for all 4
+    // so readers do not context-switch on backing-store choice.
     let ids: Vec<String> = tasks_raw.iter().map(|t| t.id.clone()).collect();
     let tags = if let Some(pool) = state.instance_pool.load().as_ref().as_ref().cloned() {
         crate::api::resources::enrich_visibility_tags(&pool, "task", &ids).await

--- a/src/auth/repository.rs
+++ b/src/auth/repository.rs
@@ -210,6 +210,48 @@ pub async fn set_ownership(
     Ok(())
 }
 
+/// Rotate only the visibility + team binding on an existing ownership row
+/// without touching `owner_agent_id` or `owner_principal_key`. Used by
+/// Phase 7 PR 1.5's `PUT /api/resources/{type}/{id}/visibility` endpoint.
+///
+/// Unlike [`set_ownership`] which UPSERTs all fields (correct at creation
+/// time), this helper is for "the owner or an admin is reclassifying an
+/// existing resource." Preserving `owner_agent_id` is critical because
+/// an admin rotating an agent-owned memory from Team to Org must not
+/// strip the agent link that allows the agent to keep reading the row.
+///
+/// Returns `Ok(false)` when no row exists for `(resource_type, resource_id)`
+/// so the caller can return 404 rather than accidentally creating an
+/// ownership row under the caller's principal (which would be a silent
+/// re-parent of a pre-existing unowned resource to the wrong owner).
+pub async fn update_visibility_only(
+    pool: &SqlitePool,
+    resource_type: &str,
+    resource_id: &str,
+    visibility: Visibility,
+    shared_with_team_id: Option<&str>,
+) -> anyhow::Result<bool> {
+    let result = sqlx::query(
+        r#"
+        UPDATE resource_ownership
+        SET visibility = ?,
+            shared_with_team_id = ?,
+            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+        WHERE resource_type = ? AND resource_id = ?
+        "#,
+    )
+    .bind(visibility.as_str())
+    .bind(shared_with_team_id)
+    .bind(resource_type)
+    .bind(resource_id)
+    .execute(pool)
+    .await
+    .with_context(|| {
+        format!("update visibility resource={resource_type}:{resource_id}")
+    })?;
+    Ok(result.rows_affected() > 0)
+}
+
 /// Read ownership. Returns `None` if the resource is not owned-tracked (e.g.,
 /// pre-existing resource not yet backfilled). See
 /// `docs/design-docs/entra-backfill-strategy.md` for the Phase 4 policy.

--- a/src/auth/repository.rs
+++ b/src/auth/repository.rs
@@ -246,9 +246,7 @@ pub async fn update_visibility_only(
     .bind(resource_id)
     .execute(pool)
     .await
-    .with_context(|| {
-        format!("update visibility resource={resource_type}:{resource_id}")
-    })?;
+    .with_context(|| format!("update visibility resource={resource_type}:{resource_id}"))?;
     Ok(result.rows_affected() > 0)
 }
 

--- a/tests/api_resource_visibility.rs
+++ b/tests/api_resource_visibility.rs
@@ -191,6 +191,61 @@ async fn team_visibility_without_team_id_rejected() {
 }
 
 #[tokio::test]
+async fn rotation_preserves_owner_agent_id() {
+    // C1 regression (PR #111 review). Before the fix, set_visibility
+    // called set_ownership with owner_agent_id = None, and the UPSERT's
+    // excluded.owner_agent_id overwrote any prior agent link to NULL.
+    // This test seeds a row with owner_agent_id = Some("agent-x"),
+    // rotates visibility, and asserts the agent link survives.
+    let (state, pool) = spacebot::api::ApiState::new_test_state_with_mock_entra().await;
+    let alice = user("alice", vec!["SpacebotUser"]);
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+    set_ownership(
+        &pool,
+        "memory",
+        "m-agent-owned",
+        Some("agent-x"),
+        &alice.principal_key(),
+        Visibility::Personal,
+        None,
+    )
+    .await
+    .unwrap();
+    let app = build_test_router_entra(state);
+
+    let body = serde_json::json!({"visibility": "org"}).to_string();
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/api/resources/memory/m-agent-owned/visibility")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", mint_mock_token(&alice)),
+        )
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // The agent link MUST still be there.
+    let own = spacebot::auth::repository::get_ownership(&pool, "memory", "m-agent-owned")
+        .await
+        .unwrap()
+        .expect("row still exists");
+    assert_eq!(
+        own.owner_agent_id.as_deref(),
+        Some("agent-x"),
+        "rotation preserves owner_agent_id"
+    );
+    assert_eq!(
+        own.owner_principal_key,
+        alice.principal_key(),
+        "rotation preserves owner_principal_key"
+    );
+    assert_eq!(own.visibility.as_str(), "org");
+}
+
+#[tokio::test]
 async fn invalid_visibility_value_rejected() {
     let (state, pool) = spacebot::api::ApiState::new_test_state_with_mock_entra().await;
     let alice = user("alice", vec!["SpacebotUser"]);

--- a/tests/api_resource_visibility.rs
+++ b/tests/api_resource_visibility.rs
@@ -253,6 +253,83 @@ async fn rotation_preserves_owner_agent_id() {
 }
 
 #[tokio::test]
+async fn owner_can_rebind_team_id() {
+    // S3 (pr-test-analyzer): Team -> Team rotation rebinds
+    // shared_with_team_id. Pre-fix this was covered only indirectly;
+    // this asserts the UPDATE path preserves the rebind result.
+    let (state, pool) = spacebot::api::ApiState::new_test_state_with_mock_entra().await;
+    let alice = user("alice", vec!["SpacebotUser"]);
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+    let team_a = upsert_team(&pool, "grp-a", "Alpha").await.unwrap();
+    let team_b = upsert_team(&pool, "grp-b", "Beta").await.unwrap();
+    set_ownership(
+        &pool,
+        "memory",
+        "m-rebind",
+        None,
+        &alice.principal_key(),
+        Visibility::Team,
+        Some(&team_a.id),
+    )
+    .await
+    .unwrap();
+    let app = build_test_router_entra(state);
+
+    let body = serde_json::json!({
+        "visibility": "team",
+        "shared_with_team_id": team_b.id,
+    })
+    .to_string();
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/api/resources/memory/m-rebind/visibility")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", mint_mock_token(&alice)),
+        )
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let own = spacebot::auth::repository::get_ownership(&pool, "memory", "m-rebind")
+        .await
+        .unwrap()
+        .expect("row exists");
+    assert_eq!(own.visibility.as_str(), "team");
+    assert_eq!(
+        own.shared_with_team_id.as_deref(),
+        Some(team_b.id.as_str()),
+        "team_id rebound from team-a to team-b"
+    );
+}
+
+#[tokio::test]
+async fn unauthenticated_returns_401() {
+    // S4 (pr-test-analyzer): If a router refactor drops the auth layer
+    // from PUT /api/resources/..., every existing test would still pass
+    // (AuthContext::legacy_static + check_write -> 404). This test
+    // omits the Authorization header so unauth returns 401 explicitly.
+    let (state, _pool) = spacebot::api::ApiState::new_test_state_with_mock_entra().await;
+    let app = build_test_router_entra(state);
+
+    let body = serde_json::json!({"visibility": "org"}).to_string();
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/api/resources/memory/any-id/visibility")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::UNAUTHORIZED,
+        "missing Authorization header must fail as 401, not 404"
+    );
+}
+
+#[tokio::test]
 async fn invalid_visibility_value_rejected() {
     let (state, pool) = spacebot::api::ApiState::new_test_state_with_mock_entra().await;
     let alice = user("alice", vec!["SpacebotUser"]);

--- a/tests/api_resource_visibility.rs
+++ b/tests/api_resource_visibility.rs
@@ -1,0 +1,228 @@
+//! Integration tests for `PUT /api/resources/{type}/{id}/visibility`.
+//!
+//! Phase 7 PR 1.5 Task 7.5. The endpoint lets an owner (or admin) rotate a
+//! resource's visibility between Personal / Team / Org and re-bind the
+//! optional `shared_with_team_id`. It is the backend consumer of the
+//! `ShareResourceModal` component that shipped in PR 1.
+//!
+//! Coverage matrix:
+//!   - `owner_can_change_visibility_personal_to_team`: happy path, owner
+//!     upgrades a memory from Personal to Team scope.
+//!   - `non_owner_cannot_change_visibility`: Bob tries to change Alice's
+//!     memory; the no-auto-broadening + owner-only write policy returns 404
+//!     so a non-owner cannot even confirm the resource exists.
+//!   - `admin_can_change_any_visibility`: admin bypass.
+//!   - `team_visibility_without_team_id_rejected`: 400 guard fires BEFORE
+//!     the DB CHECK constraint would trip.
+//!   - `pool_none_returns_500`: startup-window safety. The endpoint
+//!     cannot silently no-op on a non-attached pool.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+// D29 correction (2026-04-23 Phase 7 audit): the real helper is
+// `build_test_router_entra` under `spacebot::api::test_support`, NOT
+// `spacebot::api::server::test_support::build_test_router_with_auth`.
+use spacebot::api::test_support::build_test_router_entra;
+use spacebot::auth::context::{AuthContext, PrincipalType};
+use spacebot::auth::principals::Visibility;
+use spacebot::auth::repository::{set_ownership, upsert_team, upsert_user_from_auth};
+use spacebot::auth::testing::mint_mock_token;
+use std::sync::Arc;
+use tower::ServiceExt as _;
+
+fn user(oid: &str, roles: Vec<&str>) -> AuthContext {
+    AuthContext {
+        principal_type: PrincipalType::User,
+        tid: Arc::from("t1"),
+        oid: Arc::from(oid),
+        roles: roles.into_iter().map(Arc::from).collect(),
+        groups: vec![],
+        groups_overage: false,
+        display_email: None,
+        display_name: None,
+    }
+}
+
+#[tokio::test]
+async fn owner_can_change_visibility_personal_to_team() {
+    let (state, pool) = spacebot::api::ApiState::new_test_state_with_mock_entra().await;
+    let alice = user("alice", vec!["SpacebotUser"]);
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+    let team = upsert_team(&pool, "grp-1", "Platform").await.unwrap();
+    set_ownership(
+        &pool,
+        "memory",
+        "m-1",
+        None,
+        &alice.principal_key(),
+        Visibility::Personal,
+        None,
+    )
+    .await
+    .unwrap();
+    let app = build_test_router_entra(state);
+
+    let token = mint_mock_token(&alice);
+    let body =
+        serde_json::json!({"visibility": "team", "shared_with_team_id": team.id}).to_string();
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/api/resources/memory/m-1/visibility")
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn non_owner_cannot_change_visibility() {
+    let (state, pool) = spacebot::api::ApiState::new_test_state_with_mock_entra().await;
+    let alice = user("alice", vec!["SpacebotUser"]);
+    let bob = user("bob", vec!["SpacebotUser"]);
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+    upsert_user_from_auth(&pool, &bob).await.unwrap();
+    set_ownership(
+        &pool,
+        "memory",
+        "m-1",
+        None,
+        &alice.principal_key(),
+        Visibility::Personal,
+        None,
+    )
+    .await
+    .unwrap();
+    let app = build_test_router_entra(state);
+
+    let body = serde_json::json!({"visibility": "org"}).to_string();
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/api/resources/memory/m-1/visibility")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", mint_mock_token(&bob)),
+        )
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::NOT_FOUND,
+        "non-owner gets 404 per no-auto-broadening policy"
+    );
+}
+
+#[tokio::test]
+async fn admin_can_change_any_visibility() {
+    let (state, pool) = spacebot::api::ApiState::new_test_state_with_mock_entra().await;
+    let alice = user("alice", vec!["SpacebotUser"]);
+    let carol = user("carol", vec!["SpacebotAdmin"]);
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+    upsert_user_from_auth(&pool, &carol).await.unwrap();
+    set_ownership(
+        &pool,
+        "memory",
+        "m-2",
+        None,
+        &alice.principal_key(),
+        Visibility::Personal,
+        None,
+    )
+    .await
+    .unwrap();
+    let app = build_test_router_entra(state);
+
+    // Admin rotates Alice's memory to Org scope without being the owner.
+    let body = serde_json::json!({"visibility": "org"}).to_string();
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/api/resources/memory/m-2/visibility")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", mint_mock_token(&carol)),
+        )
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn team_visibility_without_team_id_rejected() {
+    let (state, pool) = spacebot::api::ApiState::new_test_state_with_mock_entra().await;
+    let alice = user("alice", vec!["SpacebotUser"]);
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+    set_ownership(
+        &pool,
+        "memory",
+        "m-3",
+        None,
+        &alice.principal_key(),
+        Visibility::Personal,
+        None,
+    )
+    .await
+    .unwrap();
+    let app = build_test_router_entra(state);
+
+    // Team visibility with NO shared_with_team_id. Handler must guard
+    // BEFORE the DB CHECK constraint (which would also reject but as 500).
+    let body = serde_json::json!({"visibility": "team"}).to_string();
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/api/resources/memory/m-3/visibility")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", mint_mock_token(&alice)),
+        )
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::BAD_REQUEST,
+        "team without team_id is a 400, not a 500 CHECK-constraint leak"
+    );
+}
+
+#[tokio::test]
+async fn invalid_visibility_value_rejected() {
+    let (state, pool) = spacebot::api::ApiState::new_test_state_with_mock_entra().await;
+    let alice = user("alice", vec!["SpacebotUser"]);
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+    set_ownership(
+        &pool,
+        "memory",
+        "m-4",
+        None,
+        &alice.principal_key(),
+        Visibility::Personal,
+        None,
+    )
+    .await
+    .unwrap();
+    let app = build_test_router_entra(state);
+
+    let body = serde_json::json!({"visibility": "global"}).to_string();
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/api/resources/memory/m-4/visibility")
+        .header(
+            header::AUTHORIZATION,
+            format!("Bearer {}", mint_mock_token(&alice)),
+        )
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::BAD_REQUEST,
+        "unknown visibility value must fail before reaching the DB"
+    );
+}

--- a/tests/api_resource_visibility.rs
+++ b/tests/api_resource_visibility.rs
@@ -14,8 +14,15 @@
 //!   - `admin_can_change_any_visibility`: admin bypass.
 //!   - `team_visibility_without_team_id_rejected`: 400 guard fires BEFORE
 //!     the DB CHECK constraint would trip.
-//!   - `pool_none_returns_500`: startup-window safety. The endpoint
-//!     cannot silently no-op on a non-attached pool.
+//!   - `rotation_preserves_owner_agent_id`: C1 regression. Rotating
+//!     visibility must not clobber the agent link on the ownership row.
+//!   - `invalid_visibility_value_rejected`: unknown visibility string
+//!     fails as 400 before reaching the DB.
+//!
+//! Intentionally deferred: pool-None returns 500 is covered implicitly by
+//! the `check_write` pool-None branch used in the authz tests elsewhere;
+//! wiring a stubbed-pool test here would require bypassing
+//! `ApiState::new_test_state_with_mock_entra`, which always attaches a pool.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode, header};


### PR DESCRIPTION
## Summary

Phase 7 PR 1.5 of 5. The **backend bridge** between PR 1's shared SPA primitives and PR 2-5's per-resource rollouts. Ships three things the chip consumers need:

1. `PUT /api/resources/{type}/{id}/visibility` endpoint (Task 7.5).
2. List-handler enrichment with `visibility: Option<String>` + `team_name: Option<String>` across Memories / Tasks / Cron / Agents (Task 7.5a).
3. `api.setResourceVisibility` TypeScript wire helper that accepts a discriminated-union payload identical to PR 1's `ShareSubmitArgs`.

PR 2 (Memories chip rollout) is unblocked by this PR landing.

## D36 architectural remediation

This PR applies the D36 correction that was identified during PR 1's pre-code audit. The original plan proposed an inline SQL LEFT JOIN in each of 4 list handlers. A dual-agent audit (`backend-architect` + `Explore`) confirmed that approach is impossible for 3 of 4 handlers:

| Handler | Store | Pool | LEFT JOIN feasible? |
|---|---|---|---|
| Memories | `MemoryStore` | Per-agent SQLite | No — cross-DB unsupported |
| Tasks | `TaskStore` | **Instance SQLite** | Yes — but uniformity wins |
| Cron | `CronStore` | Per-agent SQLite | No |
| Agents | `ArcSwap<Vec<AgentInfo>>` | In-memory (TOML) | No — no query at all |

PR 1 shipped the reusable batch helpers (`list_ownerships_by_ids` + `get_teams_by_ids` in `src/auth/repository.rs`) specifically for this moment. PR 1.5 wraps them in a new `enrich_visibility_tags` helper at `src/api/resources.rs` and calls it from all 4 handlers (post-fetch enrichment pattern; Tasks uses the same post-fetch pattern as the other 3 for uniformity, not inline JOIN).

**Policy correction** per D36 point (d): wire field is `visibility: Option<String>`, NOT `String`-with-default-`"personal"`. A resource without an ownership row is unowned-legacy (admin-only per Phase 4 authz + no-auto-broadening policy in `entra-backfill-strategy.md`), not "personal." Defaulting to "personal" on the wire would contradict the authz invariant.

## Commits

| SHA | Subject |
|---|---|
| `72a7059` | feat(api): PUT /api/resources/{type}/{id}/visibility |
| `7c5a75e` | chore(api-client): just typegen — pick up SetVisibilityRequest |
| `bcc31eb` | feat(api-client): api.setResourceVisibility wire helper |
| `78dbfce` | style(api-client): fix em-dash in ProjectWithRelations doc comment |
| `0c3fc2b` | feat(api): list handlers expose visibility + team_name chips |
| `4307e86` | chore(api-client): just typegen — MemoryListItem + TaskListItem + AgentListItem + VisibilityTag |

## Test coverage

- **5 integration tests** in `tests/api_resource_visibility.rs` exercising the endpoint: owner happy path, non-owner 404, admin bypass, team-without-team-id 400 guard, invalid visibility 400.
- **4 unit tests** in `src/api/resources.rs::tests` exercising `enrich_visibility_tags`: empty short-circuit, team happy path, unowned-returns-None policy pin (D36 correction), personal-has-no-team-name.
- **Integration tests deferred for T7.5a enrichment** — the handler 404s on missing per-agent store fixtures. PR 2's `AgentMemories.scope.test.tsx` exercises the memories chain end-to-end.

## Test plan

- [x] Rust unit tests: 4 new in `src/api/resources.rs::tests` — all PASS.
- [x] Rust integration tests: 5 new in `tests/api_resource_visibility.rs` — all PASS.
- [x] Interface `bunx tsc --noEmit`: clean after `api.setResourceVisibility` addition.
- [x] Interface vitest: 61 passing (zero regressions).
- [x] `just check-typegen`: schema.d.ts matches the regenerated output.
- [x] `just gate-pr`: all checks passed.

## What this unblocks

PR 2 (Memories chip rollout) is now implementable. The BLOCKED-ON-PR-1.5 grep checks in PR 2's plan header will now pass:
- `MemoryItem` carries `visibility` + `team_name` fields (via MemoryListItem wrapper in schema.d.ts)
- `api.setResourceVisibility` helper exists in client.ts
- `src/api/resources` module exists backend-side

## Out of scope (explicit)

- S5 / S6 / S9 deferred from PR 1 — still deferred, land when wiring exists.
- End-to-end integration tests for the 4 list handlers — deferred to PR 2+ which will exercise them via the SPA chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)