### PR TITLE
auth: default-deny middleware + Helm/compose alignment + hosted-mode startup guard (WS-1.1/1.2/1.3)

### DIFF
--- a/deploy/docker/config.toml
+++ b/deploy/docker/config.toml
@@ -20,6 +20,14 @@
 host = "0.0.0.0"
 port = 19898
 
+# Multi-team plan WS-1.2 (Hermes audit P0-2): the daemon defaults to
+# default-deny (return 401 when no `auth_token` and no `[api.auth.entra]`
+# are configured). docker-compose is the local dev profile, so we
+# explicitly opt into the LegacyStatic fallthrough. K8s deployments
+# (deploy/helm/spacebot/) do NOT set this; production must configure
+# auth_token or [api.auth.entra] before reaching the daemon.
+allow_unauthenticated = true
+
 # Metrics endpoint for the `observability` profile's Prometheus to scrape.
 # Port 9090 must match the Service port and docker-compose.yml `ports:` line.
 # bind = "0.0.0.0" lets Prometheus (in a separate container on the same

--- a/deploy/helm/spacebot/README.md
+++ b/deploy/helm/spacebot/README.md
@@ -91,6 +91,18 @@ helm template ... | kubeconform -strict -summary
 - **`CiliumNetworkPolicy`.** Egress rules for outbound LLM provider calls belong in `ciliumnetworkpolicy.yaml.j2` alongside the other cluster-networking policies.
 - **Active `imagePullSecrets`.** The `ghcr-pull-secret` already exists in the `ai` namespace; uncomment the block in `values.yaml` only if the GHCR image becomes private.
 
+## Authentication modes
+
+The daemon defaults to **default-deny** (multi-team plan WS-1.2, Hermes audit P0-2). When neither `[api].auth_token` nor `[api.auth.entra]` is configured, every request returns 401. The cluster-repo `spacebot-config` ConfigMap MUST provide one of three auth modes:
+
+1. **Hosted with Entra ID** (recommended for K8s). Configure `[api.auth.entra]` in `spacebot-config` via SOPS-encrypted secret. Set `SPACEBOT_DEPLOYMENT: hosted` (overriding the default `docker` in `values.yaml`). The Entra JWT middleware replaces the static-token middleware. See `docs/content/docs/(configuration)/entra-auth.mdx` and `docs/design-docs/entra-app-registrations.md` for the app-registration setup.
+
+2. **Single-tenant bearer token.** Set `[api].auth_token` in `spacebot-config`. The static-token middleware checks bearer tokens against this value (constant-time comparison). Suitable for one-instance-per-team deployments.
+
+3. **Edge SSO (Envoy / cluster gateway).** Set `[api].allow_unauthenticated = true` in `spacebot-config`. The daemon's static-token middleware falls through with `AuthContext::legacy_static()`, deferring JWT validation to the cluster gateway. **Only safe** when the gateway is provably configured to reject every unauthenticated request before it reaches the pod. This is the bearer-auth-disable seam documented in `docs/design-docs/k8s-cluster-deployment.md`.
+
+If the ConfigMap does NOT set one of the three, the deployment comes up healthy and every API call returns 401. The fail-closed default is intentional: a misconfigured Helm rollout used to silently produce an unaudited admin-equivalent surface. WS-1.1's middleware change closes that path.
+
 ## Handoff to the cluster repo
 
 When ready to deploy into the Talos cluster, invoke `/cluster-deploy scaffold` from `ai-k8s/talos-ai-cluster`. The skill emits the Flux app directory skeleton:

--- a/deploy/helm/spacebot/values.yaml
+++ b/deploy/helm/spacebot/values.yaml
@@ -86,6 +86,19 @@ controllers:
           # Entra ID auth — the multi-tenancy uses the typed users/teams
           # data model wired up by Phases 1-4. Configure [api.auth.entra]
           # in spacebot-config before flipping this to hosted.
