### PR TITLE
auth: agent_ids_for(ctx) ownership-scope helper (WS-2.1)

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -16,6 +16,7 @@ pub mod policy;
 pub mod principals;
 pub mod repository;
 pub mod roles;
+pub mod scope;
 // Plain `pub mod` (no `cfg(test)` gate): integration tests under `tests/*.rs`
 // are separate compilation units that cannot see `cfg(test)` items from the
 // library. Precedent: `tests/support/mock_entra.rs` and `ApiState::new_for_tests`.
@@ -33,3 +34,4 @@ pub use principals::{
     Visibility,
 };
 pub use roles::{ROLE_ADMIN, ROLE_SERVICE, ROLE_USER, is_admin, require_role};
+pub use scope::agent_ids_for;

--- a/src/auth/scope.rs
+++ b/src/auth/scope.rs
@@ -1,0 +1,91 @@
+//! Ownership-scoped lookups: which agent_ids can a given AuthContext see?
+//!
+//! Returns the visible agent_id list for a principal across the three
+//! ownership paths the resource_ownership table encodes: `personal`
+//! (owner_principal_key match), `team` (resolved via team_memberships
+//! JOIN, encapsulated in `auth::repository::list_team_scoped_resource_ids`),
+//! and `org` (anyone). Admins (ROLE_ADMIN, legacy_static) see every
+//! agent_id; the caller is responsible for emitting an audit row when an
+//! admin reads a non-owned resource.
+//!
+//! Returns `Vec<String>` of agent_ids rather than typed pool refs because
+//! `ApiState.agent_pools` is currently `HashMap<String, sqlx::SqlitePool>`.
+//! Phase 11.3 widens that to `HashMap<String, Arc<DbPool>>`; the typed
+//! sibling `pools_for(ctx)` lands as WS-4 Task 4.5 once the typing is
+//! in place. This helper composes `list_team_scoped_resource_ids` rather
+//! than duplicating the team-membership JOIN.
+
+use crate::auth::AuthContext;
+use crate::auth::repository::list_team_scoped_resource_ids;
+use crate::auth::roles::is_admin;
+use crate::db::DbPool;
+
+use anyhow::Context as _;
+
+const AGENT_RESOURCE_TYPE: &str = "agent";
+
+/// Returns the agent_ids visible to `ctx`. Admins see every agent;
+/// non-admin users see the union of (owned, team-shared, org-visible).
+///
+/// Caller responsibility: when `is_admin(ctx)` is true and the result is
+/// used to expose a non-owned resource, emit an audit row via
+/// `crate::auth::policy::fire_admin_read_audit`.
+pub async fn agent_ids_for(ctx: &AuthContext, pool: &DbPool) -> anyhow::Result<Vec<String>> {
+    if is_admin(ctx) {
+        return list_all_agent_ids(pool).await;
+    }
+
+    let principal_key = ctx.principal_key();
+    let mut visible = list_owned_or_org_agent_ids(pool, &principal_key).await?;
+    let team_shared =
+        list_team_scoped_resource_ids(pool, &principal_key, AGENT_RESOURCE_TYPE).await?;
+    visible.extend(team_shared);
+    visible.sort();
+    visible.dedup();
+    Ok(visible)
+}
+
+async fn list_all_agent_ids(pool: &DbPool) -> anyhow::Result<Vec<String>> {
+    match pool {
+        DbPool::Sqlite(p) => sqlx::query_scalar::<_, String>(
+            "SELECT resource_id FROM resource_ownership WHERE resource_type = 'agent'",
+        )
+        .fetch_all(p)
+        .await
+        .context("list all agent ids (sqlite)"),
+        DbPool::Postgres(p) => sqlx::query_scalar::<_, String>(
+            "SELECT resource_id FROM resource_ownership WHERE resource_type = 'agent'",
+        )
+        .fetch_all(p)
+        .await
+        .context("list all agent ids (postgres)"),
+    }
+}
+
+async fn list_owned_or_org_agent_ids(
+    pool: &DbPool,
+    principal_key: &str,
+) -> anyhow::Result<Vec<String>> {
+    // Owned-by-principal OR org-visible. Team-shared rows are fetched
+    // separately by the caller via list_team_scoped_resource_ids.
+    match pool {
+        DbPool::Sqlite(p) => sqlx::query_scalar::<_, String>(
+            "SELECT resource_id FROM resource_ownership \
+             WHERE resource_type = 'agent' \
+               AND (owner_principal_key = ? OR visibility = 'org')",
+        )
+        .bind(principal_key)
+        .fetch_all(p)
+        .await
+        .context("list owned-or-org agent ids (sqlite)"),
+        DbPool::Postgres(p) => sqlx::query_scalar::<_, String>(
+            "SELECT resource_id FROM resource_ownership \
+             WHERE resource_type = 'agent' \
+               AND (owner_principal_key = $1 OR visibility = 'org')",
+        )
+        .bind(principal_key)
+        .fetch_all(p)
+        .await
+        .context("list owned-or-org agent ids (postgres)"),
+    }
+}

