### PR TITLE
auth: gate JWKS + issuer override fields behind auth-overrides feature (WS-1.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,13 @@ jobs:
       - name: cargo test (lib)
         run: cargo test --lib
 
+      # Multi-team WS-1.4: the integration-test crate uses the
+      # `auth-overrides` feature. tests/jwks_rotation.rs and
+      # tests/entra_jwt_middleware.rs are gated `#![cfg(feature =
+      # "auth-overrides")]` and need the flag to compile. Mirrors the
+      # local gate-pr.sh integration-compile step.
       - name: cargo test (integration compile check)
-        run: cargo test --tests --no-run
+        run: cargo test --tests --no-run --features auth-overrides
 
   check-typegen:
     name: OpenAPI Typegen Drift

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,15 @@ metrics = ["dep:prometheus"]
 # - OTEL_EXPORTER_OTLP_HEADERS are not propagated to the gRPC exporter.
 otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]
 
+# Multi-team plan WS-1.4 (Hermes audit P1-1). Compile-gate the JWKS URL +
+# issuer override fields on EntraAuthConfig. The fields are useful for tests
+# and emergency cutover scenarios but reachable only via TOML edit today;
+# gating prevents production binaries from carrying them at all so a future
+# admin-config-write API cannot accidentally expose them. Tests opt in
+# implicitly via cfg(test); emergency builds opt in via
+# `cargo build --features auth-overrides`. Production MUST NOT enable this.
+auth-overrides = []
+
 [patch.crates-io]
 imap-proto = { path = "vendor/imap-proto-0.10.2" }
 

--- a/scripts/gate-pr.sh
+++ b/scripts/gate-pr.sh
@@ -130,7 +130,13 @@ else
 fi
 
 if ! $fast_mode; then
-	run_step "cargo test --tests --no-run" cargo test --tests --no-run
+	# Multi-team WS-1.4: integration tests under tests/*.rs use the
+	# `auth-overrides` feature (gated behind cfg(feature = ...) in
+	# src/auth/config.rs). Production builds exclude these fields; the
+	# gate-pr integration step opts in so tests/entra_jwt_middleware.rs and
+	# tests/jwks_rotation.rs compile against the override surface.
+	run_step "cargo test --tests --no-run --features auth-overrides" \
+		cargo test --tests --no-run --features auth-overrides
 fi
 
 log "all gate checks passed"

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -65,9 +65,18 @@ pub struct EntraAuthConfig {
     /// the `auth` module by construction. Integration tests use
     /// [`Self::new_for_test`] plus [`Self::with_test_overrides`] below.
     /// The production loader always leaves this `None`.
+    ///
+    /// Multi-team plan WS-1.4 (Hermes audit P1-1): the field is gated
+    /// behind `feature = "auth-overrides"` so production builds (`cargo
+    /// build --release` with default features) do NOT carry it at all.
+    /// Integration tests under `tests/*.rs` and emergency cutover builds
+    /// opt in via `--features auth-overrides`. CI's gate-pr passes the
+    /// flag so the existing test surface is preserved.
+    #[cfg(feature = "auth-overrides")]
     pub(crate) jwks_url_override: Option<String>,
     /// Test-only override for the issuer claim validator. Paired with
-    /// `jwks_url_override`.
+    /// `jwks_url_override`. Same `feature = "auth-overrides"` gate.
+    #[cfg(feature = "auth-overrides")]
     pub(crate) issuer_override: Option<String>,
 }
 
@@ -128,14 +137,18 @@ impl EntraAuthConfig {
             spa_client_id,
             spa_scopes,
             mock_mode: false,
+            #[cfg(feature = "auth-overrides")]
             jwks_url_override: None,
+            #[cfg(feature = "auth-overrides")]
             issuer_override: None,
         }
     }
 
     /// Integration-test helper that injects Wiremock-backed JWKS and issuer
     /// URLs. The override fields are `pub(crate)` so no other code path can