+          #
+          # Multi-team plan WS-1.2 (Hermes audit P0-2): the daemon defaults
+          # to DEFAULT-DENY when neither [api].auth_token nor [api.auth.entra]
+          # is configured. The cluster-repo spacebot-config ConfigMap MUST
+          # provide one of:
+          #   1. [api.auth.entra] block (recommended for hosted mode)
+          #   2. [api].auth_token (single-tenant)
+          #   3. [api].allow_unauthenticated = true (Envoy-SSO seam — ONLY
+          #      when the cluster gateway guarantees no unauthenticated
+          #      request reaches the pod; see
+          #      docs/design-docs/k8s-cluster-deployment.md)
+          # Without one of these, the daemon comes up healthy but every
+          # request returns 401. The fail-closed default is intentional.
           SPACEBOT_DEPLOYMENT: docker
           RUST_LOG: info
           # Persist the fastembed BGESmallENV15 ONNX model (~127 MB) on

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -430,8 +430,27 @@ async fn api_auth_middleware(
     next: Next,
 ) -> Response {
     let Some(expected_token) = state.auth_token.as_deref() else {
-        // Pass-through mode: still populate a LegacyStatic AuthContext so
-        // downstream handlers can extract it uniformly (Phase 4+).
+        // Multi-team plan WS-1.1 (Hermes audit P0-2): default-deny when no
+        // auth_token is configured. The legacy LegacyStatic fallthrough is
+        // gated behind explicit operator opt-in via `[api]
+        // allow_unauthenticated = true` (Envoy-SSO seam — see
+        // docs/design-docs/k8s-cluster-deployment.md). Without the opt-in,
+        // a misconfigured deployment fails closed with 401 instead of
+        // silently downgrading to no-tenancy mode.
+        if !state.allow_unauthenticated {
+            #[cfg(feature = "metrics")]
+            crate::telemetry::Metrics::global()
+                .auth_failures_total
+                .with_label_values(&["static_token", "no_auth_configured"])
+                .inc();
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "unauthorized"})),
+            )
+                .into_response();
+        }
+        // Operator-opted-in pass-through mode: populate LegacyStatic
+        // AuthContext so downstream handlers can extract it uniformly.
         request
             .extensions_mut()
             .insert(crate::auth::AuthContext::legacy_static());

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -52,6 +52,13 @@ pub struct AgentInfo {
 pub struct ApiState {
     pub started_at: Instant,
     pub auth_token: Option<String>,
+    /// Multi-team plan WS-1.1 (Hermes audit P0-2). Operator opt-in for the
+    /// LegacyStatic fallthrough when neither `auth_token` nor Entra is
+    /// configured. Default `false` is hard default-deny: middleware returns
+    /// 401 instead of injecting a `LegacyStatic` AuthContext. The opt-in
+    /// supports the Envoy-SSO seam documented in
+    /// `docs/design-docs/k8s-cluster-deployment.md` (bearer-auth-disable).
+    pub allow_unauthenticated: bool,
     /// When populated, the Entra-JWT middleware is installed instead of the
     /// static-token middleware. Mutually exclusive with `auth_token` at
     /// request time (the branch is chosen in `start_http_server`). Wrapped
@@ -384,6 +391,7 @@ impl ApiState {
         Self {
             started_at: Instant::now(),
             auth_token: None,
+            allow_unauthenticated: false,
             entra_auth: Arc::new(ArcSwap::from_pointee(None)),
             entra_config: Arc::new(ArcSwap::from_pointee(None)),
             entra_config_missing_warned: std::sync::atomic::AtomicBool::new(false),

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ mod providers;
 mod runtime;
 mod toml_schema;
 mod types;
+mod validate;
 mod watcher;
 
 // Re-export all public types from submodules so external consumers
@@ -22,6 +23,7 @@ pub use permissions::{
 pub(crate) use providers::default_provider_config;
 pub use runtime::RuntimeConfig;
 pub use types::*;
+pub use validate::validate_deployment_invariants;
 pub use watcher::spawn_file_watcher;
 
 // Re-export pub(crate) items that need crate-wide visibility.
@@ -2564,5 +2566,117 @@ use_bearer_auth = true
             ]
         );
         assert!(custom.use_bearer_auth);
+    }
+
+    // -----------------------------------------------------------------
+    // Multi-team plan WS-1.3 (Hermes audit P1-2): startup invariant guard
+    // -----------------------------------------------------------------
+
+    /// Helper for the validate-tests below. Builds a Config via the existing
+    /// load path with a TOML override, so all fields parse through the real
+    /// resolution pipeline rather than a synthetic Default::default().
+    fn config_with_api_overrides(
+        auth_token: Option<&str>,
+        allow_unauthenticated: bool,
+        with_entra: bool,
+    ) -> Config {
+        let entra_block = if with_entra {
+            r#"
+[api.auth.entra]
+enabled = true
+tenant_id = "00000000-0000-0000-0000-000000000000"
+audience = "api://test"
+"#
+        } else {
+            ""
+        };
+        let auth_token_line = match auth_token {
+            Some(t) => format!("auth_token = \"{}\"\n", t),
+            None => String::new(),
+        };
+        let toml = format!(
+            r#"
+[api]
+{auth_token_line}allow_unauthenticated = {allow_unauthenticated}
+{entra_block}
+"#
+        );
+        let parsed: TomlConfig = toml::from_str(&toml).expect("failed to parse test TOML");
+        Config::from_toml(parsed, PathBuf::from(".")).expect("failed to build Config")
+    }
+
+    #[test]
+    fn validate_hosted_without_entra_errors() {
+        let _lock = env_test_lock().lock();
+        let _env = EnvGuard::new();
+
+        unsafe {
+            std::env::set_var("SPACEBOT_DEPLOYMENT", "hosted");
+        }
+
+        let cfg = config_with_api_overrides(None, false, /* with_entra */ false);
+        let result = validate_deployment_invariants(&cfg);
+        assert!(
+            matches!(result, Err(crate::error::ConfigError::HostedRequiresEntra)),
+            "expected HostedRequiresEntra, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn validate_hosted_with_allow_unauthenticated_errors() {
+        let _lock = env_test_lock().lock();
+        let _env = EnvGuard::new();
+
+        unsafe {
+            std::env::set_var("SPACEBOT_DEPLOYMENT", "hosted");
+        }
+
+        let cfg = config_with_api_overrides(None, /* allow_unauth */ true, /* with_entra */ true);
+        let result = validate_deployment_invariants(&cfg);
+        assert!(
+            matches!(
+                result,
+                Err(crate::error::ConfigError::AllowUnauthenticatedInHosted)
+            ),
+            "expected AllowUnauthenticatedInHosted, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn validate_hosted_with_entra_ok() {
+        let _lock = env_test_lock().lock();
+        let _env = EnvGuard::new();
+
+        unsafe {
+            std::env::set_var("SPACEBOT_DEPLOYMENT", "hosted");
+        }
+
+        let cfg =
+            config_with_api_overrides(None, /* allow_unauth */ false, /* with_entra */ true);
+        validate_deployment_invariants(&cfg).expect("hosted+Entra should validate");
+    }
+
+    #[test]
+    fn validate_docker_with_allow_unauthenticated_warns_but_allows() {
+        let _lock = env_test_lock().lock();
+        let _env = EnvGuard::new();
+
+        // Default (SPACEBOT_DEPLOYMENT unset) is treated as docker mode by
+        // hosted_api_bind/is_hosted_deployment. EnvGuard already cleared it.
+        let cfg = config_with_api_overrides(None, /* allow_unauth */ true, /* with_entra */ false);
+        validate_deployment_invariants(&cfg)
+            .expect("docker mode + allow_unauthenticated should validate (warns only)");
+    }
+
+    #[test]
+    fn validate_docker_default_ok() {
+        let _lock = env_test_lock().lock();
+        let _env = EnvGuard::new();
+
+        let cfg = config_with_api_overrides(None, /* allow_unauth */ false, /* with_entra */ false);
+        validate_deployment_invariants(&cfg)
+            .expect("docker default-deny should validate without auth backend");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2632,7 +2632,9 @@ audience = "api://test"
             std::env::set_var("SPACEBOT_DEPLOYMENT", "hosted");
         }
 
-        let cfg = config_with_api_overrides(None, /* allow_unauth */ true, /* with_entra */ true);
+        let cfg = config_with_api_overrides(
+            None, /* allow_unauth */ true, /* with_entra */ true,
+        );
         let result = validate_deployment_invariants(&cfg);
         assert!(
             matches!(
@@ -2653,8 +2655,9 @@ audience = "api://test"
             std::env::set_var("SPACEBOT_DEPLOYMENT", "hosted");
         }
 
-        let cfg =
-            config_with_api_overrides(None, /* allow_unauth */ false, /* with_entra */ true);
+        let cfg = config_with_api_overrides(
+            None, /* allow_unauth */ false, /* with_entra */ true,
+        );
         validate_deployment_invariants(&cfg).expect("hosted+Entra should validate");
     }
 
@@ -2665,7 +2668,9 @@ audience = "api://test"
 
         // Default (SPACEBOT_DEPLOYMENT unset) is treated as docker mode by
         // hosted_api_bind/is_hosted_deployment. EnvGuard already cleared it.
-        let cfg = config_with_api_overrides(None, /* allow_unauth */ true, /* with_entra */ false);
+        let cfg = config_with_api_overrides(
+            None, /* allow_unauth */ true, /* with_entra */ false,
+        );
         validate_deployment_invariants(&cfg)
             .expect("docker mode + allow_unauthenticated should validate (warns only)");
     }
@@ -2675,7 +2680,9 @@ audience = "api://test"
         let _lock = env_test_lock().lock();
         let _env = EnvGuard::new();
 
-        let cfg = config_with_api_overrides(None, /* allow_unauth */ false, /* with_entra */ false);
+        let cfg = config_with_api_overrides(
+            None, /* allow_unauth */ false, /* with_entra */ false,
+        );
         validate_deployment_invariants(&cfg)
             .expect("docker default-deny should validate without auth backend");
     }

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -2683,6 +2683,7 @@ impl Config {
             port: toml.api.port,
             bind: hosted_api_bind(toml.api.bind),
             auth_token: toml.api.auth_token.as_deref().and_then(resolve_env_value),
+            allow_unauthenticated: toml.api.allow_unauthenticated.unwrap_or(false),
             entra_auth,
         };
 

--- a/src/config/toml_schema.rs
+++ b/src/config/toml_schema.rs
@@ -146,6 +146,14 @@ pub(super) struct TomlApiConfig {
     pub(super) bind: String,
     #[serde(default)]
     pub(super) auth_token: Option<String>,
+    /// Multi-team plan WS-1.1 (Hermes audit P0-2). Default-deny opt-out.
+    /// `None` (absent) and `Some(false)` mean default-deny: requests with no
+    /// `auth_token` and no Entra auth return 401. `Some(true)` opts into the
+    /// LegacyStatic fallthrough — appropriate ONLY for local dev or for
+    /// Envoy-SSO deployments where the cluster gateway guarantees no
+    /// unauthenticated request reaches the pod.
+    #[serde(default)]
+    pub(super) allow_unauthenticated: Option<bool>,
     /// Nested block: `[api.auth.entra]`. When present with `enabled = true`,
     /// the Entra JWT middleware replaces the static-token branch.
     #[serde(default)]
@@ -159,6 +167,7 @@ impl Default for TomlApiConfig {
             port: default_api_port(),
             bind: default_api_bind(),
             auth_token: None,
+            allow_unauthenticated: None,
             auth: TomlApiAuthConfig::default(),
         }
     }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -184,6 +184,13 @@ pub struct ApiConfig {
     /// Address to bind the HTTP server on.
     pub bind: String,
     pub auth_token: Option<String>,
+    /// When `true`, requests without a configured `auth_token` and without
+    /// Entra auth fall through with `AuthContext::legacy_static()`. Default
+    /// `false` is hard default-deny. The opt-in exists for the Envoy-SSO
+    /// seam documented in `docs/design-docs/k8s-cluster-deployment.md`
+    /// (bearer-auth-disable path) where JWT validation happens at the
+    /// cluster gateway, not in-process.
+    pub allow_unauthenticated: bool,
     /// When populated, the Entra-JWT middleware replaces the static-token
     /// middleware at server start. Resolved from `[api.auth.entra]` TOML.
     pub entra_auth: Option<crate::auth::EntraAuthConfig>,
@@ -196,6 +203,7 @@ impl Default for ApiConfig {
             port: 19898,
             bind: "127.0.0.1".into(),
             auth_token: None,
+            allow_unauthenticated: false,
             entra_auth: None,
         }
     }

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -45,9 +45,7 @@ pub fn validate_deployment_invariants(cfg: &Config) -> Result<(), ConfigError> {
         return Err(ConfigError::AllowUnauthenticatedInHosted);
     }
 
-    if cfg.api.allow_unauthenticated
-        && cfg.api.auth_token.is_none()
-        && cfg.api.entra_auth.is_none()
+    if cfg.api.allow_unauthenticated && cfg.api.auth_token.is_none() && cfg.api.entra_auth.is_none()
     {
         tracing::warn!(
             "API is configured to accept unauthenticated requests with no \

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -1,0 +1,61 @@
+//! Cross-cutting deployment-invariant checks run after config load.
+//!
+//! These validate combinations of `[api]` settings + `SPACEBOT_DEPLOYMENT`
+//! that individual field validation cannot catch on its own. Called once
+//! from `main.rs` after the runtime `Config` is finalized.
+//!
+//! Rationale: Multi-team plan WS-1.3 (Hermes audit P1-2). A misconfigured
+//! hosted deployment used to come up healthy with no auth backend; this
+//! check fails the daemon at startup with a clear error message instead.
+
+use crate::config::Config;
+use crate::error::ConfigError;
+
+/// Returns `true` when `SPACEBOT_DEPLOYMENT=hosted` (case-insensitive).
+///
+/// Mirrors the env-var read in `src/config/toml_schema.rs::hosted_api_bind`.
+/// There is no parsed `Config.deployment_mode` field today; if a future
+/// refactor introduces one, sweep both call sites at once.
+fn is_hosted_deployment() -> bool {
+    std::env::var("SPACEBOT_DEPLOYMENT")
+        .ok()
+        .map(|v| v.eq_ignore_ascii_case("hosted"))
+        .unwrap_or(false)
+}
+
+/// Validate cross-cutting deployment invariants after config load.
+///
+/// Hard failures (return `Err`):
+/// - Hosted mode without `[api.auth.entra]` configured.
+/// - Hosted mode combined with `[api].allow_unauthenticated = true`.
+///
+/// Soft warning (logs `tracing::warn!` and returns `Ok`):
+/// - `allow_unauthenticated = true` with no auth backend at all (no
+///   `auth_token`, no Entra). Appropriate only for local dev or for
+///   Envoy-SSO deployments where the cluster gateway guarantees no
+///   unauthenticated request reaches this pod.
+pub fn validate_deployment_invariants(cfg: &Config) -> Result<(), ConfigError> {
+    let hosted = is_hosted_deployment();
+
+    if hosted && cfg.api.entra_auth.is_none() {
+        return Err(ConfigError::HostedRequiresEntra);
+    }
+
+    if hosted && cfg.api.allow_unauthenticated {
+        return Err(ConfigError::AllowUnauthenticatedInHosted);
+    }
+
+    if cfg.api.allow_unauthenticated
+        && cfg.api.auth_token.is_none()
+        && cfg.api.entra_auth.is_none()
+    {
+        tracing::warn!(
+            "API is configured to accept unauthenticated requests with no \
+             auth backend. Appropriate only for local dev or Envoy-SSO \
+             deployments where the cluster gateway guarantees no \
+             unauthenticated request reaches this pod."
+        );
+    }
+
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -98,6 +98,20 @@ pub enum ConfigError {
     #[error("missing required config key: {0}")]
     MissingKey(String),
 
+    /// Multi-team plan WS-1.3 (Hermes audit P1-2). Hosted deployment mode
+    /// (`SPACEBOT_DEPLOYMENT=hosted`) is inseparable from Entra ID auth per
+    /// post-Phase-10 (PR #120) policy. Failing here at startup prevents a
+    /// hosted deployment from coming up healthy with no auth backend.
+    #[error("hosted deployment mode requires [api.auth.entra] to be configured")]
+    HostedRequiresEntra,
+
+    /// Multi-team plan WS-1.3. Composition of P1-2 + P0-2: in hosted mode,
+    /// the Envoy-SSO seam (`allow_unauthenticated = true`) is not safe
+    /// because hosted-mode tenancy is enforced in-process, not at the
+    /// gateway. Refuse to start with this combination.
+    #[error("hosted deployment mode is incompatible with allow_unauthenticated = true")]
+    AllowUnauthenticatedInHosted,
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -535,6 +535,13 @@ fn cmd_start(
 
     let config = load_config(&resolved_config_path)?;
 
+    // Multi-team plan WS-1.3 (Hermes audit P1-2): fail fast on cross-cutting
+    // deployment-invariant violations (hosted mode without Entra, hosted mode
+    // with allow_unauthenticated=true, etc.). The check runs before the
+    // Tokio runtime is built so a misconfigured deployment never reaches
+    // service-startup with a healthy-looking process.
+    spacebot::config::validate_deployment_invariants(&config)?;
+
     // Build a fresh Tokio runtime in this process (the child after daemonize,
     // or the foreground process). Tracing init — including the OTLP batch
     // exporter — must happen inside block_on because the async

--- a/src/main.rs
+++ b/src/main.rs
@@ -1864,6 +1864,7 @@ async fn run(
         injection_tx.clone(),
     );
     api_state.auth_token = config.api.auth_token.clone();
+    api_state.allow_unauthenticated = config.api.allow_unauthenticated;
     api_state.set_task_store(global_task_store.clone());
     api_state.set_wiki_store(global_wiki_store.clone());
     api_state.set_notification_store(global_notification_store.clone());

--- a/tests/api_auth_middleware.rs
+++ b/tests/api_auth_middleware.rs
@@ -147,14 +147,40 @@ async fn desktop_tokens_bypasses_token_check() {
     );
 }
 
+/// Multi-team plan WS-1.1 (Hermes audit P0-2): default-deny when neither
+/// `auth_token` nor Entra is configured. Replaces the prior
+/// `pass_through_when_no_token_configured` test, which asserted the now-stale
+/// pre-WS-1.1 fallthrough. The fallthrough is preserved behind the explicit
+/// `allow_unauthenticated = true` opt-in and is exercised by
+/// `falls_through_legacy_static_when_allow_unauthenticated_true` below.
 #[tokio::test]
-async fn pass_through_when_no_token_configured() {
+async fn returns_401_when_no_auth_configured_and_allow_unauthenticated_false() {
+    // ApiState::new_for_tests defaults allow_unauthenticated to false (the
+    // ApiState struct's Default), reflecting the production Helm posture.
     let state = Arc::new(ApiState::new_for_tests(None));
     let app = build_test_router(state);
     let res = app
         .oneshot(req_with_auth("/api/status", None))
         .await
         .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// Companion: with explicit operator opt-in, the LegacyStatic fallthrough
+/// is preserved. This is the Envoy-SSO seam documented in
+/// `docs/design-docs/k8s-cluster-deployment.md` (bearer-auth-disable path).
+#[tokio::test]
+async fn falls_through_legacy_static_when_allow_unauthenticated_true() {
+    let mut state = ApiState::new_for_tests(None);
+    state.allow_unauthenticated = true;
+    let state = Arc::new(state);
+    let app = build_test_router(state);
+    let res = app
+        .oneshot(req_with_auth("/api/status", None))
+        .await
+        .unwrap();
+    // /api/status returns Json<StatusResponse> when AuthContext is present;
+    // the LegacyStatic injection on the opt-in path satisfies that contract.
     assert_eq!(res.status(), StatusCode::OK);
 }
 


### PR DESCRIPTION
Multi-team hardening plan: foundation-auth tasks WS-1.1, WS-1.2, WS-1.3.

Closes Hermes audit P0-2 + P1-2. Three stacked commits, each independently revertable.

## What ships

### WS-1.1 — Default-deny middleware (`3cd8ec1`)

`src/api/server.rs::api_auth_middleware` no longer silently injects `AuthContext::legacy_static()` when neither `auth_token` nor Entra is configured. Returns 401 instead. The legacy LegacyStatic fallthrough is preserved behind an explicit operator opt-in: `[api] allow_unauthenticated = true` (the Envoy-SSO seam documented at `docs/design-docs/k8s-cluster-deployment.md`).

- New `ApiConfig.allow_unauthenticated: bool` (default `false`) + `TomlApiConfig.allow_unauthenticated: Option<bool>`.
- New `ApiState.allow_unauthenticated` flat field, wired in `main.rs:1867` from `config.api.allow_unauthenticated` alongside `auth_token`.
- Middleware increments `auth_failures_total{branch=static_token,reason=no_auth_configured}` on the new 401 path so dashboards distinguish "misconfigured" from "wrong token".
- Replaced `pass_through_when_no_token_configured` test (asserted the now-stale fallthrough) with `returns_401_when_no_auth_configured_and_allow_unauthenticated_false`. Added `falls_through_legacy_static_when_allow_unauthenticated_true` to pin the Envoy-SSO opt-in path.
- 14/14 `cargo nextest run --test api_auth_middleware` passed (12 pre-existing + 2 new).

### WS-1.2 — Helm + docker-compose alignment (`8a50334`)

- `deploy/docker/config.toml`: opts the local-dev profile into `allow_unauthenticated = true` so docker-compose continues to work after the middleware change.
- `deploy/helm/spacebot/values.yaml`: documents the three valid auth modes in the `SPACEBOT_DEPLOYMENT` comment block. Chart is values-only against bjw-s app-template; the actual auth knobs live in cluster-repo `spacebot-config` ConfigMap.
- `deploy/helm/spacebot/README.md`: new "Authentication modes" section listing hosted-Entra, bearer-token, and Envoy-SSO modes with cross-references.
- No code changes, no cargo runs.

### WS-1.3 — Startup invariant guard (`47f33c0`)

`src/config/validate.rs::validate_deployment_invariants` runs after `load_config()` in the `start` command path, before the Tokio runtime is built. Hard fails on:
- `SPACEBOT_DEPLOYMENT=hosted` without `[api.auth.entra]` (post-Phase-10 PR #120 invariant).
- `SPACEBOT_DEPLOYMENT=hosted` with `[api].allow_unauthenticated=true` (composition of P1-2 + P0-2).

Soft-warns (does not block startup) on `allow_unauthenticated=true` with no auth backend at all — that's the legitimate Envoy-SSO posture in non-hosted mode.

- New `ConfigError::HostedRequiresEntra` and `ConfigError::AllowUnauthenticatedInHosted` variants.
- 5 new tests in `src/config.rs` reusing `env_test_lock()` + `EnvGuard` for safe `SPACEBOT_DEPLOYMENT` setup/teardown. 17/17 passed (5 new + 12 existing config-validate tests unaffected).

## Verification cadence (per multi-team plan's deferred-cargo discipline)

- WS-1.1: 1× `cargo check --lib`, 1× `cargo nextest run --test api_auth_middleware`. 14/14 ✅.
- WS-1.2: 0 cargo runs (config + docs only).
- WS-1.3: 1× `cargo check --lib`, 1× `cargo nextest run --lib config::tests::validate`. 17/17 ✅.

Total cargo invocations across the PR: 4. (Per-step verification would have been ~12.)

## Tracker

`.scratchpad/plans/multi-team/INDEX.md` and `STATUS.md` are updated separately on `main` to flip WS-1.1, WS-1.2, WS-1.3 from 📋 to 🚀 with this branch + commit refs.

Refs:
- `.scratchpad/plans/multi-team/01-foundation-auth.md` Tasks 1, 2, 3
- Hermes audit `.scratchpad/hermes-recommendations/reviewed/01-implementation-plan.md` Phase 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)