--- a/tests/auth_scope.rs
+++ b/tests/auth_scope.rs
@@ -1,0 +1,142 @@
+//! Tests for `auth::scope::agent_ids_for`.
+//!
+//! Four cases cover the visibility paths the helper resolves:
+//! - Admin sees every agent (legacy_static is admin-equivalent).
+//! - Non-admin user sees only personally-owned agents.
+//! - Non-admin user sees agents shared with a team they belong to.
+//! - Non-admin user sees agents marked org-visible regardless of ownership.
+
+use spacebot::auth::agent_ids_for;
+use spacebot::auth::context::{AuthContext, PrincipalType};
+use spacebot::auth::principals::Visibility;
+use spacebot::auth::repository::{set_ownership, upsert_team, upsert_user_from_auth};
+use spacebot::auth::roles::ROLE_USER;
+use spacebot::db::DbPool;
+
+use std::sync::Arc;
+
+fn user_ctx(oid: &str) -> AuthContext {
+    AuthContext {
+        principal_type: PrincipalType::User,
+        tid: Arc::from("t1"),
+        oid: Arc::from(oid),
+        roles: vec![Arc::from(ROLE_USER)],
+        groups: vec![],
+        groups_overage: false,
+        display_email: None,
+        display_name: None,
+    }
+}
+
+async fn fresh_pool() -> Arc<DbPool> {
+    let (_state, sqlite) = spacebot::api::ApiState::new_test_state_with_mock_entra().await;
+    Arc::new(DbPool::Sqlite(sqlite))
+}
+
+async fn seed_agent(
+    pool: &Arc<DbPool>,
+    agent_id: &str,
+    owner: &AuthContext,
+    visibility: Visibility,
+    team_id: Option<&str>,
+) {
+    set_ownership(
+        pool,
+        "agent",
+        agent_id,
+        None,
+        &owner.principal_key(),
+        visibility,
+        team_id,
+    )
+    .await
+    .unwrap();
+}
+
+/// Insert a team_memberships row directly. There is no `pub` helper for this
+/// in `auth::repository`; production middleware writes it via raw SQL during
+/// JWT-claim sync, and the test mirrors that path.
+async fn add_team_membership(pool: &Arc<DbPool>, principal_key: &str, team_id: &str) {
+    match pool.as_ref() {
+        DbPool::Sqlite(p) => {
+            sqlx::query(
+                "INSERT INTO team_memberships (principal_key, team_id, source) \
+                 VALUES (?, ?, 'token_claim')",
+            )
+            .bind(principal_key)
+            .bind(team_id)
+            .execute(p)
+            .await
+            .unwrap();
+        }
+        DbPool::Postgres(_) => unreachable!("test uses SQLite fixture"),
+    }
+}
+
+#[tokio::test]
+async fn admin_sees_all_agent_ids() {
+    let pool = fresh_pool().await;
+    let alice = user_ctx("alice");
+    let bob = user_ctx("bob");
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+    upsert_user_from_auth(&pool, &bob).await.unwrap();
+
+    seed_agent(&pool, "a-alice", &alice, Visibility::Personal, None).await;
+    seed_agent(&pool, "a-bob", &bob, Visibility::Personal, None).await;
+
+    // legacy_static() is admin-equivalent (is_admin returns true).
+    let admin = AuthContext::legacy_static();
+    let mut visible = agent_ids_for(&admin, &pool).await.unwrap();
+    visible.sort();
+    assert_eq!(visible, vec!["a-alice".to_string(), "a-bob".to_string()]);
+}
+
+#[tokio::test]
+async fn user_sees_only_owned_personal_agents() {
+    let pool = fresh_pool().await;
+    let alice = user_ctx("alice");
+    let bob = user_ctx("bob");
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+    upsert_user_from_auth(&pool, &bob).await.unwrap();
+
+    seed_agent(&pool, "a-alice", &alice, Visibility::Personal, None).await;
+    seed_agent(&pool, "a-bob", &bob, Visibility::Personal, None).await;
+
+    let visible = agent_ids_for(&alice, &pool).await.unwrap();
+    assert_eq!(visible, vec!["a-alice".to_string()]);
+}
+
+#[tokio::test]
+async fn user_sees_team_shared_agents() {
+    let pool = fresh_pool().await;
+    let alice = user_ctx("alice");
+    let bob = user_ctx("bob");
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+    upsert_user_from_auth(&pool, &bob).await.unwrap();
+
+    // upsert_team derives `id = "team-<external_id>"`.
+    upsert_team(&pool, "eng", "Engineering").await.unwrap();
+    add_team_membership(&pool, &alice.principal_key(), "team-eng").await;
+
+    // Bob owns a-bob and shares it with the engineering team. Alice is in
+    // the team and should see it.
+    seed_agent(&pool, "a-bob", &bob, Visibility::Team, Some("team-eng")).await;
+
+    let visible = agent_ids_for(&alice, &pool).await.unwrap();
+    assert_eq!(visible, vec!["a-bob".to_string()]);
+}
+
+#[tokio::test]
+async fn user_sees_org_visible_agents() {
+    let pool = fresh_pool().await;
+    let alice = user_ctx("alice");
+    let bob = user_ctx("bob");
+    upsert_user_from_auth(&pool, &alice).await.unwrap();
+    upsert_user_from_auth(&pool, &bob).await.unwrap();
+
+    // Bob owns a-bob with org visibility. Anyone authenticated should see it.
+    seed_agent(&pool, "a-bob", &bob, Visibility::Org, None).await;
+
+    let visible = agent_ids_for(&alice, &pool).await.unwrap();
+    assert_eq!(visible, vec!["a-bob".to_string()]);
+}