-    /// set them.
+    /// set them. Gated behind `feature = "auth-overrides"` so production
+    /// builds do not carry this method at all (Multi-team WS-1.4).
+    #[cfg(feature = "auth-overrides")]
     #[doc(hidden)]
     pub fn with_test_overrides(mut self, jwks_url: String, issuer: String) -> Self {
         self.jwks_url_override = Some(jwks_url);
@@ -159,7 +172,9 @@ mod tests {
             spa_client_id: Arc::from("22222222-2222-2222-2222-222222222222"),
             spa_scopes: vec![Arc::from("api://test/api.access")],
             mock_mode: false,
+            #[cfg(feature = "auth-overrides")]
             jwks_url_override: None,
+            #[cfg(feature = "auth-overrides")]
             issuer_override: None,
         }
     }

--- a/src/auth/jwks.rs
+++ b/src/auth/jwks.rs
@@ -108,7 +108,13 @@ impl EntraValidator {
         // `jwt_authorizer`) because jwt_authorizer does not re-export it.
         // Both crates are in [dependencies] for this reason.
         let aud_refs: Vec<&str> = vec![cfg.audience.as_ref()];
+        // Multi-team WS-1.4: the override fields exist only when
+        // `auth-overrides` feature is enabled. Production builds always use
+        // the computed issuer; the override path compiles in for tests only.
+        #[cfg(feature = "auth-overrides")]
         let iss_string = cfg.issuer_override.clone().unwrap_or_else(|| cfg.issuer());
+        #[cfg(not(feature = "auth-overrides"))]
+        let iss_string = cfg.issuer();
         let iss_refs: Vec<&str> = vec![iss_string.as_str()];
         // `nbf` validation is off by default in jwt-authorizer 0.15. Enable
         // it so not-yet-valid tokens are rejected (prevents tokens minted
@@ -122,10 +128,14 @@ impl EntraValidator {
 
         // Test override wins over computed URL so Wiremock-backed
         // integration tests can point the validator at a fake tenant.
+        // Multi-team WS-1.4: feature-gated; production uses the computed URL only.
+        #[cfg(feature = "auth-overrides")]
         let jwks_url = cfg
             .jwks_url_override
             .clone()
             .unwrap_or_else(|| cfg.jwks_url());
+        #[cfg(not(feature = "auth-overrides"))]
+        let jwks_url = cfg.jwks_url();
         // SOC 2 / key-rotation correctness.
         //
         // jwt-authorizer's default Refresh (refresh_interval = 600s,

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -2671,7 +2671,11 @@ impl Config {
                         .map(|s| std::sync::Arc::from(s.as_str()))
                         .collect(),
                     mock_mode: e.mock_mode,
+                    // Multi-team WS-1.4: gated behind feature = "auth-overrides".
+                    // Production builds (default features) skip these fields entirely.
+                    #[cfg(feature = "auth-overrides")]
                     jwks_url_override: None,
+                    #[cfg(feature = "auth-overrides")]
                     issuer_override: None,
                 })
             }

--- a/tests/entra_jwt_middleware.rs
+++ b/tests/entra_jwt_middleware.rs
@@ -1,6 +1,14 @@
 //! Phase 1 Task 1.12: Wiremock-backed integration tests for the Entra JWT
 //! validator. Covers the happy path, the wrong-signature path, and the
 //! service-principal path.
+//!
+//! Requires `feature = "auth-overrides"` (multi-team WS-1.4): the test
+//! points the validator at the Wiremock-backed tenant via
+//! `EntraAuthConfig::with_test_overrides`, which is feature-gated. The
+//! gate-pr script and the CI Test job pass `--features auth-overrides`;
+//! default `cargo check --all-targets` skips this file by design — the
+//! override surface is not available in production builds.
+#![cfg(feature = "auth-overrides")]
 
 #[path = "support/mock_entra.rs"]
 mod mock_entra;

--- a/tests/jwks_rotation.rs
+++ b/tests/jwks_rotation.rs
@@ -9,6 +9,14 @@
 //! Calls `MockTenant::mint_user_token` directly so the rotation path
 //! exercises the real `EntraValidator` and its JWKS refetch logic, not a
 //! `MockValidator` shortcut that skips signature checks.
