### PR TITLE
feat(db): Phase 11.1 — DbPool enum + dialect adapter foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ jwt-authorizer = "0.15"
 jsonwebtoken = "9"
 
 # Databases
-sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "migrate", "chrono", "uuid"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "postgres", "migrate", "chrono", "uuid"] }
 lancedb = "0.27"
 lance-index = "4.0"
 redb = "4.1"

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -1219,7 +1219,7 @@ pub async fn create_agent_internal(
             .clone()
     };
 
-    let memory_store = crate::memory::MemoryStore::new(db.sqlite.clone());
+    let memory_store = crate::memory::MemoryStore::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
     let embedding_table = crate::memory::EmbeddingTable::open_or_create(&db.lance)
         .await
         .map_err(|error| {
@@ -1339,7 +1339,7 @@ pub async fn create_agent_internal(
         runtime_config: runtime_config.clone(),
         event_tx: event_tx.clone(),
         memory_event_tx: memory_event_tx.clone(),
-        sqlite_pool: db.sqlite.clone(),
+        sqlite_pool: db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone(),
         messaging_manager: Some(messaging_manager.clone()),
         sandbox: sandbox.clone(),
         links: Arc::new(arc_swap::ArcSwap::from_pointee(
@@ -1379,7 +1379,7 @@ pub async fn create_agent_internal(
                 .or(agent_config.cron_timezone.as_deref())
                 .and_then(|tz| tz.parse::<chrono_tz::Tz>().ok())
                 .unwrap_or(chrono_tz::Tz::UTC);
-            crate::memory::WorkingMemoryStore::new(db.sqlite.clone(), tz)
+            crate::memory::WorkingMemoryStore::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone(), tz)
         },
         api_state: Some(state.clone()),
         wiki_store: state.wiki_store.load().as_ref().clone(),
@@ -1397,7 +1397,7 @@ pub async fn create_agent_internal(
     let event_rx = event_tx.subscribe();
     state.register_agent_events(agent_id.clone(), event_rx);
 
-    let cron_store = std::sync::Arc::new(crate::cron::CronStore::new(db.sqlite.clone()));
+    let cron_store = std::sync::Arc::new(crate::cron::CronStore::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone()));
     let cron_context = crate::cron::CronContext {
         deps: deps.clone(),
         screenshot_dir: agent_config.screenshot_dir(),
@@ -1414,9 +1414,9 @@ pub async fn create_agent_internal(
     let browser_config = (**runtime_config.browser_config.load()).clone();
     let brave_search_key = (**runtime_config.brave_search_key.load()).clone();
     let conversation_logger =
-        crate::conversation::history::ConversationLogger::new(db.sqlite.clone());
-    let channel_store = crate::conversation::ChannelStore::new(db.sqlite.clone());
-    let run_logger = crate::conversation::ProcessRunLogger::new(db.sqlite.clone());
+        crate::conversation::history::ConversationLogger::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+    let channel_store = crate::conversation::ChannelStore::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+    let run_logger = crate::conversation::ProcessRunLogger::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
     let cortex_ctx = crate::agent::cortex_chat::CortexChatSession::create_context();
     #[allow(deprecated)] // Cortex chat is legacy; being replaced by Channel Settings
     let cortex_tool_server = crate::tools::create_cortex_chat_tool_server(
@@ -1445,7 +1445,7 @@ pub async fn create_agent_internal(
         tracing::warn!(%error, agent_id = %agent_id, "failed to add factory tools to cortex chat");
     }
 
-    let cortex_store = crate::agent::cortex_chat::CortexChatStore::new(db.sqlite.clone());
+    let cortex_store = crate::agent::cortex_chat::CortexChatStore::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
     let cortex_session = crate::agent::cortex_chat::CortexChatSession::new(
         deps.clone(),
         cortex_tool_server,
@@ -1462,14 +1462,14 @@ pub async fn create_agent_internal(
         }
         logger
     };
-    let cortex_logger = make_cortex_logger(db.sqlite.clone());
+    let cortex_logger = make_cortex_logger(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
     let _warmup_loop = crate::agent::cortex::spawn_warmup_loop(deps.clone(), cortex_logger.clone());
     let _cortex_loop = crate::agent::cortex::spawn_cortex_loop(deps.clone(), cortex_logger.clone());
     let _association_loop =
         crate::agent::cortex::spawn_association_loop(deps.clone(), cortex_logger);
     crate::agent::cortex::spawn_ready_task_loop(
         deps.clone(),
-        make_cortex_logger(db.sqlite.clone()),
+        make_cortex_logger(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone()),
     );
 
     let ingestion_config = **runtime_config.ingestion.load();
@@ -1477,7 +1477,7 @@ pub async fn create_agent_internal(
         crate::agent::ingestion::spawn_ingestion_loop(agent_config.ingest_dir(), deps.clone());
     }
 
-    let sqlite_pool = db.sqlite.clone();
+    let sqlite_pool = db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone();
     let mut deps_with_cron = deps.clone();
     deps_with_cron.cron_tool = Some(cron_tool);
     let agent = crate::Agent {

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -1193,7 +1193,9 @@ pub async fn create_agent_internal(
         })?;
     }
 
-    let db = crate::db::Db::connect(&agent_config.data_dir)
+    let db_url_guard = state.database_url.load();
+    let db_url: Option<&str> = (**db_url_guard).as_deref();
+    let db = crate::db::Db::connect(&agent_config.data_dir, db_url)
         .await
         .map_err(|error| {
             tracing::error!(%error, agent_id = %agent_id, "failed to connect agent databases");

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -1221,7 +1221,11 @@ pub async fn create_agent_internal(
             .clone()
     };
 
-    let memory_store = crate::memory::MemoryStore::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+    let memory_store = crate::memory::MemoryStore::new(
+        db.sqlite_pool()
+            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+            .clone(),
+    );
     let embedding_table = crate::memory::EmbeddingTable::open_or_create(&db.lance)
         .await
         .map_err(|error| {
@@ -1341,7 +1345,10 @@ pub async fn create_agent_internal(
         runtime_config: runtime_config.clone(),
         event_tx: event_tx.clone(),
         memory_event_tx: memory_event_tx.clone(),
-        sqlite_pool: db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone(),
+        sqlite_pool: db
+            .sqlite_pool()
+            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+            .clone(),
         messaging_manager: Some(messaging_manager.clone()),
         sandbox: sandbox.clone(),
         links: Arc::new(arc_swap::ArcSwap::from_pointee(
@@ -1381,7 +1388,12 @@ pub async fn create_agent_internal(
                 .or(agent_config.cron_timezone.as_deref())
                 .and_then(|tz| tz.parse::<chrono_tz::Tz>().ok())
                 .unwrap_or(chrono_tz::Tz::UTC);
-            crate::memory::WorkingMemoryStore::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone(), tz)
+            crate::memory::WorkingMemoryStore::new(
+                db.sqlite_pool()
+                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                    .clone(),
+                tz,
+            )
         },
         api_state: Some(state.clone()),
         wiki_store: state.wiki_store.load().as_ref().clone(),
@@ -1399,7 +1411,11 @@ pub async fn create_agent_internal(
     let event_rx = event_tx.subscribe();
     state.register_agent_events(agent_id.clone(), event_rx);
 
-    let cron_store = std::sync::Arc::new(crate::cron::CronStore::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone()));
+    let cron_store = std::sync::Arc::new(crate::cron::CronStore::new(
+        db.sqlite_pool()
+            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+            .clone(),
+    ));
     let cron_context = crate::cron::CronContext {
         deps: deps.clone(),
         screenshot_dir: agent_config.screenshot_dir(),
@@ -1415,10 +1431,21 @@ pub async fn create_agent_internal(
 
     let browser_config = (**runtime_config.browser_config.load()).clone();
     let brave_search_key = (**runtime_config.brave_search_key.load()).clone();
-    let conversation_logger =
-        crate::conversation::history::ConversationLogger::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
-    let channel_store = crate::conversation::ChannelStore::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
-    let run_logger = crate::conversation::ProcessRunLogger::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+    let conversation_logger = crate::conversation::history::ConversationLogger::new(
+        db.sqlite_pool()
+            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+            .clone(),
+    );
+    let channel_store = crate::conversation::ChannelStore::new(
+        db.sqlite_pool()
+            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+            .clone(),
+    );
+    let run_logger = crate::conversation::ProcessRunLogger::new(
+        db.sqlite_pool()
+            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+            .clone(),
+    );
     let cortex_ctx = crate::agent::cortex_chat::CortexChatSession::create_context();
     #[allow(deprecated)] // Cortex chat is legacy; being replaced by Channel Settings
     let cortex_tool_server = crate::tools::create_cortex_chat_tool_server(
@@ -1447,7 +1474,11 @@ pub async fn create_agent_internal(
         tracing::warn!(%error, agent_id = %agent_id, "failed to add factory tools to cortex chat");
     }
 
-    let cortex_store = crate::agent::cortex_chat::CortexChatStore::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+    let cortex_store = crate::agent::cortex_chat::CortexChatStore::new(
+        db.sqlite_pool()
+            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+            .clone(),
+    );
     let cortex_session = crate::agent::cortex_chat::CortexChatSession::new(
         deps.clone(),
         cortex_tool_server,
@@ -1464,14 +1495,22 @@ pub async fn create_agent_internal(
         }
         logger
     };
-    let cortex_logger = make_cortex_logger(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+    let cortex_logger = make_cortex_logger(
+        db.sqlite_pool()
+            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+            .clone(),
+    );
     let _warmup_loop = crate::agent::cortex::spawn_warmup_loop(deps.clone(), cortex_logger.clone());
     let _cortex_loop = crate::agent::cortex::spawn_cortex_loop(deps.clone(), cortex_logger.clone());
     let _association_loop =
         crate::agent::cortex::spawn_association_loop(deps.clone(), cortex_logger);
     crate::agent::cortex::spawn_ready_task_loop(
         deps.clone(),
-        make_cortex_logger(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone()),
+        make_cortex_logger(
+            db.sqlite_pool()
+                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                .clone(),
+        ),
     );
 
     let ingestion_config = **runtime_config.ingestion.load();
@@ -1479,7 +1518,10 @@ pub async fn create_agent_internal(
         crate::agent::ingestion::spawn_ingestion_loop(agent_config.ingest_dir(), deps.clone());
     }
 
-    let sqlite_pool = db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone();
+    let sqlite_pool = db
+        .sqlite_pool()
+        .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+        .clone();
     let mut deps_with_cron = deps.clone();
     deps_with_cron.cron_tool = Some(cron_tool);
     let agent = crate::Agent {

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -1221,11 +1221,8 @@ pub async fn create_agent_internal(
             .clone()
     };
 
-    let memory_store = crate::memory::MemoryStore::new(
-        db.sqlite_pool()
-            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-            .clone(),
-    );
+    let memory_store =
+        crate::memory::MemoryStore::new(db.sqlite_pool().map_err(|e| e.to_string())?.clone());
     let embedding_table = crate::memory::EmbeddingTable::open_or_create(&db.lance)
         .await
         .map_err(|error| {
@@ -1345,10 +1342,7 @@ pub async fn create_agent_internal(
         runtime_config: runtime_config.clone(),
         event_tx: event_tx.clone(),
         memory_event_tx: memory_event_tx.clone(),
-        sqlite_pool: db
-            .sqlite_pool()
-            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-            .clone(),
+        sqlite_pool: db.sqlite_pool().map_err(|e| e.to_string())?.clone(),
         messaging_manager: Some(messaging_manager.clone()),
         sandbox: sandbox.clone(),
         links: Arc::new(arc_swap::ArcSwap::from_pointee(
@@ -1389,9 +1383,7 @@ pub async fn create_agent_internal(
                 .and_then(|tz| tz.parse::<chrono_tz::Tz>().ok())
                 .unwrap_or(chrono_tz::Tz::UTC);
             crate::memory::WorkingMemoryStore::new(
-                db.sqlite_pool()
-                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                    .clone(),
+                db.sqlite_pool().map_err(|e| e.to_string())?.clone(),
                 tz,
             )
         },
@@ -1412,9 +1404,7 @@ pub async fn create_agent_internal(
     state.register_agent_events(agent_id.clone(), event_rx);
 
     let cron_store = std::sync::Arc::new(crate::cron::CronStore::new(
-        db.sqlite_pool()
-            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-            .clone(),
+        db.sqlite_pool().map_err(|e| e.to_string())?.clone(),
     ));
     let cron_context = crate::cron::CronContext {
         deps: deps.clone(),
@@ -1432,19 +1422,13 @@ pub async fn create_agent_internal(
     let browser_config = (**runtime_config.browser_config.load()).clone();
     let brave_search_key = (**runtime_config.brave_search_key.load()).clone();
     let conversation_logger = crate::conversation::history::ConversationLogger::new(
-        db.sqlite_pool()
-            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-            .clone(),
+        db.sqlite_pool().map_err(|e| e.to_string())?.clone(),
     );
     let channel_store = crate::conversation::ChannelStore::new(
-        db.sqlite_pool()
-            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-            .clone(),
+        db.sqlite_pool().map_err(|e| e.to_string())?.clone(),
     );
     let run_logger = crate::conversation::ProcessRunLogger::new(
-        db.sqlite_pool()
-            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-            .clone(),
+        db.sqlite_pool().map_err(|e| e.to_string())?.clone(),
     );
     let cortex_ctx = crate::agent::cortex_chat::CortexChatSession::create_context();
     #[allow(deprecated)] // Cortex chat is legacy; being replaced by Channel Settings
@@ -1475,9 +1459,7 @@ pub async fn create_agent_internal(
     }
 
     let cortex_store = crate::agent::cortex_chat::CortexChatStore::new(
-        db.sqlite_pool()
-            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-            .clone(),
+        db.sqlite_pool().map_err(|e| e.to_string())?.clone(),
     );
     let cortex_session = crate::agent::cortex_chat::CortexChatSession::new(
         deps.clone(),
@@ -1495,22 +1477,14 @@ pub async fn create_agent_internal(
         }
         logger
     };
-    let cortex_logger = make_cortex_logger(
-        db.sqlite_pool()
-            .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-            .clone(),
-    );
+    let cortex_logger = make_cortex_logger(db.sqlite_pool().map_err(|e| e.to_string())?.clone());
     let _warmup_loop = crate::agent::cortex::spawn_warmup_loop(deps.clone(), cortex_logger.clone());
     let _cortex_loop = crate::agent::cortex::spawn_cortex_loop(deps.clone(), cortex_logger.clone());
     let _association_loop =
         crate::agent::cortex::spawn_association_loop(deps.clone(), cortex_logger);
     crate::agent::cortex::spawn_ready_task_loop(
         deps.clone(),
-        make_cortex_logger(
-            db.sqlite_pool()
-                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                .clone(),
-        ),
+        make_cortex_logger(db.sqlite_pool().map_err(|e| e.to_string())?.clone()),
     );
 
     let ingestion_config = **runtime_config.ingestion.load();
@@ -1518,10 +1492,7 @@ pub async fn create_agent_internal(
         crate::agent::ingestion::spawn_ingestion_loop(agent_config.ingest_dir(), deps.clone());
     }
 
-    let sqlite_pool = db
-        .sqlite_pool()
-        .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-        .clone();
+    let sqlite_pool = db.sqlite_pool().map_err(|e| e.to_string())?.clone();
     let mut deps_with_cron = deps.clone();
     deps_with_cron.cron_tool = Some(cron_tool);
     let agent = crate::Agent {

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -1194,7 +1194,7 @@ pub async fn create_agent_internal(
     }
 
     let db_url_guard = state.database_url.load();
-    let db_url: Option<&str> = (**db_url_guard).as_deref();
+    let db_url: Option<&crate::db::DatabaseUrl> = (**db_url_guard).as_ref();
     let db = crate::db::Db::connect(&agent_config.data_dir, db_url)
         .await
         .map_err(|error| {

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -162,7 +162,9 @@ pub struct ApiState {
     /// Phase 11 backend selection. None falls back to per-agent SQLite.
     /// `Some("sqlite:...")` or `Some("postgres://...")` routes through the
     /// dialect-aware path in `db::Db::connect` and `db::connect_instance_db`.
-    /// Populated from `Config.database.url` at daemon startup.
+    /// Populated from `Config.database.url` at daemon startup. Handlers
+    /// must read via `(**state.database_url.load()).as_deref()` and must
+    /// not call `set_database_url`; mutation is reserved for startup paths.
     pub database_url: ArcSwap<Option<String>>,
     /// Shared LLM manager for agent creation.
     pub llm_manager: RwLock<Option<Arc<LlmManager>>>,
@@ -1187,6 +1189,12 @@ impl ApiState {
 
     /// Set the runtime database URL for new agent creation. None falls back
     /// to per-agent SQLite under each agent's data dir.
+    ///
+    /// STARTUP ONLY: invoked from `main.rs` after `set_instance_dir`. Do not
+    /// call from HTTP handlers or background tasks. The PR 11.1 sweep's
+    /// invariant ("pool is SQLite; Postgres URLs hard-error at connect")
+    /// rests on this URL being set once at startup, before any agent's
+    /// `Db::connect` is reached. Hot-swap is not supported in PR 11.1.
     pub fn set_database_url(&self, url: Option<String>) {
         self.database_url.store(Arc::new(url));
     }

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -159,6 +159,11 @@ pub struct ApiState {
     pub update_status: SharedUpdateStatus,
     /// Instance directory path for accessing instance-level skills.
     pub instance_dir: ArcSwap<PathBuf>,
+    /// Phase 11 backend selection. None falls back to per-agent SQLite.
+    /// `Some("sqlite:...")` or `Some("postgres://...")` routes through the
+    /// dialect-aware path in `db::Db::connect` and `db::connect_instance_db`.
+    /// Populated from `Config.database.url` at daemon startup.
+    pub database_url: ArcSwap<Option<String>>,
     /// Shared LLM manager for agent creation.
     pub llm_manager: RwLock<Option<Arc<LlmManager>>>,
     /// Shared embedding model for agent creation.
@@ -402,6 +407,7 @@ impl ApiState {
             provider_setup_tx,
             update_status: crate::update::new_shared_status(),
             instance_dir: ArcSwap::from_pointee(PathBuf::new()),
+            database_url: ArcSwap::from_pointee(None),
             llm_manager: RwLock::new(None),
             embedding_model: RwLock::new(None),
             prompt_engine: RwLock::new(None),
@@ -1177,6 +1183,12 @@ impl ApiState {
     /// Set the instance directory path.
     pub fn set_instance_dir(&self, dir: PathBuf) {
         self.instance_dir.store(Arc::new(dir));
+    }
+
+    /// Set the runtime database URL for new agent creation. None falls back
+    /// to per-agent SQLite under each agent's data dir.
+    pub fn set_database_url(&self, url: Option<String>) {
+        self.database_url.store(Arc::new(url));
     }
 
     /// Set the shared LLM manager for runtime agent creation.

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -160,12 +160,13 @@ pub struct ApiState {
     /// Instance directory path for accessing instance-level skills.
     pub instance_dir: ArcSwap<PathBuf>,
     /// Phase 11 backend selection. None falls back to per-agent SQLite.
-    /// `Some("sqlite:...")` or `Some("postgres://...")` routes through the
-    /// dialect-aware path in `db::Db::connect` and `db::connect_instance_db`.
-    /// Populated from `Config.database.url` at daemon startup. Handlers
-    /// must read via `(**state.database_url.load()).as_deref()` and must
-    /// not call `set_database_url`; mutation is reserved for startup paths.
-    pub database_url: ArcSwap<Option<String>>,
+    /// `Some(DatabaseUrl::Sqlite(...))` or `Some(DatabaseUrl::Postgres(...))`
+    /// routes through the dialect-aware path in `db::Db::connect` and
+    /// `db::connect_instance_db`. Populated from `Config.database.url` at
+    /// daemon startup. Handlers read via `(**state.database_url.load())
+    /// .as_ref()` and must not call `set_database_url`; mutation is
+    /// reserved for startup paths.
+    pub database_url: ArcSwap<Option<crate::db::DatabaseUrl>>,
     /// Shared LLM manager for agent creation.
     pub llm_manager: RwLock<Option<Arc<LlmManager>>>,
     /// Shared embedding model for agent creation.
@@ -1195,7 +1196,7 @@ impl ApiState {
     /// invariant ("pool is SQLite; Postgres URLs hard-error at connect")
     /// rests on this URL being set once at startup, before any agent's
     /// `Db::connect` is reached. Hot-swap is not supported in PR 11.1.
-    pub fn set_database_url(&self, url: Option<String>) {
+    pub fn set_database_url(&self, url: Option<crate::db::DatabaseUrl>) {
         self.database_url.store(Arc::new(url));
     }
 

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -3016,10 +3016,9 @@ mod tests {
 url = "postgres://user:pass@host:5432/spacebot"
 "#;
         let parsed: TomlConfig = toml::from_str(toml_input).unwrap();
-        assert_eq!(
-            parsed.database.url.as_deref(),
-            Some("postgres://user:pass@host:5432/spacebot")
-        );
+        let url = parsed.database.url.as_ref().expect("url must be parsed");
+        assert_eq!(url.dialect(), crate::db::Dialect::Postgres);
+        assert_eq!(url.as_str(), "postgres://user:pass@host:5432/spacebot");
     }
 
     #[test]
@@ -3036,5 +3035,35 @@ url = "postgres://user:pass@host:5432/spacebot"
 "#;
         let parsed: TomlConfig = toml::from_str(toml_input).unwrap();
         assert!(parsed.database.url.is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_scheme_at_config_load_not_at_connect() {
+        // Demonstrates the DatabaseUrl::FromStr validation runs at config load
+        // rather than at connect time, so operator typos surface during startup
+        // in the deserialization error rather than at first Db::connect.
+        //
+        // Note: the toml crate's error formatter echoes the raw source line,
+        // which means credentials in a config.toml literal still appear in the
+        // error context. The typed error message itself IS redacted (asserted
+        // below). Operators should reference credentials via the secrets store
+        // (`secret:foo` syntax) rather than inline strings in config.toml.
+        let toml_input = r#"
+[database]
+url = "potgres://host:5432/db"
+"#;
+        let err = match toml::from_str::<TomlConfig>(toml_input) {
+            Ok(_) => panic!("expected typo'd scheme to fail at config load"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unsupported database URL scheme"),
+            "expected typed UnsupportedScheme error: {msg}"
+        );
+        assert!(
+            msg.contains("potgres://"),
+            "expected typo'd scheme in error: {msg}"
+        );
     }
 }

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -1067,6 +1067,8 @@ impl Config {
             // Phase 5: no-export fallback when the minimal env-driven
             // loader is used (fresh install / no config.toml yet).
             audit: crate::config::types::AuditConfig::default(),
+            // Phase 11: minimal env-driven loader gets per-agent SQLite default.
+            database: crate::config::types::DatabaseConfig::default(),
         })
     }
 
@@ -2769,6 +2771,10 @@ impl Config {
             crate::config::types::AuditConfig { export }
         };
 
+        let database = crate::config::types::DatabaseConfig {
+            url: toml.database.url.clone(),
+        };
+
         let mut links: Vec<LinkDef> = toml
             .links
             .into_iter()
@@ -2862,6 +2868,7 @@ impl Config {
             spacedrive,
             telemetry,
             audit,
+            database,
         })
     }
 }
@@ -3000,5 +3007,34 @@ mod tests {
         let cfg = Config::from_toml(toml_config, instance_dir).unwrap();
         assert!(!cfg.spacedrive.enabled);
         assert_eq!(cfg.spacedrive.base_url, "http://127.0.0.1:8080");
+    }
+
+    #[test]
+    fn parses_database_url_when_block_present() {
+        let toml_input = r#"
+[database]
+url = "postgres://user:pass@host:5432/spacebot"
+"#;
+        let parsed: TomlConfig = toml::from_str(toml_input).unwrap();
+        assert_eq!(
+            parsed.database.url.as_deref(),
+            Some("postgres://user:pass@host:5432/spacebot")
+        );
+    }
+
+    #[test]
+    fn defaults_to_none_when_database_block_absent() {
+        let toml_input = "";
+        let parsed: TomlConfig = toml::from_str(toml_input).unwrap();
+        assert!(parsed.database.url.is_none());
+    }
+
+    #[test]
+    fn defaults_to_none_when_url_field_absent() {
+        let toml_input = r#"
+[database]
+"#;
+        let parsed: TomlConfig = toml::from_str(toml_input).unwrap();
+        assert!(parsed.database.url.is_none());
     }
 }

--- a/src/config/toml_schema.rs
+++ b/src/config/toml_schema.rs
@@ -80,8 +80,10 @@ pub(super) fn default_audit_export_interval_secs() -> u64 {
 /// `[database.*]` table.
 #[derive(Deserialize, Default)]
 pub(super) struct TomlDatabaseConfig {
-    /// `sqlite:` or `postgres:` URL. Unset means per-agent SQLite under data dir.
-    pub(super) url: Option<String>,
+    /// Typed connection URL. The custom `Deserialize` impl on `DatabaseUrl`
+    /// classifies the scheme prefix at config-load time, so operator typos
+    /// surface here rather than at startup connect time.
+    pub(super) url: Option<crate::db::DatabaseUrl>,
 }
 
 #[derive(Deserialize)]

--- a/src/config/toml_schema.rs
+++ b/src/config/toml_schema.rs
@@ -39,6 +39,10 @@ pub(super) struct TomlConfig {
     /// sub-block; more audit knobs (retention, rate-limits) may land later.
     #[serde(default)]
     pub(super) audit: TomlAuditConfig,
+    /// Phase 11 backend selection. When `[database]` is absent or `url` is
+    /// unset, the daemon falls back to per-agent SQLite under the data dir.
+    #[serde(default)]
+    pub(super) database: TomlDatabaseConfig,
 }
 
 /// Phase 5: audit-log config root. Only `[audit.export]` is populated today;
@@ -69,6 +73,15 @@ pub(super) struct TomlAuditExportConfig {
 
 pub(super) fn default_audit_export_interval_secs() -> u64 {
     86400
+}
+
+/// `[database]` block. Single field today; the parent struct exists so
+/// future knobs (max_connections override) can slot in without another
+/// `[database.*]` table.
+#[derive(Deserialize, Default)]
+pub(super) struct TomlDatabaseConfig {
+    /// `sqlite:` or `postgres:` URL. Unset means per-agent SQLite under data dir.
+    pub(super) url: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -95,15 +95,16 @@ pub struct AuditExportScheduledConfig {
     pub interval: std::time::Duration,
 }
 
-/// Phase 11 database backend configuration. The `url` field selects the
-/// backend at runtime: `sqlite:` URLs (or absent) route through the SQLite
-/// path in `db::Db::connect`; `postgres:`/`postgresql:` URLs route through
-/// the Postgres path. See `docs/design-docs/postgres-migration.md`.
+/// Phase 11 database backend configuration. The `url` field is a typed
+/// `DatabaseUrl` whose variant encodes the backend dialect, validated at
+/// config load time. `Sqlite` URLs route through the SQLite path in
+/// `db::Db::connect`; `Postgres` URLs route through the Postgres path.
+/// See `docs/design-docs/postgres-migration.md`.
 #[derive(Debug, Clone, Default)]
 pub struct DatabaseConfig {
-    /// `sqlite:` or `postgres:` connection URL. None falls back to per-agent
-    /// SQLite under the agent data dir (today's behavior).
-    pub url: Option<String>,
+    /// Typed connection URL. None falls back to per-agent SQLite under the
+    /// agent data dir (today's behavior).
+    pub url: Option<crate::db::DatabaseUrl>,
 }
 
 impl Config {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -69,6 +69,9 @@ pub struct Config {
     /// Phase 5 audit-log configuration. `audit.export` is None when
     /// `[audit.export]` is absent from TOML or carries `enabled = false`.
     pub audit: AuditConfig,
+    /// Phase 11 database backend selection. `database.url` is None when
+    /// `[database]` is absent from TOML, falling back to per-agent SQLite.
+    pub database: DatabaseConfig,
 }
 
 /// Phase 5 audit-log configuration root. See `src/audit/export.rs` for
@@ -90,6 +93,17 @@ pub struct AuditConfig {
 pub struct AuditExportScheduledConfig {
     pub config: crate::audit::export::ExportConfig,
     pub interval: std::time::Duration,
+}
+
+/// Phase 11 database backend configuration. The `url` field selects the
+/// backend at runtime: `sqlite:` URLs (or absent) route through the SQLite
+/// path in `db::Db::connect`; `postgres:`/`postgresql:` URLs route through
+/// the Postgres path. See `docs/design-docs/postgres-migration.md`.
+#[derive(Debug, Clone, Default)]
+pub struct DatabaseConfig {
+    /// `sqlite:` or `postgres:` connection URL. None falls back to per-agent
+    /// SQLite under the agent data dir (today's behavior).
+    pub url: Option<String>,
 }
 
 impl Config {

--- a/src/db.rs
+++ b/src/db.rs
@@ -13,9 +13,11 @@ use crate::dialect::{DialectAdapter, PostgresDialect, SqliteDialect};
 use crate::error::{DbError, Result};
 
 use anyhow::Context as _;
+use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, SqlitePool};
 
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::Arc;
 
 /// Backend dialect selected at connection time. Drives migration directory
@@ -25,6 +27,77 @@ use std::sync::Arc;
 pub enum Dialect {
     Sqlite,
     Postgres,
+}
+
+/// Validated database connection URL with backend dialect encoded in the
+/// type. Constructed via `FromStr` (or `serde::Deserialize`), which
+/// classifies the scheme prefix at parse time. Operator typos surface
+/// at config load, not at connect time.
+///
+/// Use `dialect()` to extract the matching `Dialect` tag, `as_str()` to
+/// borrow the inner connection string for sqlx.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(try_from = "String", into = "String")]
+pub enum DatabaseUrl {
+    Sqlite(String),
+    Postgres(String),
+}
+
+impl DatabaseUrl {
+    /// Backend dialect tag.
+    pub fn dialect(&self) -> Dialect {
+        match self {
+            DatabaseUrl::Sqlite(_) => Dialect::Sqlite,
+            DatabaseUrl::Postgres(_) => Dialect::Postgres,
+        }
+    }
+
+    /// Borrow the underlying connection string for sqlx.
+    pub fn as_str(&self) -> &str {
+        match self {
+            DatabaseUrl::Sqlite(s) | DatabaseUrl::Postgres(s) => s.as_str(),
+        }
+    }
+}
+
+impl FromStr for DatabaseUrl {
+    type Err = DbError;
+
+    fn from_str(url: &str) -> std::result::Result<Self, Self::Err> {
+        if url.starts_with("sqlite:") {
+            Ok(DatabaseUrl::Sqlite(url.to_string()))
+        } else if url.starts_with("postgres:") || url.starts_with("postgresql:") {
+            Ok(DatabaseUrl::Postgres(url.to_string()))
+        } else {
+            Err(DbError::UnsupportedScheme(redact_url(url)))
+        }
+    }
+}
+
+impl TryFrom<String> for DatabaseUrl {
+    type Error = DbError;
+
+    fn try_from(url: String) -> std::result::Result<Self, Self::Error> {
+        url.parse()
+    }
+}
+
+impl<'de> Deserialize<'de> for DatabaseUrl {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+impl From<DatabaseUrl> for String {
+    fn from(url: DatabaseUrl) -> String {
+        match url {
+            DatabaseUrl::Sqlite(s) | DatabaseUrl::Postgres(s) => s,
+        }
+    }
 }
 
 /// Backend-typed connection pool. Each variant holds the native sqlx pool
@@ -90,11 +163,11 @@ impl Db {
     ///
     /// `db_url` selects the backend at runtime:
     /// - `None` falls back to per-agent SQLite under `data_dir/agent.db`.
-    /// - `Some("sqlite:...")` connects to the named SQLite file.
-    /// - `Some("postgres://...")` errors in PR 11.1 because
+    /// - `Some(DatabaseUrl::Sqlite(...))` connects to the named SQLite file.
+    /// - `Some(DatabaseUrl::Postgres(...))` errors in PR 11.1 because
     ///   `migrations/postgres/` is not yet shipped. PR 11.3 lands the
     ///   Postgres migration tree and unblocks this path.
-    pub async fn connect(data_dir: &Path, db_url: Option<&str>) -> Result<Self> {
+    pub async fn connect(data_dir: &Path, db_url: Option<&DatabaseUrl>) -> Result<Self> {
         let pool = connect_per_agent_pool(data_dir, db_url).await?;
 
         let lance_path = data_dir.join("lancedb");
@@ -147,7 +220,10 @@ impl Db {
 ///
 /// If an old `tasks.db` exists from before the rename, it is moved to
 /// `spacebot.db` first.
-pub async fn connect_instance_db(data_dir: &Path, db_url: Option<&str>) -> Result<Arc<DbPool>> {
+pub async fn connect_instance_db(
+    data_dir: &Path,
+    db_url: Option<&DatabaseUrl>,
+) -> Result<Arc<DbPool>> {
     std::fs::create_dir_all(data_dir)
         .with_context(|| format!("failed to create data directory: {}", data_dir.display()))?;
 
@@ -174,34 +250,31 @@ impl MigrationsTree {
     }
 }
 
-async fn connect_per_agent_pool(data_dir: &Path, db_url: Option<&str>) -> Result<DbPool> {
-    let (url, dialect) = resolve_per_agent_url(data_dir, db_url)?;
-    open_pool_and_migrate(&url, dialect, MigrationsTree::PerAgent).await
+async fn connect_per_agent_pool(data_dir: &Path, db_url: Option<&DatabaseUrl>) -> Result<DbPool> {
+    let resolved = resolve_per_agent_url(data_dir, db_url)?;
+    open_pool_and_migrate(&resolved, MigrationsTree::PerAgent).await
 }
 
-async fn connect_instance_pool(data_dir: &Path, db_url: Option<&str>) -> Result<DbPool> {
-    let (url, dialect) = resolve_instance_url(data_dir, db_url)?;
-    open_pool_and_migrate(&url, dialect, MigrationsTree::Instance).await
+async fn connect_instance_pool(data_dir: &Path, db_url: Option<&DatabaseUrl>) -> Result<DbPool> {
+    let resolved = resolve_instance_url(data_dir, db_url)?;
+    open_pool_and_migrate(&resolved, MigrationsTree::Instance).await
 }
 
-/// Open a pool for the given dialect and run migrations from the matching
-/// directory tree. Uses `sqlx::migrate::Migrator::new(Path)` for runtime
-/// directory selection so migrations are loaded from disk at startup
-/// rather than embedded in the binary. This trades binary self-containment
-/// for runtime backend switching, which is the right call for daemon
-/// deployments that ship with their `migrations/` directory adjacent.
+/// Open a pool for the given URL variant and run migrations from the
+/// matching directory tree. Uses `sqlx::migrate::Migrator::new(Path)` for
+/// runtime directory selection so migrations are loaded from disk at
+/// startup rather than embedded in the binary. This trades binary
+/// self-containment for runtime backend switching, which is the right
+/// call for daemon deployments that ship with their `migrations/`
+/// directory adjacent.
 ///
 /// PR 11.1 hard-errors on Postgres because the `migrations/postgres/`
 /// tree is not yet shipped. PR 11.2 / 11.3 land it.
-async fn open_pool_and_migrate(
-    url: &str,
-    dialect: Dialect,
-    tree: MigrationsTree,
-) -> Result<DbPool> {
-    match dialect {
-        Dialect::Sqlite => {
-            let pool = SqlitePool::connect(url).await.with_context(|| {
-                format!("failed to connect to SQLite: {}", redact_url(url))
+async fn open_pool_and_migrate(url: &DatabaseUrl, tree: MigrationsTree) -> Result<DbPool> {
+    match url {
+        DatabaseUrl::Sqlite(s) => {
+            let pool = SqlitePool::connect(s).await.with_context(|| {
+                format!("failed to connect to SQLite: {}", redact_url(s))
             })?;
             let migrator = sqlx::migrate::Migrator::new(std::path::Path::new(tree.sqlite_path()))
                 .await
@@ -214,7 +287,7 @@ async fn open_pool_and_migrate(
                 .with_context(|| format!("failed to run {} migrations", tree.sqlite_path()))?;
             Ok(DbPool::Sqlite(pool))
         }
-        Dialect::Postgres => Err(DbError::Other(anyhow::anyhow!(
+        DatabaseUrl::Postgres(_) => Err(DbError::Other(anyhow::anyhow!(
             "Postgres backend selected but migrations/postgres/ does not exist. \
              PR 11.2 ships the instance-tier Postgres migrations; \
              PR 11.3 ships the per-agent Postgres migrations."
@@ -223,14 +296,14 @@ async fn open_pool_and_migrate(
     }
 }
 
-/// Resolve a per-agent database URL into (url, dialect).
+/// Resolve a per-agent database URL into a `DatabaseUrl`.
 ///
 /// `db_url = None` falls back to today's behavior: per-agent SQLite at
 /// `data_dir/agent.db`, including the legacy `spacebot.db` rename. A
 /// user-supplied URL bypasses the legacy rename.
-fn resolve_per_agent_url(data_dir: &Path, db_url: Option<&str>) -> Result<(String, Dialect)> {
+fn resolve_per_agent_url(data_dir: &Path, db_url: Option<&DatabaseUrl>) -> Result<DatabaseUrl> {
     if let Some(url) = db_url {
-        return classify_url(url);
+        return Ok(url.clone());
     }
 
     let agent_db = data_dir.join("agent.db");
@@ -244,14 +317,16 @@ fn resolve_per_agent_url(data_dir: &Path, db_url: Option<&str>) -> Result<(Strin
             )
         })?;
     }
-    let url = format!("sqlite:{}?mode=rwc", agent_db.display());
-    Ok((url, Dialect::Sqlite))
+    Ok(DatabaseUrl::Sqlite(format!(
+        "sqlite:{}?mode=rwc",
+        agent_db.display()
+    )))
 }
 
-/// Resolve an instance-pool database URL into (url, dialect).
-fn resolve_instance_url(data_dir: &Path, db_url: Option<&str>) -> Result<(String, Dialect)> {
+/// Resolve an instance-pool database URL into a `DatabaseUrl`.
+fn resolve_instance_url(data_dir: &Path, db_url: Option<&DatabaseUrl>) -> Result<DatabaseUrl> {
     if let Some(url) = db_url {
-        return classify_url(url);
+        return Ok(url.clone());
     }
 
     let db_path = data_dir.join("spacebot.db");
@@ -264,20 +339,10 @@ fn resolve_instance_url(data_dir: &Path, db_url: Option<&str>) -> Result<(String
             )
         })?;
     }
-    let url = format!("sqlite:{}?mode=rwc", db_path.display());
-    Ok((url, Dialect::Sqlite))
-}
-
-/// Classify an explicit URL string into (url, dialect). Used by both
-/// per-agent and instance-pool resolution when `db_url` is supplied.
-fn classify_url(url: &str) -> Result<(String, Dialect)> {
-    if url.starts_with("sqlite:") {
-        Ok((url.to_string(), Dialect::Sqlite))
-    } else if url.starts_with("postgres:") || url.starts_with("postgresql:") {
-        Ok((url.to_string(), Dialect::Postgres))
-    } else {
-        Err(DbError::UnsupportedScheme(redact_url(url)).into())
-    }
+    Ok(DatabaseUrl::Sqlite(format!(
+        "sqlite:{}?mode=rwc",
+        db_path.display()
+    )))
 }
 
 /// Strip user:pass credentials from a connection URL before embedding it in
@@ -305,35 +370,35 @@ mod tests {
     use super::*;
 
     #[test]
-    fn classify_url_picks_sqlite_for_sqlite_scheme() {
-        let result = classify_url("sqlite:/tmp/x.db");
-        assert!(result.is_ok());
-        let (url, dialect) = result.unwrap();
-        assert_eq!(url, "sqlite:/tmp/x.db");
-        assert_eq!(dialect, Dialect::Sqlite);
+    fn database_url_parses_sqlite_scheme() {
+        let url: DatabaseUrl = "sqlite:/tmp/x.db".parse().unwrap();
+        assert_eq!(url.dialect(), Dialect::Sqlite);
+        assert_eq!(url.as_str(), "sqlite:/tmp/x.db");
     }
 
     #[test]
-    fn classify_url_picks_postgres_for_postgres_scheme() {
-        let (_url, dialect) = classify_url("postgres://user:pass@host:5432/db").unwrap();
-        assert_eq!(dialect, Dialect::Postgres);
+    fn database_url_parses_postgres_scheme() {
+        let url: DatabaseUrl = "postgres://user:pass@host:5432/db".parse().unwrap();
+        assert_eq!(url.dialect(), Dialect::Postgres);
     }
 
     #[test]
-    fn classify_url_picks_postgres_for_postgresql_scheme() {
-        let (_url, dialect) = classify_url("postgresql://user:pass@host:5432/db").unwrap();
-        assert_eq!(dialect, Dialect::Postgres);
+    fn database_url_parses_postgresql_scheme() {
+        let url: DatabaseUrl = "postgresql://user:pass@host:5432/db".parse().unwrap();
+        assert_eq!(url.dialect(), Dialect::Postgres);
     }
 
     #[test]
-    fn classify_url_rejects_unknown_scheme() {
-        let err = classify_url("mysql://x").unwrap_err();
+    fn database_url_rejects_unknown_scheme() {
+        let err: DbError = "mysql://x".parse::<DatabaseUrl>().unwrap_err();
         assert!(err.to_string().contains("mysql://x"));
     }
 
     #[test]
-    fn classify_url_redacts_credentials_in_unsupported_scheme_error() {
-        let err = classify_url("potgres://user:secret@host:5432/db").unwrap_err();
+    fn database_url_redacts_credentials_in_unsupported_scheme_error() {
+        let err: DbError = "potgres://user:secret@host:5432/db"
+            .parse::<DatabaseUrl>()
+            .unwrap_err();
         let msg = err.to_string();
         assert!(
             !msg.contains("secret"),
@@ -345,6 +410,15 @@ mod tests {
         );
         assert!(msg.contains("***:***@host:5432/db"));
         assert!(msg.contains("potgres://"));
+    }
+
+    #[test]
+    fn database_url_deserializes_via_serde() {
+        let url: DatabaseUrl = serde_json::from_str(r#""sqlite:/tmp/x.db""#).unwrap();
+        assert_eq!(url.dialect(), Dialect::Sqlite);
+
+        let err = serde_json::from_str::<DatabaseUrl>(r#""mysql://x""#).unwrap_err();
+        assert!(err.to_string().contains("mysql://x"));
     }
 
     #[test]
@@ -391,7 +465,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn db_connect_with_sqlite_url_runs_migrations() {
         let tmp = tempfile::tempdir().unwrap();
-        let url = format!("sqlite:{}/agent.db?mode=rwc", tmp.path().display());
+        let url: DatabaseUrl = format!("sqlite:{}/agent.db?mode=rwc", tmp.path().display())
+            .parse()
+            .unwrap();
         let db = Db::connect(tmp.path(), Some(&url)).await.unwrap();
         let pool = db.sqlite_pool().unwrap();
         let row: (i64,) = sqlx::query_as("SELECT count(*) FROM _sqlx_migrations")
@@ -404,7 +480,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn db_connect_with_postgres_url_fails_fast_with_pr_pointer() {
         let tmp = tempfile::tempdir().unwrap();
-        let err = match Db::connect(tmp.path(), Some("postgres://nope:5432/x")).await {
+        let url: DatabaseUrl = "postgres://nope:5432/x".parse().unwrap();
+        let err = match Db::connect(tmp.path(), Some(&url)).await {
             Ok(_) => panic!("expected postgres URL to fail at connect"),
             Err(e) => e,
         };

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,9 +1,10 @@
 //! Database connection management and migrations.
 //!
 //! Phase 11 introduces a Postgres backend alongside SQLite via the
-//! `DbPool` enum. Each variant holds a native typed sqlx pool — chrono
-//! types, `query_as!` macros, and `FromRow` derives all work naturally
-//! per variant because there's no `Any` driver in the dispatch path.
+//! `DbPool` enum. Each variant holds a native typed sqlx pool, so
+//! chrono types, `query_as!` macros, and `FromRow` derives all work
+//! naturally per variant because there's no `Any` driver in the
+//! dispatch path.
 //! Backend selection happens at runtime from the `DATABASE_URL` scheme:
 //! `sqlite:` (or unset) routes to SQLite; `postgres:`/`postgresql:`
 //! routes to Postgres. See `docs/design-docs/postgres-migration.md`.

--- a/src/db.rs
+++ b/src/db.rs
@@ -13,7 +13,7 @@ use crate::dialect::{DialectAdapter, PostgresDialect, SqliteDialect};
 use crate::error::{DbError, Result};
 
 use anyhow::Context as _;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use sqlx::{PgPool, SqlitePool};
 
 use std::path::Path;
@@ -24,23 +24,74 @@ use std::sync::Arc;
 /// selection and accompanies the pool for handlers that need to branch on
 /// backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Dialect {
     Sqlite,
     Postgres,
 }
 
+/// SQLite connection string. Constructed only by `DatabaseUrl::from_str`,
+/// which guarantees the wrapped string starts with `sqlite:`.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SqliteUrl(String);
+
+impl SqliteUrl {
+    /// Borrow the underlying connection string for sqlx.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for SqliteUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SqliteUrl")
+            .field(&redact_url(&self.0))
+            .finish()
+    }
+}
+
+/// Postgres connection string. Constructed only by `DatabaseUrl::from_str`,
+/// which guarantees the wrapped string starts with `postgres:` or
+/// `postgresql:`. Debug formatting redacts `user:pass@` credentials so
+/// stray `tracing::debug!(?url, ...)` calls cannot leak operator secrets.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PostgresUrl(String);
+
+impl PostgresUrl {
+    /// Borrow the underlying connection string for sqlx.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for PostgresUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("PostgresUrl")
+            .field(&redact_url(&self.0))
+            .finish()
+    }
+}
+
 /// Validated database connection URL with backend dialect encoded in the
 /// type. Constructed via `FromStr` (or `serde::Deserialize`), which
 /// classifies the scheme prefix at parse time. Operator typos surface
-/// at config load, not at connect time.
+/// during TOML deserialization, not at connect time.
 ///
 /// Use `dialect()` to extract the matching `Dialect` tag, `as_str()` to
-/// borrow the inner connection string for sqlx.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(try_from = "String", into = "String")]
+/// borrow the inner connection string for sqlx. Variant payloads
+/// (`SqliteUrl`, `PostgresUrl`) wrap the raw string in private fields so
+/// downstream code cannot construct a variant whose tag and content
+/// disagree (e.g., `Sqlite` holding a `postgres://` string).
+///
+/// `Debug` formatting redacts `user:pass@` credentials per variant.
+/// `Serialize` is intentionally NOT implemented: the typed URL must not
+/// flow into HTTP responses or JSON dumps where credentials would leak.
+#[derive(Clone, Deserialize, PartialEq, Eq)]
+#[serde(try_from = "String")]
+#[non_exhaustive]
 pub enum DatabaseUrl {
-    Sqlite(String),
-    Postgres(String),
+    Sqlite(SqliteUrl),
+    Postgres(PostgresUrl),
 }
 
 impl DatabaseUrl {
@@ -55,7 +106,17 @@ impl DatabaseUrl {
     /// Borrow the underlying connection string for sqlx.
     pub fn as_str(&self) -> &str {
         match self {
-            DatabaseUrl::Sqlite(s) | DatabaseUrl::Postgres(s) => s.as_str(),
+            DatabaseUrl::Sqlite(u) => u.as_str(),
+            DatabaseUrl::Postgres(u) => u.as_str(),
+        }
+    }
+}
+
+impl std::fmt::Debug for DatabaseUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DatabaseUrl::Sqlite(u) => f.debug_tuple("Sqlite").field(u).finish(),
+            DatabaseUrl::Postgres(u) => f.debug_tuple("Postgres").field(u).finish(),
         }
     }
 }
@@ -65,9 +126,9 @@ impl FromStr for DatabaseUrl {
 
     fn from_str(url: &str) -> std::result::Result<Self, Self::Err> {
         if url.starts_with("sqlite:") {
-            Ok(DatabaseUrl::Sqlite(url.to_string()))
+            Ok(DatabaseUrl::Sqlite(SqliteUrl(url.to_string())))
         } else if url.starts_with("postgres:") || url.starts_with("postgresql:") {
-            Ok(DatabaseUrl::Postgres(url.to_string()))
+            Ok(DatabaseUrl::Postgres(PostgresUrl(url.to_string())))
         } else {
             Err(DbError::UnsupportedScheme(redact_url(url)))
         }
@@ -79,24 +140,6 @@ impl TryFrom<String> for DatabaseUrl {
 
     fn try_from(url: String) -> std::result::Result<Self, Self::Error> {
         url.parse()
-    }
-}
-
-impl<'de> Deserialize<'de> for DatabaseUrl {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
-
-impl From<DatabaseUrl> for String {
-    fn from(url: DatabaseUrl) -> String {
-        match url {
-            DatabaseUrl::Sqlite(s) | DatabaseUrl::Postgres(s) => s,
-        }
     }
 }
 
@@ -234,6 +277,7 @@ pub async fn connect_instance_db(
 /// Which migration tree to run on connect. PR 11.1 only knows the SQLite
 /// trees; PR 11.2 + PR 11.3 add Postgres-side variants.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum MigrationsTree {
     /// Per-agent SQLite migrations at `migrations/`.
     PerAgent,
@@ -273,9 +317,9 @@ async fn connect_instance_pool(data_dir: &Path, db_url: Option<&DatabaseUrl>) ->
 async fn open_pool_and_migrate(url: &DatabaseUrl, tree: MigrationsTree) -> Result<DbPool> {
     match url {
         DatabaseUrl::Sqlite(s) => {
-            let pool = SqlitePool::connect(s)
-                .await
-                .with_context(|| format!("failed to connect to SQLite: {}", redact_url(s)))?;
+            let pool = SqlitePool::connect(s.as_str()).await.with_context(|| {
+                format!("failed to connect to SQLite: {}", redact_url(s.as_str()))
+            })?;
             let migrator = sqlx::migrate::Migrator::new(std::path::Path::new(tree.sqlite_path()))
                 .await
                 .with_context(|| {
@@ -317,10 +361,8 @@ fn resolve_per_agent_url(data_dir: &Path, db_url: Option<&DatabaseUrl>) -> Resul
             )
         })?;
     }
-    Ok(DatabaseUrl::Sqlite(format!(
-        "sqlite:{}?mode=rwc",
-        agent_db.display()
-    )))
+    let url = format!("sqlite:{}?mode=rwc", agent_db.display());
+    DatabaseUrl::from_str(&url).map_err(Into::into)
 }
 
 /// Resolve an instance-pool database URL into a `DatabaseUrl`.
@@ -339,10 +381,8 @@ fn resolve_instance_url(data_dir: &Path, db_url: Option<&DatabaseUrl>) -> Result
             )
         })?;
     }
-    Ok(DatabaseUrl::Sqlite(format!(
-        "sqlite:{}?mode=rwc",
-        db_path.display()
-    )))
+    let url = format!("sqlite:{}?mode=rwc", db_path.display());
+    DatabaseUrl::from_str(&url).map_err(Into::into)
 }
 
 /// Strip user:pass credentials from a connection URL before embedding it in
@@ -527,7 +567,7 @@ mod tests {
     #[test]
     fn resolve_per_agent_url_no_op_when_legacy_absent() {
         let tmp = tempfile::tempdir().unwrap();
-        // No legacy, no target — fresh install case.
+        // No legacy, no target. Fresh install case.
         let resolved = resolve_per_agent_url(tmp.path(), None).unwrap();
         assert!(resolved.as_str().contains("agent.db"));
         // No file should have been created by the resolve step itself

--- a/src/db.rs
+++ b/src/db.rs
@@ -544,7 +544,10 @@ mod tests {
         let resolved = resolve_per_agent_url(tmp.path(), Some(&supplied)).unwrap();
         assert_eq!(resolved.as_str(), "sqlite:/somewhere/else.db");
         // Operator-supplied URL bypasses the rename logic entirely.
-        assert!(legacy.exists(), "legacy must not be touched when url supplied");
+        assert!(
+            legacy.exists(),
+            "legacy must not be touched when url supplied"
+        );
     }
 
     #[test]
@@ -588,7 +591,10 @@ mod tests {
         let supplied: DatabaseUrl = "sqlite:/elsewhere.db".parse().unwrap();
         let resolved = resolve_instance_url(tmp.path(), Some(&supplied)).unwrap();
         assert_eq!(resolved.as_str(), "sqlite:/elsewhere.db");
-        assert!(legacy.exists(), "legacy must not be touched when url supplied");
+        assert!(
+            legacy.exists(),
+            "legacy must not be touched when url supplied"
+        );
     }
 
     // R5: connect_instance_db has distinct behavior from Db::connect
@@ -622,7 +628,10 @@ mod tests {
         let pool_handle = inner.clone();
         let pool = DbPool::Sqlite(inner);
         pool.close().await;
-        assert!(pool_handle.is_closed(), "pool must report closed after close()");
+        assert!(
+            pool_handle.is_closed(),
+            "pool must report closed after close()"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/db.rs
+++ b/src/db.rs
@@ -309,4 +309,54 @@ mod tests {
         let err = classify_url("mysql://x").unwrap_err();
         assert!(err.to_string().contains("mysql://x"));
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dbpool_sqlite_variant_dialect_and_adapter() {
+        let inner = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let pool = DbPool::Sqlite(inner);
+        assert_eq!(pool.dialect(), Dialect::Sqlite);
+        assert_eq!(pool.adapter().now_expr(), "datetime('now')");
+        assert!(pool.as_sqlite().is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dbpool_postgres_variant_as_sqlite_returns_err() {
+        let inner = sqlx::PgPool::connect_lazy("postgres://nope:5432/x")
+            .expect("connect_lazy parses URL without connecting");
+        let pool = DbPool::Postgres(inner);
+        assert_eq!(pool.dialect(), Dialect::Postgres);
+        assert_eq!(pool.adapter().now_expr(), "now()");
+        let err = pool.as_sqlite().unwrap_err();
+        assert!(
+            err.to_string().contains("requires SQLite backend"),
+            "expected SQLite-backend error, got: {err}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn db_connect_with_sqlite_url_runs_migrations() {
+        let tmp = tempfile::tempdir().unwrap();
+        let url = format!("sqlite:{}/agent.db?mode=rwc", tmp.path().display());
+        let db = Db::connect(tmp.path(), Some(&url)).await.unwrap();
+        let pool = db.sqlite_pool().unwrap();
+        let row: (i64,) = sqlx::query_as("SELECT count(*) FROM _sqlx_migrations")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        assert!(row.0 > 0, "expected at least one migration applied");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn db_connect_with_postgres_url_fails_fast_with_pr_pointer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = match Db::connect(tmp.path(), Some("postgres://nope:5432/x")).await {
+            Ok(_) => panic!("expected postgres URL to fail at connect"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("PR 11.2") || msg.contains("PR 11.3"),
+            "expected fail-fast message to point at later PR, got: {msg}"
+        );
+    }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -273,9 +273,9 @@ async fn connect_instance_pool(data_dir: &Path, db_url: Option<&DatabaseUrl>) ->
 async fn open_pool_and_migrate(url: &DatabaseUrl, tree: MigrationsTree) -> Result<DbPool> {
     match url {
         DatabaseUrl::Sqlite(s) => {
-            let pool = SqlitePool::connect(s).await.with_context(|| {
-                format!("failed to connect to SQLite: {}", redact_url(s))
-            })?;
+            let pool = SqlitePool::connect(s)
+                .await
+                .with_context(|| format!("failed to connect to SQLite: {}", redact_url(s)))?;
             let migrator = sqlx::migrate::Migrator::new(std::path::Path::new(tree.sqlite_path()))
                 .await
                 .with_context(|| {
@@ -490,5 +490,150 @@ mod tests {
             msg.contains("PR 11.2") || msg.contains("PR 11.3"),
             "expected fail-fast message to point at later PR, got: {msg}"
         );
+    }
+
+    // R5: Legacy DB rename coverage. resolve_per_agent_url and
+    // resolve_instance_url run std::fs::rename against user data on every
+    // upgrade. If the precondition logic ever inverts, users lose data on
+    // upgrade. These tests pin the four branches of each rename helper.
+
+    #[test]
+    fn resolve_per_agent_url_renames_legacy_when_target_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("spacebot.db");
+        std::fs::write(&legacy, b"legacy-marker").unwrap();
+        let resolved = resolve_per_agent_url(tmp.path(), None).unwrap();
+        assert_eq!(resolved.dialect(), Dialect::Sqlite);
+        assert!(resolved.as_str().contains("agent.db"));
+        assert!(!legacy.exists(), "legacy file must be moved");
+        let target = tmp.path().join("agent.db");
+        assert!(target.exists(), "renamed target must exist");
+        assert_eq!(std::fs::read(&target).unwrap(), b"legacy-marker");
+    }
+
+    #[test]
+    fn resolve_per_agent_url_skips_rename_when_both_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("spacebot.db");
+        let target = tmp.path().join("agent.db");
+        std::fs::write(&legacy, b"legacy").unwrap();
+        std::fs::write(&target, b"current").unwrap();
+        let _ = resolve_per_agent_url(tmp.path(), None).unwrap();
+        // Both must remain untouched: rename runs only when target is absent.
+        assert_eq!(std::fs::read(&legacy).unwrap(), b"legacy");
+        assert_eq!(std::fs::read(&target).unwrap(), b"current");
+    }
+
+    #[test]
+    fn resolve_per_agent_url_no_op_when_legacy_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No legacy, no target — fresh install case.
+        let resolved = resolve_per_agent_url(tmp.path(), None).unwrap();
+        assert!(resolved.as_str().contains("agent.db"));
+        // No file should have been created by the resolve step itself
+        // (Db::connect creates it during SqlitePool::connect, not here).
+        assert!(!tmp.path().join("spacebot.db").exists());
+    }
+
+    #[test]
+    fn resolve_per_agent_url_skips_rename_when_url_supplied() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("spacebot.db");
+        std::fs::write(&legacy, b"legacy-must-not-move").unwrap();
+        let supplied: DatabaseUrl = "sqlite:/somewhere/else.db".parse().unwrap();
+        let resolved = resolve_per_agent_url(tmp.path(), Some(&supplied)).unwrap();
+        assert_eq!(resolved.as_str(), "sqlite:/somewhere/else.db");
+        // Operator-supplied URL bypasses the rename logic entirely.
+        assert!(legacy.exists(), "legacy must not be touched when url supplied");
+    }
+
+    #[test]
+    fn resolve_instance_url_renames_legacy_tasks_db_when_target_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("tasks.db");
+        std::fs::write(&legacy, b"legacy-tasks").unwrap();
+        let resolved = resolve_instance_url(tmp.path(), None).unwrap();
+        assert!(resolved.as_str().contains("spacebot.db"));
+        assert!(!legacy.exists(), "legacy tasks.db must be moved");
+        let target = tmp.path().join("spacebot.db");
+        assert!(target.exists());
+        assert_eq!(std::fs::read(&target).unwrap(), b"legacy-tasks");
+    }
+
+    #[test]
+    fn resolve_instance_url_skips_rename_when_both_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("tasks.db");
+        let target = tmp.path().join("spacebot.db");
+        std::fs::write(&legacy, b"legacy").unwrap();
+        std::fs::write(&target, b"current").unwrap();
+        let _ = resolve_instance_url(tmp.path(), None).unwrap();
+        assert_eq!(std::fs::read(&legacy).unwrap(), b"legacy");
+        assert_eq!(std::fs::read(&target).unwrap(), b"current");
+    }
+
+    #[test]
+    fn resolve_instance_url_no_op_when_legacy_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let resolved = resolve_instance_url(tmp.path(), None).unwrap();
+        assert!(resolved.as_str().contains("spacebot.db"));
+        assert!(!tmp.path().join("tasks.db").exists());
+    }
+
+    #[test]
+    fn resolve_instance_url_skips_rename_when_url_supplied() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("tasks.db");
+        std::fs::write(&legacy, b"legacy-must-not-move").unwrap();
+        let supplied: DatabaseUrl = "sqlite:/elsewhere.db".parse().unwrap();
+        let resolved = resolve_instance_url(tmp.path(), Some(&supplied)).unwrap();
+        assert_eq!(resolved.as_str(), "sqlite:/elsewhere.db");
+        assert!(legacy.exists(), "legacy must not be touched when url supplied");
+    }
+
+    // R5: connect_instance_db has distinct behavior from Db::connect
+    // (uses MigrationsTree::Instance → migrations/global/, returns bare
+    // Arc<DbPool>). Cover the SQLite happy path.
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn connect_instance_db_with_sqlite_url_runs_global_migrations() {
+        let tmp = tempfile::tempdir().unwrap();
+        let url: DatabaseUrl = format!("sqlite:{}/spacebot.db?mode=rwc", tmp.path().display())
+            .parse()
+            .unwrap();
+        let pool = connect_instance_db(tmp.path(), Some(&url)).await.unwrap();
+        let sqlite = pool.as_sqlite().unwrap();
+        let row: (i64,) = sqlx::query_as("SELECT count(*) FROM _sqlx_migrations")
+            .fetch_one(sqlite)
+            .await
+            .unwrap();
+        assert!(
+            row.0 > 0,
+            "expected at least one migrations/global migration applied"
+        );
+    }
+
+    // R5: Close paths. Db::close consumes self and awaits pool.close.
+    // Verify the pool reports closed afterward.
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dbpool_sqlite_close_marks_pool_closed() {
+        let inner = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let pool_handle = inner.clone();
+        let pool = DbPool::Sqlite(inner);
+        pool.close().await;
+        assert!(pool_handle.is_closed(), "pool must report closed after close()");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn db_close_marks_underlying_pool_closed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let url: DatabaseUrl = format!("sqlite:{}/agent.db?mode=rwc", tmp.path().display())
+            .parse()
+            .unwrap();
+        let db = Db::connect(tmp.path(), Some(&url)).await.unwrap();
+        let pool_handle = db.sqlite_pool().unwrap().clone();
+        db.close().await;
+        assert!(pool_handle.is_closed(), "underlying pool must close");
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,17 +1,81 @@
 //! Database connection management and migrations.
+//!
+//! Phase 11 introduces a Postgres backend alongside SQLite via the
+//! `DbPool` enum. Each variant holds a native typed sqlx pool — chrono
+//! types, `query_as!` macros, and `FromRow` derives all work naturally
+//! per variant because there's no `Any` driver in the dispatch path.
+//! Backend selection happens at runtime from the `DATABASE_URL` scheme:
+//! `sqlite:` (or unset) routes to SQLite; `postgres:`/`postgresql:`
+//! routes to Postgres. See `docs/design-docs/postgres-migration.md`.
 
+use crate::dialect::{DialectAdapter, PostgresDialect, SqliteDialect};
 use crate::error::{DbError, Result};
 
 use anyhow::Context as _;
-use sqlx::SqlitePool;
+use sqlx::{PgPool, SqlitePool};
 
 use std::path::Path;
 use std::sync::Arc;
 
+/// Backend dialect selected at connection time. Drives migration directory
+/// selection and accompanies the pool for handlers that need to branch on
+/// backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dialect {
+    Sqlite,
+    Postgres,
+}
+
+/// Backend-typed connection pool. Each variant holds the native sqlx pool
+/// so chrono types, query_as! macros, and FromRow derives work per variant.
+pub enum DbPool {
+    Sqlite(SqlitePool),
+    Postgres(PgPool),
+}
+
+impl DbPool {
+    /// Backend dialect tag.
+    pub fn dialect(&self) -> Dialect {
+        match self {
+            DbPool::Sqlite(_) => Dialect::Sqlite,
+            DbPool::Postgres(_) => Dialect::Postgres,
+        }
+    }
+
+    /// Construct the matching `DialectAdapter` for this pool variant.
+    pub fn adapter(&self) -> Box<dyn DialectAdapter> {
+        match self {
+            DbPool::Sqlite(_) => Box::new(SqliteDialect),
+            DbPool::Postgres(_) => Box::new(PostgresDialect),
+        }
+    }
+
+    /// Close the pool gracefully.
+    pub async fn close(&self) {
+        match self {
+            DbPool::Sqlite(p) => p.close().await,
+            DbPool::Postgres(p) => p.close().await,
+        }
+    }
+
+    /// Borrow the SQLite pool. Returns Err if backend is Postgres.
+    /// Stores not yet migrated to dual-backend dispatch use this accessor
+    /// to keep their `&SqlitePool` parameter type during PR 11.1.
+    pub fn as_sqlite(&self) -> Result<&SqlitePool> {
+        match self {
+            DbPool::Sqlite(p) => Ok(p),
+            DbPool::Postgres(_) => Err(DbError::Query(
+                "store requires SQLite backend; Postgres dispatch lands in PR 11.2/11.3".into(),
+            )
+            .into()),
+        }
+    }
+}
+
 /// Database connections bundle for per-agent databases.
 pub struct Db {
-    /// SQLite pool for relational data.
-    pub sqlite: SqlitePool,
+    /// Backend-typed SQL pool. Wrapped in `Arc` so stores can clone.
+    pub pool: Arc<DbPool>,
 
     /// LanceDB connection for vector storage.
     pub lance: lancedb::Connection,
@@ -22,32 +86,16 @@ pub struct Db {
 
 impl Db {
     /// Connect to all databases and run migrations.
-    pub async fn connect(data_dir: &Path) -> Result<Self> {
-        // SQLite — per-agent agent.db. If an old spacebot.db exists from
-        // before the rename, move it to agent.db.
-        let agent_db = data_dir.join("agent.db");
-        let legacy_db = data_dir.join("spacebot.db");
-        if legacy_db.exists() && !agent_db.exists() {
-            std::fs::rename(&legacy_db, &agent_db).with_context(|| {
-                format!(
-                    "failed to rename legacy per-agent DB {} -> {}",
-                    legacy_db.display(),
-                    agent_db.display()
-                )
-            })?;
-        }
-        let sqlite_url = format!("sqlite:{}?mode=rwc", agent_db.display());
-        let sqlite = SqlitePool::connect(&sqlite_url)
-            .await
-            .with_context(|| "failed to connect to SQLite")?;
+    ///
+    /// `db_url` selects the backend at runtime:
+    /// - `None` falls back to per-agent SQLite under `data_dir/agent.db`.
+    /// - `Some("sqlite:...")` connects to the named SQLite file.
+    /// - `Some("postgres://...")` errors in PR 11.1 because
+    ///   `migrations/postgres/` is not yet shipped. PR 11.3 lands the
+    ///   Postgres migration tree and unblocks this path.
+    pub async fn connect(data_dir: &Path, db_url: Option<&str>) -> Result<Self> {
+        let pool = connect_per_agent_pool(data_dir, db_url).await?;
 
-        // Run migrations
-        sqlx::migrate!("./migrations")
-            .run(&sqlite)
-            .await
-            .with_context(|| "failed to run database migrations")?;
-
-        // LanceDB
         let lance_path = data_dir.join("lancedb");
         std::fs::create_dir_all(&lance_path).with_context(|| {
             format!(
@@ -55,42 +103,155 @@ impl Db {
                 lance_path.display()
             )
         })?;
-
         let lance = lancedb::connect(lance_path.to_str().unwrap_or("./lancedb"))
             .execute()
             .await
             .map_err(|e| DbError::LanceConnect(e.to_string()))?;
 
-        // Redb
         let redb_path = data_dir.join("config.redb");
         let redb = redb::Database::create(&redb_path)
             .with_context(|| format!("failed to create redb at: {}", redb_path.display()))?;
 
         Ok(Self {
-            sqlite,
+            pool: Arc::new(pool),
             lance,
             redb: Arc::new(redb),
         })
     }
 
+    /// Borrow the underlying SQLite pool. Returns Err if backend is Postgres.
+    /// PR 11.1 stores remain on `&SqlitePool` parameter type and use this
+    /// accessor; PR 11.2/11.3 migrate stores to take `Arc<DbPool>` directly.
+    pub fn sqlite_pool(&self) -> Result<&SqlitePool> {
+        self.pool.as_sqlite()
+    }
+
     /// Close all database connections gracefully.
     pub async fn close(self) {
-        self.sqlite.close().await;
+        self.pool.close().await;
         // LanceDB and redb close automatically when dropped
     }
 }
 
 /// Connect to the instance-level spacebot database and run its migrations.
 ///
-/// The instance database lives at `{instance_dir}/data/spacebot.db` and holds
-/// data shared across all agents: tasks, projects, repos, worktrees. This
-/// replaces per-agent task and project tables.
+/// Returns `Arc<DbPool>` rather than the raw sqlx pool so callers can hold
+/// the variant tag alongside the pool. The instance database lives at
+/// `{instance_dir}/data/spacebot.db` for SQLite mode and is the cluster
+/// Postgres database for Postgres mode.
+///
+/// `db_url` semantics match `Db::connect`. `None` falls back to instance
+/// SQLite under `data_dir/spacebot.db`. Postgres URLs error in PR 11.1
+/// pending the Postgres migration tree.
 ///
 /// If an old `tasks.db` exists from before the rename, it is moved to
 /// `spacebot.db` first.
-pub async fn connect_instance_db(data_dir: &Path) -> Result<SqlitePool> {
+pub async fn connect_instance_db(data_dir: &Path, db_url: Option<&str>) -> Result<Arc<DbPool>> {
     std::fs::create_dir_all(data_dir)
         .with_context(|| format!("failed to create data directory: {}", data_dir.display()))?;
+
+    let pool = connect_instance_pool(data_dir, db_url).await?;
+    Ok(Arc::new(pool))
+}
+
+/// Which migration tree to run on connect. PR 11.1 only knows the SQLite
+/// trees; PR 11.2 + PR 11.3 add Postgres-side variants.
+#[derive(Debug, Clone, Copy)]
+pub enum MigrationsTree {
+    /// Per-agent SQLite migrations at `migrations/`.
+    PerAgent,
+    /// Instance-wide SQLite migrations at `migrations/global/`.
+    Instance,
+}
+
+impl MigrationsTree {
+    fn sqlite_path(self) -> &'static str {
+        match self {
+            MigrationsTree::PerAgent => "migrations",
+            MigrationsTree::Instance => "migrations/global",
+        }
+    }
+}
+
+async fn connect_per_agent_pool(data_dir: &Path, db_url: Option<&str>) -> Result<DbPool> {
+    let (url, dialect) = resolve_per_agent_url(data_dir, db_url)?;
+    open_pool_and_migrate(&url, dialect, MigrationsTree::PerAgent).await
+}
+
+async fn connect_instance_pool(data_dir: &Path, db_url: Option<&str>) -> Result<DbPool> {
+    let (url, dialect) = resolve_instance_url(data_dir, db_url)?;
+    open_pool_and_migrate(&url, dialect, MigrationsTree::Instance).await
+}
+
+/// Open a pool for the given dialect and run migrations from the matching
+/// directory tree. Uses `sqlx::migrate::Migrator::new(Path)` for runtime
+/// directory selection so migrations are loaded from disk at startup
+/// rather than embedded in the binary. This trades binary self-containment
+/// for runtime backend switching, which is the right call for daemon
+/// deployments that ship with their `migrations/` directory adjacent.
+///
+/// PR 11.1 hard-errors on Postgres because the `migrations/postgres/`
+/// tree is not yet shipped. PR 11.2 / 11.3 land it.
+async fn open_pool_and_migrate(
+    url: &str,
+    dialect: Dialect,
+    tree: MigrationsTree,
+) -> Result<DbPool> {
+    match dialect {
+        Dialect::Sqlite => {
+            let pool = SqlitePool::connect(url)
+                .await
+                .with_context(|| format!("failed to connect to SQLite: {url}"))?;
+            let migrator = sqlx::migrate::Migrator::new(std::path::Path::new(tree.sqlite_path()))
+                .await
+                .with_context(|| {
+                    format!("failed to load migrations from {}", tree.sqlite_path())
+                })?;
+            migrator
+                .run(&pool)
+                .await
+                .with_context(|| format!("failed to run {} migrations", tree.sqlite_path()))?;
+            Ok(DbPool::Sqlite(pool))
+        }
+        Dialect::Postgres => Err(DbError::Other(anyhow::anyhow!(
+            "Postgres backend selected but migrations/postgres/ does not exist. \
+             PR 11.2 ships the instance-tier Postgres migrations; \
+             PR 11.3 ships the per-agent Postgres migrations."
+        ))
+        .into()),
+    }
+}
+
+/// Resolve a per-agent database URL into (url, dialect).
+///
+/// `db_url = None` falls back to today's behavior: per-agent SQLite at
+/// `data_dir/agent.db`, including the legacy `spacebot.db` rename. A
+/// user-supplied URL bypasses the legacy rename.
+fn resolve_per_agent_url(data_dir: &Path, db_url: Option<&str>) -> Result<(String, Dialect)> {
+    if let Some(url) = db_url {
+        return classify_url(url);
+    }
+
+    let agent_db = data_dir.join("agent.db");
+    let legacy_db = data_dir.join("spacebot.db");
+    if legacy_db.exists() && !agent_db.exists() {
+        std::fs::rename(&legacy_db, &agent_db).with_context(|| {
+            format!(
+                "failed to rename legacy per-agent DB {} -> {}",
+                legacy_db.display(),
+                agent_db.display()
+            )
+        })?;
+    }
+    let url = format!("sqlite:{}?mode=rwc", agent_db.display());
+    Ok((url, Dialect::Sqlite))
+}
+
+/// Resolve an instance-pool database URL into (url, dialect).
+fn resolve_instance_url(data_dir: &Path, db_url: Option<&str>) -> Result<(String, Dialect)> {
+    if let Some(url) = db_url {
+        return classify_url(url);
+    }
 
     let db_path = data_dir.join("spacebot.db");
     let legacy_tasks_db = data_dir.join("tasks.db");
@@ -103,18 +264,49 @@ pub async fn connect_instance_db(data_dir: &Path) -> Result<SqlitePool> {
         })?;
     }
     let url = format!("sqlite:{}?mode=rwc", db_path.display());
+    Ok((url, Dialect::Sqlite))
+}
 
-    let pool = SqlitePool::connect(&url).await.with_context(|| {
-        format!(
-            "failed to connect to instance database: {}",
-            db_path.display()
-        )
-    })?;
+/// Classify an explicit URL string into (url, dialect). Used by both
+/// per-agent and instance-pool resolution when `db_url` is supplied.
+fn classify_url(url: &str) -> Result<(String, Dialect)> {
+    if url.starts_with("sqlite:") {
+        Ok((url.to_string(), Dialect::Sqlite))
+    } else if url.starts_with("postgres:") || url.starts_with("postgresql:") {
+        Ok((url.to_string(), Dialect::Postgres))
+    } else {
+        Err(DbError::UnsupportedScheme(url.to_string()).into())
+    }
+}
 
-    sqlx::migrate!("./migrations/global")
-        .run(&pool)
-        .await
-        .with_context(|| "failed to run instance database migrations")?;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    Ok(pool)
+    #[test]
+    fn classify_url_picks_sqlite_for_sqlite_scheme() {
+        let result = classify_url("sqlite:/tmp/x.db");
+        assert!(result.is_ok());
+        let (url, dialect) = result.unwrap();
+        assert_eq!(url, "sqlite:/tmp/x.db");
+        assert_eq!(dialect, Dialect::Sqlite);
+    }
+
+    #[test]
+    fn classify_url_picks_postgres_for_postgres_scheme() {
+        let (_url, dialect) = classify_url("postgres://user:pass@host:5432/db").unwrap();
+        assert_eq!(dialect, Dialect::Postgres);
+    }
+
+    #[test]
+    fn classify_url_picks_postgres_for_postgresql_scheme() {
+        let (_url, dialect) = classify_url("postgresql://user:pass@host:5432/db").unwrap();
+        assert_eq!(dialect, Dialect::Postgres);
+    }
+
+    #[test]
+    fn classify_url_rejects_unknown_scheme() {
+        let err = classify_url("mysql://x").unwrap_err();
+        assert!(err.to_string().contains("mysql://x"));
+    }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -200,9 +200,9 @@ async fn open_pool_and_migrate(
 ) -> Result<DbPool> {
     match dialect {
         Dialect::Sqlite => {
-            let pool = SqlitePool::connect(url)
-                .await
-                .with_context(|| format!("failed to connect to SQLite: {url}"))?;
+            let pool = SqlitePool::connect(url).await.with_context(|| {
+                format!("failed to connect to SQLite: {}", redact_url(url))
+            })?;
             let migrator = sqlx::migrate::Migrator::new(std::path::Path::new(tree.sqlite_path()))
                 .await
                 .with_context(|| {
@@ -276,8 +276,28 @@ fn classify_url(url: &str) -> Result<(String, Dialect)> {
     } else if url.starts_with("postgres:") || url.starts_with("postgresql:") {
         Ok((url.to_string(), Dialect::Postgres))
     } else {
-        Err(DbError::UnsupportedScheme(url.to_string()).into())
+        Err(DbError::UnsupportedScheme(redact_url(url)).into())
     }
+}
+
+/// Strip user:pass credentials from a connection URL before embedding it in
+/// log lines, error messages, or panic strings. Replaces `user:pass@` with
+/// `***:***@`. Targets the realistic threat: a typo'd `postgres://` URL
+/// surfacing through `DbError::UnsupportedScheme` or a connect failure
+/// echoing the URL into operator logs.
+///
+/// Limitations: does not redact query-string credentials (`?password=...`)
+/// or URL-encoded user:pass forms. Sufficient for PR 11.1's two callers.
+fn redact_url(url: &str) -> String {
+    let Some(scheme_end) = url.find("://") else {
+        return url.to_string();
+    };
+    let after_scheme = scheme_end + 3;
+    let Some(at_offset) = url[after_scheme..].find('@') else {
+        return url.to_string();
+    };
+    let at = after_scheme + at_offset;
+    format!("{}***:***{}", &url[..after_scheme], &url[at..])
 }
 
 #[cfg(test)]
@@ -309,6 +329,40 @@ mod tests {
     fn classify_url_rejects_unknown_scheme() {
         let err = classify_url("mysql://x").unwrap_err();
         assert!(err.to_string().contains("mysql://x"));
+    }
+
+    #[test]
+    fn classify_url_redacts_credentials_in_unsupported_scheme_error() {
+        let err = classify_url("potgres://user:secret@host:5432/db").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("secret"),
+            "credentials leaked into UnsupportedScheme error: {msg}"
+        );
+        assert!(
+            !msg.contains("user"),
+            "user component leaked into UnsupportedScheme error: {msg}"
+        );
+        assert!(msg.contains("***:***@host:5432/db"));
+        assert!(msg.contains("potgres://"));
+    }
+
+    #[test]
+    fn redact_url_passes_credentialless_urls_through() {
+        assert_eq!(redact_url("sqlite:/tmp/x.db"), "sqlite:/tmp/x.db");
+        assert_eq!(redact_url("sqlite::memory:"), "sqlite::memory:");
+        assert_eq!(
+            redact_url("postgres://host:5432/db"),
+            "postgres://host:5432/db"
+        );
+    }
+
+    #[test]
+    fn redact_url_redacts_user_and_password() {
+        assert_eq!(
+            redact_url("postgres://alice:hunter2@host:5432/db"),
+            "postgres://***:***@host:5432/db"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -1,0 +1,63 @@
+//! SQL dialect adaptation for SQLite and Postgres backends.
+//!
+//! The dialect adapter holds the small set of SQL string differences between
+//! SQLite and Postgres that don't warrant a full match arm in store-level
+//! dispatch. These are concentrated at table-DDL sites: `AUTOINCREMENT` vs
+//! `BIGSERIAL`, `datetime('now')` vs `now()`, `TEXT` vs `JSONB`.
+//!
+//! Backend selection happens in `db::Db::connect` based on the connection-
+//! string scheme. The `DialectAdapter` accompanies each `DbPool` variant so
+//! migration code and DDL helpers can branch without re-resolving the URL.
+//!
+//! Per-query SQL differences (placeholder syntax `?` vs `$1`, JSON operators,
+//! `RETURNING` clauses) live inside per-variant match arms in the stores
+//! themselves, NOT in this trait. The trait is a small companion abstraction,
+//! not the load-bearing dispatch layer.
+
+/// SQL dialect adapter for cross-backend DDL string differences.
+pub trait DialectAdapter: Send + Sync + std::fmt::Debug {
+    /// Expression for "current timestamp" in DEFAULT clauses and SQL bodies.
+    fn now_expr(&self) -> &'static str;
+
+    /// Column declaration for an auto-incrementing integer primary key.
+    fn autoincrement_pk(&self) -> &'static str;
+
+    /// Column type for JSON storage (TEXT on SQLite, JSONB on Postgres).
+    fn json_type(&self) -> &'static str;
+}
+
+/// SQLite dialect adapter.
+#[derive(Debug)]
+pub struct SqliteDialect;
+
+impl DialectAdapter for SqliteDialect {
+    fn now_expr(&self) -> &'static str {
+        "datetime('now')"
+    }
+
+    fn autoincrement_pk(&self) -> &'static str {
+        "INTEGER PRIMARY KEY AUTOINCREMENT"
+    }
+
+    fn json_type(&self) -> &'static str {
+        "TEXT"
+    }
+}
+
+/// Postgres dialect adapter.
+#[derive(Debug)]
+pub struct PostgresDialect;
+
+impl DialectAdapter for PostgresDialect {
+    fn now_expr(&self) -> &'static str {
+        "now()"
+    }
+
+    fn autoincrement_pk(&self) -> &'static str {
+        "BIGSERIAL PRIMARY KEY"
+    }
+
+    fn json_type(&self) -> &'static str {
+        "JSONB"
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -123,6 +123,9 @@ pub enum DbError {
     #[error("query failed: {0}")]
     Query(String),
 
+    #[error("unsupported database URL scheme: {0} (expected sqlite: or postgres:)")]
+    UnsupportedScheme(String),
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod conversation;
 pub mod cron;
 pub mod daemon;
 pub mod db;
+pub mod dialect;
 pub mod error;
 pub mod factory;
 pub mod github_copilot_auth;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2189,13 +2189,8 @@ async fn run(
     // the resumed worker into its state so follow-ups route correctly.
     if agents_initialized {
         for (agent_id, agent) in agents.iter() {
-            let run_logger = spacebot::conversation::ProcessRunLogger::new(
-                agent
-                    .db
-                    .sqlite_pool()
-                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                    .clone(),
-            );
+            let run_logger =
+                spacebot::conversation::ProcessRunLogger::new(agent.db.sqlite_pool()?.clone());
             let idle_workers = match run_logger
                 .get_idle_interactive_workers(&agent.config.id)
                 .await
@@ -3131,11 +3126,7 @@ async fn initialize_agents(
                 )
             })?;
 
-        let run_logger = spacebot::conversation::ProcessRunLogger::new(
-            db.sqlite_pool()
-                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                .clone(),
-        );
+        let run_logger = spacebot::conversation::ProcessRunLogger::new(db.sqlite_pool()?.clone());
         let orphaned_workers = run_logger
             .reconcile_running_workers_for_agent(
                 &agent_config.id,
@@ -3186,9 +3177,7 @@ async fn initialize_agents(
 
         // Per-agent memory system
         let memory_store = spacebot::memory::MemoryStore::with_agent_id(
-            db.sqlite_pool()
-                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                .clone(),
+            db.sqlite_pool()?.clone(),
             &agent_config.id,
         );
         let project_store = global_project_store.clone();
@@ -3219,9 +3208,7 @@ async fn initialize_agents(
                 .unwrap_or(chrono_tz::Tz::UTC)
         };
         let working_memory = spacebot::memory::WorkingMemoryStore::new(
-            db.sqlite_pool()
-                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                .clone(),
+            db.sqlite_pool()?.clone(),
             working_memory_timezone,
         );
 
@@ -3313,10 +3300,7 @@ async fn initialize_agents(
             runtime_config,
             event_tx,
             memory_event_tx,
-            sqlite_pool: db
-                .sqlite_pool()
-                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                .clone(),
+            sqlite_pool: db.sqlite_pool()?.clone(),
             messaging_manager: None,
             sandbox,
             links: agent_links.clone(),
@@ -3355,23 +3339,13 @@ async fn initialize_agents(
             let to_channel = link.channel_id_for(&link.to_agent_id);
 
             if let Some(agent) = agents.get(&Arc::from(link.from_agent_id.as_str())) {
-                let store = spacebot::conversation::ChannelStore::new(
-                    agent
-                        .db
-                        .sqlite_pool()
-                        .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                        .clone(),
-                );
+                let store =
+                    spacebot::conversation::ChannelStore::new(agent.db.sqlite_pool()?.clone());
                 store.upsert(&from_channel, &empty_meta);
             }
             if let Some(agent) = agents.get(&Arc::from(link.to_agent_id.as_str())) {
-                let store = spacebot::conversation::ChannelStore::new(
-                    agent
-                        .db
-                        .sqlite_pool()
-                        .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                        .clone(),
-                );
+                let store =
+                    spacebot::conversation::ChannelStore::new(agent.db.sqlite_pool()?.clone());
                 store.upsert(&to_channel, &empty_meta);
             }
         }
@@ -3409,14 +3383,7 @@ async fn initialize_agents(
         for (agent_id, agent) in agents.iter() {
             let event_rx = agent.deps.event_tx.subscribe();
             api_state.register_agent_events(agent_id.to_string(), event_rx);
-            agent_pools.insert(
-                agent_id.to_string(),
-                agent
-                    .db
-                    .sqlite_pool()
-                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                    .clone(),
-            );
+            agent_pools.insert(agent_id.to_string(), agent.db.sqlite_pool()?.clone());
             memory_searches.insert(agent_id.to_string(), agent.deps.memory_search.clone());
             mcp_managers.insert(agent_id.to_string(), agent.deps.mcp_manager.clone());
             agent_workspaces.insert(agent_id.to_string(), agent.config.workspace.clone());
@@ -3463,11 +3430,7 @@ async fn initialize_agents(
 
         for (agent_id, agent) in agents.iter() {
             let deps = agent.deps.clone();
-            let sqlite_pool = agent
-                .db
-                .sqlite_pool()
-                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                .clone();
+            let sqlite_pool = agent.db.sqlite_pool()?.clone();
             let agent_id = agent_id.clone();
             startup_warmup.spawn(async move {
                 let logger = spacebot::agent::cortex::CortexLogger::new(sqlite_pool);
@@ -3985,11 +3948,7 @@ async fn initialize_agents(
 
     for (agent_id, agent) in agents.iter_mut() {
         let store = Arc::new(spacebot::cron::CronStore::new(
-            agent
-                .db
-                .sqlite_pool()
-                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                .clone(),
+            agent.db.sqlite_pool()?.clone(),
         ));
         agent.deps.messaging_manager = Some(messaging_manager.clone());
 
@@ -4091,14 +4050,9 @@ async fn initialize_agents(
 
     // Start cortex warmup, runtime, and association loops for each agent
     for (agent_id, agent) in agents.iter() {
-        let cortex_logger = spacebot::agent::cortex::CortexLogger::new(
-            agent
-                .db
-                .sqlite_pool()
-                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                .clone(),
-        )
-        .with_notifications(global_notification_store.clone(), agent_id.to_string());
+        let cortex_logger =
+            spacebot::agent::cortex::CortexLogger::new(agent.db.sqlite_pool()?.clone())
+                .with_notifications(global_notification_store.clone(), agent_id.to_string());
         let warmup_handle =
             spacebot::agent::cortex::spawn_warmup_loop(agent.deps.clone(), cortex_logger.clone());
         cortex_handles.push(warmup_handle);
@@ -4116,14 +4070,8 @@ async fn initialize_agents(
 
         let ready_task_handle = spacebot::agent::cortex::spawn_ready_task_loop(
             agent.deps.clone(),
-            spacebot::agent::cortex::CortexLogger::new(
-                agent
-                    .db
-                    .sqlite_pool()
-                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                    .clone(),
-            )
-            .with_notifications(global_notification_store.clone(), agent_id.to_string()),
+            spacebot::agent::cortex::CortexLogger::new(agent.db.sqlite_pool()?.clone())
+                .with_notifications(global_notification_store.clone(), agent_id.to_string()),
         );
         cortex_handles.push(ready_task_handle);
         tracing::info!(agent_id = %agent_id, "cortex ready-task loop started");
@@ -4136,26 +4084,12 @@ async fn initialize_agents(
             let browser_config = (**agent.deps.runtime_config.browser_config.load()).clone();
             let brave_search_key = (**agent.deps.runtime_config.brave_search_key.load()).clone();
             let conversation_logger = spacebot::conversation::history::ConversationLogger::new(
-                agent
-                    .db
-                    .sqlite_pool()
-                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                    .clone(),
+                agent.db.sqlite_pool()?.clone(),
             );
-            let channel_store = spacebot::conversation::ChannelStore::new(
-                agent
-                    .db
-                    .sqlite_pool()
-                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                    .clone(),
-            );
-            let run_logger = spacebot::conversation::ProcessRunLogger::new(
-                agent
-                    .db
-                    .sqlite_pool()
-                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                    .clone(),
-            );
+            let channel_store =
+                spacebot::conversation::ChannelStore::new(agent.db.sqlite_pool()?.clone());
+            let run_logger =
+                spacebot::conversation::ProcessRunLogger::new(agent.db.sqlite_pool()?.clone());
             let cortex_ctx = spacebot::agent::cortex_chat::CortexChatSession::create_context();
             #[allow(deprecated)] // Cortex chat is legacy — being replaced by Channel Settings
             let tool_server = spacebot::tools::create_cortex_chat_tool_server(
@@ -4191,13 +4125,8 @@ async fn initialize_agents(
                 }
             };
 
-            let store = spacebot::agent::cortex_chat::CortexChatStore::new(
-                agent
-                    .db
-                    .sqlite_pool()
-                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                    .clone(),
-            );
+            let store =
+                spacebot::agent::cortex_chat::CortexChatStore::new(agent.db.sqlite_pool()?.clone());
             let session = spacebot::agent::cortex_chat::CortexChatSession::new(
                 agent.deps.clone(),
                 tool_server,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2068,6 +2068,7 @@ async fn run(
     let config_path = config.instance_dir.join("config.toml");
     api_state.set_config_path(config_path.clone()).await;
     api_state.set_instance_dir(config.instance_dir.clone());
+    api_state.set_database_url(config.database.url.clone());
     api_state.set_llm_manager(llm_manager.clone()).await;
     api_state.set_embedding_model(embedding_model.clone()).await;
     api_state.set_prompt_engine(prompt_engine.clone()).await;
@@ -3402,6 +3403,7 @@ async fn initialize_agents(
             api_state.set_secrets_store(store.clone());
         }
         api_state.set_instance_dir(config.instance_dir.clone());
+        api_state.set_database_url(config.database.url.clone());
     }
 
     // Run a startup warmup pass for every agent before adapters begin receiving

--- a/src/main.rs
+++ b/src/main.rs
@@ -2179,7 +2179,7 @@ async fn run(
     // the resumed worker into its state so follow-ups route correctly.
     if agents_initialized {
         for (agent_id, agent) in agents.iter() {
-            let run_logger = spacebot::conversation::ProcessRunLogger::new(agent.db.sqlite.clone());
+            let run_logger = spacebot::conversation::ProcessRunLogger::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
             let idle_workers = match run_logger
                 .get_idle_interactive_workers(&agent.config.id)
                 .await
@@ -3115,7 +3115,7 @@ async fn initialize_agents(
                 )
             })?;
 
-        let run_logger = spacebot::conversation::ProcessRunLogger::new(db.sqlite.clone());
+        let run_logger = spacebot::conversation::ProcessRunLogger::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
         let orphaned_workers = run_logger
             .reconcile_running_workers_for_agent(
                 &agent_config.id,
@@ -3166,7 +3166,7 @@ async fn initialize_agents(
 
         // Per-agent memory system
         let memory_store =
-            spacebot::memory::MemoryStore::with_agent_id(db.sqlite.clone(), &agent_config.id);
+            spacebot::memory::MemoryStore::with_agent_id(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone(), &agent_config.id);
         let project_store = global_project_store.clone();
         let embedding_table = spacebot::memory::EmbeddingTable::open_or_create(&db.lance)
             .await
@@ -3195,7 +3195,7 @@ async fn initialize_agents(
                 .unwrap_or(chrono_tz::Tz::UTC)
         };
         let working_memory =
-            spacebot::memory::WorkingMemoryStore::new(db.sqlite.clone(), working_memory_timezone);
+            spacebot::memory::WorkingMemoryStore::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone(), working_memory_timezone);
 
         // Per-agent control and memory event buses (broadcast fan-out).
         let (event_tx, memory_event_tx) = spacebot::create_process_event_buses();
@@ -3285,7 +3285,7 @@ async fn initialize_agents(
             runtime_config,
             event_tx,
             memory_event_tx,
-            sqlite_pool: db.sqlite.clone(),
+            sqlite_pool: db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone(),
             messaging_manager: None,
             sandbox,
             links: agent_links.clone(),
@@ -3324,11 +3324,11 @@ async fn initialize_agents(
             let to_channel = link.channel_id_for(&link.to_agent_id);
 
             if let Some(agent) = agents.get(&Arc::from(link.from_agent_id.as_str())) {
-                let store = spacebot::conversation::ChannelStore::new(agent.db.sqlite.clone());
+                let store = spacebot::conversation::ChannelStore::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
                 store.upsert(&from_channel, &empty_meta);
             }
             if let Some(agent) = agents.get(&Arc::from(link.to_agent_id.as_str())) {
-                let store = spacebot::conversation::ChannelStore::new(agent.db.sqlite.clone());
+                let store = spacebot::conversation::ChannelStore::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
                 store.upsert(&to_channel, &empty_meta);
             }
         }
@@ -3366,7 +3366,7 @@ async fn initialize_agents(
         for (agent_id, agent) in agents.iter() {
             let event_rx = agent.deps.event_tx.subscribe();
             api_state.register_agent_events(agent_id.to_string(), event_rx);
-            agent_pools.insert(agent_id.to_string(), agent.db.sqlite.clone());
+            agent_pools.insert(agent_id.to_string(), agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
             memory_searches.insert(agent_id.to_string(), agent.deps.memory_search.clone());
             mcp_managers.insert(agent_id.to_string(), agent.deps.mcp_manager.clone());
             agent_workspaces.insert(agent_id.to_string(), agent.config.workspace.clone());
@@ -3412,7 +3412,7 @@ async fn initialize_agents(
 
         for (agent_id, agent) in agents.iter() {
             let deps = agent.deps.clone();
-            let sqlite_pool = agent.db.sqlite.clone();
+            let sqlite_pool = agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone();
             let agent_id = agent_id.clone();
             startup_warmup.spawn(async move {
                 let logger = spacebot::agent::cortex::CortexLogger::new(sqlite_pool);
@@ -3890,7 +3890,7 @@ async fn initialize_agents(
 
     let portal_agent_pools = agents
         .iter()
-        .map(|(agent_id, agent)| (agent_id.to_string(), agent.db.sqlite.clone()))
+        .map(|(agent_id, agent)| (agent_id.to_string(), agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone()))
         .collect();
     let portal_adapter = Arc::new(spacebot::messaging::portal::PortalAdapter::new(
         portal_agent_pools,
@@ -3920,7 +3920,7 @@ async fn initialize_agents(
     let mut cron_schedulers_map = std::collections::HashMap::new();
 
     for (agent_id, agent) in agents.iter_mut() {
-        let store = Arc::new(spacebot::cron::CronStore::new(agent.db.sqlite.clone()));
+        let store = Arc::new(spacebot::cron::CronStore::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone()));
         agent.deps.messaging_manager = Some(messaging_manager.clone());
 
         // Seed cron jobs from config into the database
@@ -4021,7 +4021,7 @@ async fn initialize_agents(
 
     // Start cortex warmup, runtime, and association loops for each agent
     for (agent_id, agent) in agents.iter() {
-        let cortex_logger = spacebot::agent::cortex::CortexLogger::new(agent.db.sqlite.clone())
+        let cortex_logger = spacebot::agent::cortex::CortexLogger::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone())
             .with_notifications(global_notification_store.clone(), agent_id.to_string());
         let warmup_handle =
             spacebot::agent::cortex::spawn_warmup_loop(agent.deps.clone(), cortex_logger.clone());
@@ -4040,7 +4040,7 @@ async fn initialize_agents(
 
         let ready_task_handle = spacebot::agent::cortex::spawn_ready_task_loop(
             agent.deps.clone(),
-            spacebot::agent::cortex::CortexLogger::new(agent.db.sqlite.clone())
+            spacebot::agent::cortex::CortexLogger::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone())
                 .with_notifications(global_notification_store.clone(), agent_id.to_string()),
         );
         cortex_handles.push(ready_task_handle);
@@ -4054,9 +4054,9 @@ async fn initialize_agents(
             let browser_config = (**agent.deps.runtime_config.browser_config.load()).clone();
             let brave_search_key = (**agent.deps.runtime_config.brave_search_key.load()).clone();
             let conversation_logger =
-                spacebot::conversation::history::ConversationLogger::new(agent.db.sqlite.clone());
-            let channel_store = spacebot::conversation::ChannelStore::new(agent.db.sqlite.clone());
-            let run_logger = spacebot::conversation::ProcessRunLogger::new(agent.db.sqlite.clone());
+                spacebot::conversation::history::ConversationLogger::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+            let channel_store = spacebot::conversation::ChannelStore::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+            let run_logger = spacebot::conversation::ProcessRunLogger::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
             let cortex_ctx = spacebot::agent::cortex_chat::CortexChatSession::create_context();
             #[allow(deprecated)] // Cortex chat is legacy — being replaced by Channel Settings
             let tool_server = spacebot::tools::create_cortex_chat_tool_server(
@@ -4092,7 +4092,7 @@ async fn initialize_agents(
                 }
             };
 
-            let store = spacebot::agent::cortex_chat::CortexChatStore::new(agent.db.sqlite.clone());
+            let store = spacebot::agent::cortex_chat::CortexChatStore::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
             let session = spacebot::agent::cortex_chat::CortexChatSession::new(
                 agent.deps.clone(),
                 tool_server,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1727,7 +1727,9 @@ async fn run(
     .context("failed to initialize instance database")?;
     let instance_pool = instance_db
         .as_sqlite()
-        .context("PR 11.1 instance pool requires SQLite backend; Postgres support lands in PR 11.2")?
+        .context(
+            "PR 11.1 instance pool requires SQLite backend; Postgres support lands in PR 11.2",
+        )?
         .clone();
 
     // Migrate legacy per-agent tasks to the global database on first run.
@@ -2187,7 +2189,13 @@ async fn run(
     // the resumed worker into its state so follow-ups route correctly.
     if agents_initialized {
         for (agent_id, agent) in agents.iter() {
-            let run_logger = spacebot::conversation::ProcessRunLogger::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+            let run_logger = spacebot::conversation::ProcessRunLogger::new(
+                agent
+                    .db
+                    .sqlite_pool()
+                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                    .clone(),
+            );
             let idle_workers = match run_logger
                 .get_idle_interactive_workers(&agent.config.id)
                 .await
@@ -3114,19 +3122,20 @@ async fn initialize_agents(
         })?;
 
         // Per-agent database connections
-        let db = spacebot::db::Db::connect(
-            &agent_config.data_dir,
-            config.database.url.as_deref(),
-        )
-        .await
-        .with_context(|| {
-            format!(
-                "failed to connect databases for agent '{}'",
-                agent_config.id
+        let db = spacebot::db::Db::connect(&agent_config.data_dir, config.database.url.as_deref())
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to connect databases for agent '{}'",
+                    agent_config.id
                 )
             })?;
 
-        let run_logger = spacebot::conversation::ProcessRunLogger::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+        let run_logger = spacebot::conversation::ProcessRunLogger::new(
+            db.sqlite_pool()
+                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                .clone(),
+        );
         let orphaned_workers = run_logger
             .reconcile_running_workers_for_agent(
                 &agent_config.id,
@@ -3176,8 +3185,12 @@ async fn initialize_agents(
             };
 
         // Per-agent memory system
-        let memory_store =
-            spacebot::memory::MemoryStore::with_agent_id(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone(), &agent_config.id);
+        let memory_store = spacebot::memory::MemoryStore::with_agent_id(
+            db.sqlite_pool()
+                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                .clone(),
+            &agent_config.id,
+        );
         let project_store = global_project_store.clone();
         let embedding_table = spacebot::memory::EmbeddingTable::open_or_create(&db.lance)
             .await
@@ -3205,8 +3218,12 @@ async fn initialize_agents(
                 .and_then(|tz_name| tz_name.parse::<chrono_tz::Tz>().ok())
                 .unwrap_or(chrono_tz::Tz::UTC)
         };
-        let working_memory =
-            spacebot::memory::WorkingMemoryStore::new(db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone(), working_memory_timezone);
+        let working_memory = spacebot::memory::WorkingMemoryStore::new(
+            db.sqlite_pool()
+                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                .clone(),
+            working_memory_timezone,
+        );
 
         // Per-agent control and memory event buses (broadcast fan-out).
         let (event_tx, memory_event_tx) = spacebot::create_process_event_buses();
@@ -3296,7 +3313,10 @@ async fn initialize_agents(
             runtime_config,
             event_tx,
             memory_event_tx,
-            sqlite_pool: db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone(),
+            sqlite_pool: db
+                .sqlite_pool()
+                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                .clone(),
             messaging_manager: None,
             sandbox,
             links: agent_links.clone(),
@@ -3335,11 +3355,23 @@ async fn initialize_agents(
             let to_channel = link.channel_id_for(&link.to_agent_id);
 
             if let Some(agent) = agents.get(&Arc::from(link.from_agent_id.as_str())) {
-                let store = spacebot::conversation::ChannelStore::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+                let store = spacebot::conversation::ChannelStore::new(
+                    agent
+                        .db
+                        .sqlite_pool()
+                        .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                        .clone(),
+                );
                 store.upsert(&from_channel, &empty_meta);
             }
             if let Some(agent) = agents.get(&Arc::from(link.to_agent_id.as_str())) {
-                let store = spacebot::conversation::ChannelStore::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+                let store = spacebot::conversation::ChannelStore::new(
+                    agent
+                        .db
+                        .sqlite_pool()
+                        .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                        .clone(),
+                );
                 store.upsert(&to_channel, &empty_meta);
             }
         }
@@ -3377,7 +3409,14 @@ async fn initialize_agents(
         for (agent_id, agent) in agents.iter() {
             let event_rx = agent.deps.event_tx.subscribe();
             api_state.register_agent_events(agent_id.to_string(), event_rx);
-            agent_pools.insert(agent_id.to_string(), agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+            agent_pools.insert(
+                agent_id.to_string(),
+                agent
+                    .db
+                    .sqlite_pool()
+                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                    .clone(),
+            );
             memory_searches.insert(agent_id.to_string(), agent.deps.memory_search.clone());
             mcp_managers.insert(agent_id.to_string(), agent.deps.mcp_manager.clone());
             agent_workspaces.insert(agent_id.to_string(), agent.config.workspace.clone());
@@ -3424,7 +3463,11 @@ async fn initialize_agents(
 
         for (agent_id, agent) in agents.iter() {
             let deps = agent.deps.clone();
-            let sqlite_pool = agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone();
+            let sqlite_pool = agent
+                .db
+                .sqlite_pool()
+                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                .clone();
             let agent_id = agent_id.clone();
             startup_warmup.spawn(async move {
                 let logger = spacebot::agent::cortex::CortexLogger::new(sqlite_pool);
@@ -3902,7 +3945,16 @@ async fn initialize_agents(
 
     let portal_agent_pools = agents
         .iter()
-        .map(|(agent_id, agent)| (agent_id.to_string(), agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone()))
+        .map(|(agent_id, agent)| {
+            (
+                agent_id.to_string(),
+                agent
+                    .db
+                    .sqlite_pool()
+                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                    .clone(),
+            )
+        })
         .collect();
     let portal_adapter = Arc::new(spacebot::messaging::portal::PortalAdapter::new(
         portal_agent_pools,
@@ -3932,7 +3984,13 @@ async fn initialize_agents(
     let mut cron_schedulers_map = std::collections::HashMap::new();
 
     for (agent_id, agent) in agents.iter_mut() {
-        let store = Arc::new(spacebot::cron::CronStore::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone()));
+        let store = Arc::new(spacebot::cron::CronStore::new(
+            agent
+                .db
+                .sqlite_pool()
+                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                .clone(),
+        ));
         agent.deps.messaging_manager = Some(messaging_manager.clone());
 
         // Seed cron jobs from config into the database
@@ -4033,8 +4091,14 @@ async fn initialize_agents(
 
     // Start cortex warmup, runtime, and association loops for each agent
     for (agent_id, agent) in agents.iter() {
-        let cortex_logger = spacebot::agent::cortex::CortexLogger::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone())
-            .with_notifications(global_notification_store.clone(), agent_id.to_string());
+        let cortex_logger = spacebot::agent::cortex::CortexLogger::new(
+            agent
+                .db
+                .sqlite_pool()
+                .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                .clone(),
+        )
+        .with_notifications(global_notification_store.clone(), agent_id.to_string());
         let warmup_handle =
             spacebot::agent::cortex::spawn_warmup_loop(agent.deps.clone(), cortex_logger.clone());
         cortex_handles.push(warmup_handle);
@@ -4052,8 +4116,14 @@ async fn initialize_agents(
 
         let ready_task_handle = spacebot::agent::cortex::spawn_ready_task_loop(
             agent.deps.clone(),
-            spacebot::agent::cortex::CortexLogger::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone())
-                .with_notifications(global_notification_store.clone(), agent_id.to_string()),
+            spacebot::agent::cortex::CortexLogger::new(
+                agent
+                    .db
+                    .sqlite_pool()
+                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                    .clone(),
+            )
+            .with_notifications(global_notification_store.clone(), agent_id.to_string()),
         );
         cortex_handles.push(ready_task_handle);
         tracing::info!(agent_id = %agent_id, "cortex ready-task loop started");
@@ -4065,10 +4135,27 @@ async fn initialize_agents(
         for (agent_id, agent) in agents.iter() {
             let browser_config = (**agent.deps.runtime_config.browser_config.load()).clone();
             let brave_search_key = (**agent.deps.runtime_config.brave_search_key.load()).clone();
-            let conversation_logger =
-                spacebot::conversation::history::ConversationLogger::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
-            let channel_store = spacebot::conversation::ChannelStore::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
-            let run_logger = spacebot::conversation::ProcessRunLogger::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+            let conversation_logger = spacebot::conversation::history::ConversationLogger::new(
+                agent
+                    .db
+                    .sqlite_pool()
+                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                    .clone(),
+            );
+            let channel_store = spacebot::conversation::ChannelStore::new(
+                agent
+                    .db
+                    .sqlite_pool()
+                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                    .clone(),
+            );
+            let run_logger = spacebot::conversation::ProcessRunLogger::new(
+                agent
+                    .db
+                    .sqlite_pool()
+                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                    .clone(),
+            );
             let cortex_ctx = spacebot::agent::cortex_chat::CortexChatSession::create_context();
             #[allow(deprecated)] // Cortex chat is legacy — being replaced by Channel Settings
             let tool_server = spacebot::tools::create_cortex_chat_tool_server(
@@ -4104,7 +4191,13 @@ async fn initialize_agents(
                 }
             };
 
-            let store = spacebot::agent::cortex_chat::CortexChatStore::new(agent.db.sqlite_pool().expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect").clone());
+            let store = spacebot::agent::cortex_chat::CortexChatStore::new(
+                agent
+                    .db
+                    .sqlite_pool()
+                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
+                    .clone(),
+            );
             let session = spacebot::agent::cortex_chat::CortexChatSession::new(
                 agent.deps.clone(),
                 tool_server,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3906,19 +3906,16 @@ async fn initialize_agents(
         }
     }
 
-    let portal_agent_pools = agents
+    let portal_agent_pools: HashMap<String, sqlx::SqlitePool> = agents
         .iter()
         .map(|(agent_id, agent)| {
-            (
-                agent_id.to_string(),
-                agent
-                    .db
-                    .sqlite_pool()
-                    .expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")
-                    .clone(),
-            )
+            agent
+                .db
+                .sqlite_pool()
+                .map(|pool| (agent_id.to_string(), pool.clone()))
         })
-        .collect();
+        .collect::<spacebot::error::Result<_>>()
+        .context("portal adapter requires SQLite agent pools (PR 11.1 invariant)")?;
     let portal_adapter = Arc::new(spacebot::messaging::portal::PortalAdapter::new(
         portal_agent_pools,
     ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1721,7 +1721,7 @@ async fn run(
     // unique task numbers. Lives alongside secrets.redb in the instance data dir.
     let instance_db = spacebot::db::connect_instance_db(
         &config.instance_dir.join("data"),
-        config.database.url.as_deref(),
+        config.database.url.as_ref(),
     )
     .await
     .context("failed to initialize instance database")?;
@@ -3122,7 +3122,7 @@ async fn initialize_agents(
         })?;
 
         // Per-agent database connections
-        let db = spacebot::db::Db::connect(&agent_config.data_dir, config.database.url.as_deref())
+        let db = spacebot::db::Db::connect(&agent_config.data_dir, config.database.url.as_ref())
             .await
             .with_context(|| {
                 format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1719,9 +1719,16 @@ async fn run(
 
     // Instance-level global task database. Shared across all agents with globally
     // unique task numbers. Lives alongside secrets.redb in the instance data dir.
-    let instance_pool = spacebot::db::connect_instance_db(&config.instance_dir.join("data"))
-        .await
-        .context("failed to initialize instance database")?;
+    let instance_db = spacebot::db::connect_instance_db(
+        &config.instance_dir.join("data"),
+        config.database.url.as_deref(),
+    )
+    .await
+    .context("failed to initialize instance database")?;
+    let instance_pool = instance_db
+        .as_sqlite()
+        .context("PR 11.1 instance pool requires SQLite backend; Postgres support lands in PR 11.2")?
+        .clone();
 
     // Migrate legacy per-agent tasks to the global database on first run.
     spacebot::tasks::migration::migrate_legacy_tasks(&config.instance_dir, &instance_pool)
@@ -3107,12 +3114,15 @@ async fn initialize_agents(
         })?;
 
         // Per-agent database connections
-        let db = spacebot::db::Db::connect(&agent_config.data_dir)
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to connect databases for agent '{}'",
-                    agent_config.id
+        let db = spacebot::db::Db::connect(
+            &agent_config.data_dir,
+            config.database.url.as_deref(),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "failed to connect databases for agent '{}'",
+                agent_config.id
                 )
             })?;
 

--- a/tests/bulletin.rs
+++ b/tests/bulletin.rs
@@ -56,7 +56,7 @@ async fn bootstrap_deps() -> anyhow::Result<spacebot::AgentDeps> {
         .await
         .context("failed to connect databases")?;
 
-    let memory_store = spacebot::memory::MemoryStore::new(db.sqlite.clone());
+    let memory_store = spacebot::memory::MemoryStore::new(db.sqlite_pool().unwrap().clone());
 
     let embedding_table = spacebot::memory::EmbeddingTable::open_or_create(&db.lance)
         .await
@@ -71,7 +71,7 @@ async fn bootstrap_deps() -> anyhow::Result<spacebot::AgentDeps> {
         embedding_table,
         embedding_model,
     ));
-    let task_store = Arc::new(spacebot::tasks::TaskStore::new(db.sqlite.clone()));
+    let task_store = Arc::new(spacebot::tasks::TaskStore::new(db.sqlite_pool().unwrap().clone()));
 
     let identity = spacebot::identity::Identity::load(&agent_config.workspace).await;
     let prompts =
@@ -113,12 +113,12 @@ async fn bootstrap_deps() -> anyhow::Result<spacebot::AgentDeps> {
         llm_manager,
         mcp_manager,
         task_store,
-        project_store: Arc::new(spacebot::projects::ProjectStore::new(db.sqlite.clone())),
+        project_store: Arc::new(spacebot::projects::ProjectStore::new(db.sqlite_pool().unwrap().clone())),
         cron_tool: None,
         runtime_config,
         event_tx,
         memory_event_tx,
-        sqlite_pool: db.sqlite.clone(),
+        sqlite_pool: db.sqlite_pool().unwrap().clone(),
         messaging_manager: None,
         sandbox,
         links: Arc::new(arc_swap::ArcSwap::from_pointee(Vec::new())),
@@ -129,7 +129,7 @@ async fn bootstrap_deps() -> anyhow::Result<spacebot::AgentDeps> {
         ),
         injection_tx: tokio::sync::mpsc::channel(1).0,
         working_memory: spacebot::memory::WorkingMemoryStore::new(
-            db.sqlite.clone(),
+            db.sqlite_pool().unwrap().clone(),
             chrono_tz::Tz::UTC,
         ),
         api_state: None,

--- a/tests/bulletin.rs
+++ b/tests/bulletin.rs
@@ -52,7 +52,7 @@ async fn bootstrap_deps() -> anyhow::Result<spacebot::AgentDeps> {
     let resolved_agents = config.resolve_agents();
     let agent_config = resolved_agents.first().context("no agents configured")?;
 
-    let db = spacebot::db::Db::connect(&agent_config.data_dir)
+    let db = spacebot::db::Db::connect(&agent_config.data_dir, None)
         .await
         .context("failed to connect databases")?;
 

--- a/tests/bulletin.rs
+++ b/tests/bulletin.rs
@@ -71,7 +71,9 @@ async fn bootstrap_deps() -> anyhow::Result<spacebot::AgentDeps> {
         embedding_table,
         embedding_model,
     ));
-    let task_store = Arc::new(spacebot::tasks::TaskStore::new(db.sqlite_pool().unwrap().clone()));
+    let task_store = Arc::new(spacebot::tasks::TaskStore::new(
+        db.sqlite_pool().unwrap().clone(),
+    ));
 
     let identity = spacebot::identity::Identity::load(&agent_config.workspace).await;
     let prompts =
@@ -113,7 +115,9 @@ async fn bootstrap_deps() -> anyhow::Result<spacebot::AgentDeps> {
         llm_manager,
         mcp_manager,
         task_store,
-        project_store: Arc::new(spacebot::projects::ProjectStore::new(db.sqlite_pool().unwrap().clone())),
+        project_store: Arc::new(spacebot::projects::ProjectStore::new(
+            db.sqlite_pool().unwrap().clone(),
+        )),
         cron_tool: None,
         runtime_config,
         event_tx,

--- a/tests/context_dump.rs
+++ b/tests/context_dump.rs
@@ -55,7 +55,7 @@ async fn bootstrap_deps() -> anyhow::Result<(spacebot::AgentDeps, spacebot::conf
         .await
         .context("failed to connect databases")?;
 
-    let memory_store = spacebot::memory::MemoryStore::new(db.sqlite.clone());
+    let memory_store = spacebot::memory::MemoryStore::new(db.sqlite_pool().unwrap().clone());
 
     let embedding_table = spacebot::memory::EmbeddingTable::open_or_create(&db.lance)
         .await
@@ -70,7 +70,7 @@ async fn bootstrap_deps() -> anyhow::Result<(spacebot::AgentDeps, spacebot::conf
         embedding_table,
         embedding_model,
     ));
-    let task_store = Arc::new(spacebot::tasks::TaskStore::new(db.sqlite.clone()));
+    let task_store = Arc::new(spacebot::tasks::TaskStore::new(db.sqlite_pool().unwrap().clone()));
 
     let identity = spacebot::identity::Identity::load(&agent_config.workspace).await;
     let prompts =
@@ -112,12 +112,12 @@ async fn bootstrap_deps() -> anyhow::Result<(spacebot::AgentDeps, spacebot::conf
         llm_manager,
         mcp_manager,
         task_store,
-        project_store: Arc::new(spacebot::projects::ProjectStore::new(db.sqlite.clone())),
+        project_store: Arc::new(spacebot::projects::ProjectStore::new(db.sqlite_pool().unwrap().clone())),
         cron_tool: None,
         runtime_config,
         event_tx,
         memory_event_tx,
-        sqlite_pool: db.sqlite.clone(),
+        sqlite_pool: db.sqlite_pool().unwrap().clone(),
         messaging_manager: None,
         sandbox,
         links: Arc::new(arc_swap::ArcSwap::from_pointee(Vec::new())),
@@ -128,7 +128,7 @@ async fn bootstrap_deps() -> anyhow::Result<(spacebot::AgentDeps, spacebot::conf
         ),
         injection_tx: tokio::sync::mpsc::channel(1).0,
         working_memory: spacebot::memory::WorkingMemoryStore::new(
-            db.sqlite.clone(),
+            db.sqlite_pool().unwrap().clone(),
             chrono_tz::Tz::UTC,
         ),
         api_state: None,

--- a/tests/context_dump.rs
+++ b/tests/context_dump.rs
@@ -70,7 +70,9 @@ async fn bootstrap_deps() -> anyhow::Result<(spacebot::AgentDeps, spacebot::conf
         embedding_table,
         embedding_model,
     ));
-    let task_store = Arc::new(spacebot::tasks::TaskStore::new(db.sqlite_pool().unwrap().clone()));
+    let task_store = Arc::new(spacebot::tasks::TaskStore::new(
+        db.sqlite_pool().unwrap().clone(),
+    ));
 
     let identity = spacebot::identity::Identity::load(&agent_config.workspace).await;
     let prompts =
@@ -112,7 +114,9 @@ async fn bootstrap_deps() -> anyhow::Result<(spacebot::AgentDeps, spacebot::conf
         llm_manager,
         mcp_manager,
         task_store,
-        project_store: Arc::new(spacebot::projects::ProjectStore::new(db.sqlite_pool().unwrap().clone())),
+        project_store: Arc::new(spacebot::projects::ProjectStore::new(
+            db.sqlite_pool().unwrap().clone(),
+        )),
         cron_tool: None,
         runtime_config,
         event_tx,

--- a/tests/context_dump.rs
+++ b/tests/context_dump.rs
@@ -51,7 +51,7 @@ async fn bootstrap_deps() -> anyhow::Result<(spacebot::AgentDeps, spacebot::conf
     let resolved_agents = config.resolve_agents();
     let agent_config = resolved_agents.first().context("no agents configured")?;
 
-    let db = spacebot::db::Db::connect(&agent_config.data_dir)
+    let db = spacebot::db::Db::connect(&agent_config.data_dir, None)
         .await
         .context("failed to connect databases")?;
 

--- a/tests/dialect_adapter.rs
+++ b/tests/dialect_adapter.rs
@@ -1,0 +1,39 @@
+//! Phase 11: DialectAdapter trait unit tests.
+
+use spacebot::dialect::{DialectAdapter, PostgresDialect, SqliteDialect};
+
+#[test]
+fn sqlite_now_expr_returns_datetime_now() {
+    let d = SqliteDialect;
+    assert_eq!(d.now_expr(), "datetime('now')");
+}
+
+#[test]
+fn postgres_now_expr_returns_now_paren_paren() {
+    let d = PostgresDialect;
+    assert_eq!(d.now_expr(), "now()");
+}
+
+#[test]
+fn sqlite_autoincrement_pk_string() {
+    let d = SqliteDialect;
+    assert_eq!(d.autoincrement_pk(), "INTEGER PRIMARY KEY AUTOINCREMENT");
+}
+
+#[test]
+fn postgres_autoincrement_pk_uses_bigserial() {
+    let d = PostgresDialect;
+    assert_eq!(d.autoincrement_pk(), "BIGSERIAL PRIMARY KEY");
+}
+
+#[test]
+fn sqlite_json_type_is_text() {
+    let d = SqliteDialect;
+    assert_eq!(d.json_type(), "TEXT");
+}
+
+#[test]
+fn postgres_json_type_is_jsonb() {
+    let d = PostgresDialect;
+    assert_eq!(d.json_type(), "JSONB");
+}


### PR DESCRIPTION
## Summary

Foundation PR for the Postgres backend (Phase 11). Introduces `enum DbPool { Sqlite(SqlitePool), Postgres(PgPool) }` over native typed sqlx pools, the `DialectAdapter` companion trait for DDL-string differences, the `[database]` TOML config block, and `database_url` plumbing through `ApiState`. Stores remain on `&SqlitePool` via the new `Db::sqlite_pool()` accessor. PR 11.2 ships per-store dispatch + Postgres migrations.

This replaces an earlier abandoned design that used `sqlx::AnyPool` (archived at `docs/design-docs/archive/postgres-migration-anypool-attempt-2026-04-25.md`). The chrono-on-Any gap (sqlx Issue #1167) blocked that path; enum-dispatch over native typed pools (atuin pattern) is the production-grade replacement.

## Architecture

```rust
pub enum DbPool {
    Sqlite(SqlitePool),
    Postgres(PgPool),
}
```

Each variant uses native sqlx-sqlite or sqlx-postgres so chrono types, query_as! macros, and FromRow derives all work per variant. Backend selected at startup from `config.database.url` scheme: `sqlite:` (or unset) routes to SQLite, `postgres:`/`postgresql:` routes to Postgres. Postgres URLs hard-error in PR 11.1 because `migrations/postgres/` is not yet shipped (PR 11.2/11.3 ship it).

Migration runner switched from `sqlx::migrate!` (compile-time literal) to `sqlx::migrate::Migrator::new(Path)` (runtime-loaded) via the `MigrationsTree` enum. Trade-off: migrations load from disk at startup rather than embed in the binary, which is the right call for daemon deployments shipping with their `migrations/` directory adjacent.

## Bridge invariant preserved

`AgentDeps.sqlite_pool: SqlitePool` (lib.rs:425) survives unchanged. The construction site at `main.rs:3288` was swept from `db.sqlite.clone()` to `db.sqlite_pool().expect(...).clone()`, so all ~25 transitive consumers across `agent/{channel,branch,worker,ingestion}.rs`, `tools/spawn_worker.rs`, `tools.rs`, and `main.rs` continue receiving real `SqlitePool` clones. Sqlx pool clones share their internal `Arc`, so the audit-log singleton invariant (A-13) is undisturbed.

## Commits

10 commits on this branch (squash on merge):
1. `feat(deps): add sqlx postgres feature` — Cargo.toml feature flag
2. `feat(dialect): DialectAdapter trait` — new src/dialect.rs + 6 unit tests
3. `feat(error): add DbError::UnsupportedScheme variant`
4. `feat(db): introduce DbPool enum and Db { pool: Arc<DbPool> } shape` — full src/db.rs rewrite (intentional broken build, closed by next commit)
5. `refactor(db): switch consumers to Db::sqlite_pool() accessor` — 38-site sweep with `.expect()` documenting the SQLite-only invariant for PR 11.1
6. `test(db): cover DbPool::adapter, dialect, as_sqlite, and connect paths` — 4 new tokio tests
7. `feat(config): add [database] block for Phase 11 backend selection` — TomlDatabaseConfig + DatabaseConfig + 3 round-trip tests
8. `feat(api): plumb database_url through ApiState` — ArcSwap<Option<String>> + setter + 2 startup-path calls
9. `refactor(db): update connect callsites to plumb database.url` — 4 callsite updates closing the broken build
10. `style: cargo fmt --all` — final formatter pass

## Test plan

- [x] `cargo test --lib` — 936 tests pass, 0 failed
- [x] `cargo test --lib db::tests` — 8 tests pass (4 classify_url + 4 DbPool method/connect)
- [x] `cargo test --lib config::load::tests` — 5 tests pass (2 spacedrive existing + 3 new database round-trip)
- [x] `cargo test --test dialect_adapter` — 6 tests pass
- [x] `cargo check --all-targets` — clean
- [x] `cargo clippy --all-targets` — 0 warnings under `-D warnings`
- [x] `just check-typegen` — clean (no API surface change)
- [x] `just gate-pr` — all gate checks passed
- [x] `postgres://` URL triggers fail-fast at startup with PR 11.2/11.3 pointer (covered by `db_connect_with_postgres_url_fails_fast_with_pr_pointer`)

### Integration test note

`tests/bulletin.rs` and `tests/context_dump.rs` failed in the dev environment with `failed to resolve API key for provider 'azure'` / `'litellm'`. Confirmed pre-existing by running the same tests on `main` (which has zero PR 11.1 changes) and observing identical failures. PR 11.1 touches zero auth/secrets code paths. The `dialect_adapter` integration test that doesn't need credentials passes 6/6.

## Risk surface

- **`as_sqlite()` returns Err on Postgres backend** is architecturally dead weight in PR 11.1 because Postgres URLs hard-error at `Db::connect` before any consumer site runs. The accessor matters during PR 11.2 transition windows. PR 11.1 sweep uses `.expect("PR 11.1: pool is SQLite; Postgres URLs hard-error at connect")` to document the invariant per RUST_STYLE_GUIDE.md.
- **Migration source is now runtime-loaded.** `Migrator::new(Path)` reads `migrations/` from disk at startup. For Spacebot's daemon shipping shape (deployed alongside its `migrations/` directory), this is fine. For future binary distribution, switch back to `migrate!()` with one invocation per `MigrationsTree` variant in a per-arm match.
- **Async shutdown semantics — pool clones outlive `Db::close`.** `Db::close(self)` consumes self and awaits `self.pool.close().await`, but stores hold cloned `SqlitePool` instances (sqlx pools are internally `Arc`-shared). Inflight queries on cloned pools are NOT awaited by `Db::close`. This matches today's behavior. Operators relying on graceful shutdown should send SIGTERM and wait for the daemon to drain its tokio runtime.
- **The `Db` struct rename from `sqlite: SqlitePool` to `pool: Arc<DbPool>`** is a public API break for any external consumer of the spacebot crate as a library. Spacebot is currently a binary crate with no library consumers; this is acceptable.
- **Hash-chain singleton invariant (A-13) preservation.** `AuditAppender` (`src/audit/appender.rs`) holds `pool: SqlitePool` and serializes writes via a `tokio::sync::Mutex<()>`. The hash chain is enforced by the Mutex on the AuditAppender instance, not by pool identity. PR 11.1's sweep at the construction site preserves this invariant. PR 11.2 must keep the invariant when porting AuditAppender to take `Arc<DbPool>`.

## Out of scope for PR 11.1

- Postgres migration tree (`migrations/postgres/`) — PR 11.2 + 11.3
- Per-store dispatch (stores still take `&SqlitePool`) — PR 11.2 + 11.3
- testcontainers integration tests — PR 11.2
- K8s deployment + Helm wiring — PR 11.4
- Postgres advisory-lock leader election for migrations — PR 11.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)