### PR DESCRIPTION
## Summary

Adds `auth::scope::agent_ids_for(ctx, pool) -> Vec<String>`, the ownership-scope helper that unblocks the WS-2 handler authz sweep. Returns the agent_id list visible to a given `AuthContext` across the three visibility paths in `resource_ownership`: `personal` (owner match), `team` (resolved via the existing `list_team_scoped_resource_ids` JOIN), and `org` (anyone authenticated). Admins see every agent_id.

## Why

Hermes audit P1-5 calls for a typed `pools_for(ctx)` that returns the per-agent pools a principal can see. That requires `agent_pools: Arc<DbPool>` typing, which doesn't ship until Phase 11.3 (WS-4.4). Until then, `agent_pools` is `HashMap<String, sqlx::SqlitePool>` and any handler that wants to scope a `pools.iter()` loop needs the visible agent-id list. This helper provides that, type-stable today; the typed sibling `pools_for(ctx)` lands as WS-4 Task 4.5 once 11.3 widens the type.

## Implementation notes

Composes `list_team_scoped_resource_ids` from `src/auth/repository.rs:685` rather than duplicating the team-membership JOIN. Owner-and-org rows fetched via direct SELECT bound on `principal_key`. Backend dispatch on `DbPool::Sqlite | DbPool::Postgres` with bound-parameter SQL on each arm.

`AGENT_RESOURCE_TYPE = "agent"` is a module-level const matching the hardcoded value in the existing helper.

## Verification

| Check | Result |
|---|---|
| `cargo check --lib` | clean |
| `cargo fmt --all -- --check` | clean |
| `cargo nextest run --test auth_scope` | 4/4 passed |
| `just gate-pr` | <pending after push> |

The 4 tests cover each visibility path:
- `admin_sees_all_agent_ids` (legacy_static is admin-equivalent via `is_admin`)
- `user_sees_only_owned_personal_agents`
- `user_sees_team_shared_agents` (mirrors middleware's raw-SQL `team_memberships` insert)
- `user_sees_org_visible_agents`

## Files

| File | Change |
|---|---|
| `src/auth/scope.rs` | New module, 100 lines |
| `src/auth.rs` | Add `pub mod scope;` and `pub use scope::agent_ids_for;` |
| `tests/auth_scope.rs` | New integration test, 4 cases |

## Plan errata captured for downstream WS-2 tasks

The plan body cited `add_team_member` and a `TeamMembershipRecord { team_id, principal_key, role, created_at }` shape; the actual repository.rs has no public team-member insert (production middleware writes via raw SQL during JWT-claim sync) and the real `TeamMembershipRecord` is `{ principal_key, team_id, observed_at, source }`. The plan also passes a `&TeamRecord` to `upsert_team`, which actually takes `(pool, external_id, display_name)` and derives `id = "team-<external_id>"`. The test file works around all three corrections; future WS-2 PRs that consume team membership in tests should use the same direct-SQL pattern (no public helper exists today).

## Refs

- Plan: `.scratchpad/plans/multi-team/02-handler-authz-sweep.md` Task 1
- Tracker: `.scratchpad/plans/multi-team/INDEX.md` row WS-2.1
- Hermes audit: P1-5 (partial)
- Sibling: WS-2.2 PR-A (credential-bearing handlers) is parallel-safe; ready to start once this lands or alongside.

Test plan:
- [x] `cargo check --lib` clean
- [x] `cargo nextest run --test auth_scope` 4/4 passed
- [ ] CI green on push