+//!
+//! Requires `feature = "auth-overrides"` (multi-team WS-1.4): the test
+//! points the validator at the Wiremock-backed tenant via
+//! `EntraAuthConfig::with_test_overrides`, which is feature-gated. The
+//! gate-pr script and the CI Test job pass `--features auth-overrides`;
+//! default `cargo check --all-targets` skips this file by design — the
+//! override surface is not available in production builds.
+#![cfg(feature = "auth-overrides")]
 
 #[path = "support/mock_entra.rs"]
 mod mock_entra;


### PR DESCRIPTION
## Summary

- Adds the `auth-overrides` Cargo feature (off by default).
- Gates `EntraAuthConfig::jwks_url_override` and `EntraAuthConfig::issuer_override` behind `#[cfg(feature = "auth-overrides")]`. Production builds carry neither the field nor the `with_test_overrides` setter.
- Updates `src/auth/jwks.rs` to compile-fork its issuer/JWKS-URL resolution: the override path exists only with the feature; default builds use `cfg.issuer()` / `cfg.jwks_url()` directly.
- Wires `scripts/gate-pr.sh`'s integration-compile step to `--features auth-overrides` so existing test surface keeps building.

Closes Hermes audit P1-1 (multi-team plan WS-1.4).

## Why

`jwks_url_override` and `issuer_override` are reachable today only through TOML edits, but the struct layout and methods exist in every release binary. A future admin-config-write API or a misconfigured deployment could surface them. Compile-gating ensures production binaries cannot carry the override path at all — a property auditors can verify with `nm target/release/spacebot | grep jwks_url_override`.

## Scope

This is **WS-1.4** — parallel-safe with PR #139 (WS-1.1/1.2/1.3). No code overlap; both PRs target `main` independently.

## Verification

| Check | Result |
|---|---|
| `cargo check --lib --no-default-features` | clean |
| `cargo check --lib --features auth-overrides` | clean |
| `cargo nextest run --lib auth::config` | 2/2 passed |
| `cargo test --tests --no-run --features auth-overrides` | clean |
| `cargo build --release` | clean |
| `nm target/release/spacebot \| grep jwks_url_override` | **ABSENT** |
| `nm target/release/spacebot \| grep issuer_override` | **ABSENT** |
| `just gate-pr` | <pending after push> |

The symbol-absence check is the production correctness assertion. The release binary built with default features (`embeddings`, no `auth-overrides`) contains zero references to either override field.

**Plan correction:** the plan in `.scratchpad/plans/multi-team/01-foundation-auth.md` Task 4 Step 4.5 called for `cargo build --release --no-default-features`. That flag combination is forbidden by `src/lib.rs:8`'s `compile_error!` guard (release builds must include `embeddings`). The semantically equivalent check is `cargo build --release` (default features include `embeddings` but not `auth-overrides`). The plan should be amended in a follow-up commit.

## Test plan

- [x] Integration tests (`entra_jwt_middleware.rs`, `jwks_rotation.rs`) compile under `--features auth-overrides`
- [x] Unit tests in `src/auth/config.rs` compile under both feature states
- [x] Public-config projection (`tests/api_auth_config.rs:98-112`) still asserts `jwks_url_override` and `issuer_override` are absent from serialized output (assertion compiles unconditionally; remains valid both with and without the feature)
- [ ] CI `just gate-pr` passes after push

## Files

| File | Change |
|---|---|
| `Cargo.toml` | Add `auth-overrides = []` feature |
| `src/auth/config.rs` | Gate fields, `Default`/test-fixture initializers, `with_test_overrides` setter |
| `src/auth/jwks.rs` | Compile-fork issuer + JWKS URL resolution (override branch under feature only) |
| `src/config/load.rs` | Gate the field initializer in the TOML→runtime conversion fixture |
| `scripts/gate-pr.sh` | Pass `--features auth-overrides` to the integration-compile step |

## Refs

- Plan: `.scratchpad/plans/multi-team/01-foundation-auth.md` Task 4
- Tracker: `.scratchpad/plans/multi-team/INDEX.md` row WS-1.4
- Hermes audit: `.scratchpad/hermes-recommendations/reviewed/01-implementation-plan.md` Phase 1 P1-1
- Parallel sibling: PR #139 (WS-1.1/1.2/1.3)
